### PR TITLE
Fix scripts, following repository renaming

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -6,15 +6,15 @@
         "type": "git"
     },
     "commence": {
-        "branch": "master",
+        "branch": "noteed/feature/remove-design-hs",
         "repo": "git@github.com:hypered/commence.git",
-        "rev": "2bddc1dab7e37200c1501bc724571bcd9af5c237",
+        "rev": "f1f6573f966e219c41a6c630b85312120deccd22",
         "type": "git"
     },
     "design-hs": {
         "branch": "main",
-        "repo": "git@github.com:smartcoop/design-hs.git",
-        "rev": "ca84b3fc4f54ac9a5c5a45c41bf2749ebd9ee8d4",
+        "repo": "git@github.com:hypered/smart-design-hs.git",
+        "rev": "4ec712eae1116b1ed3d5916c8893e771a2f5fa2f",
         "type": "git"
     },
     "gitignore": {

--- a/scripts/ghci-cty.conf
+++ b/scripts/ghci-cty.conf
@@ -1,4 +1,4 @@
-:load ../design-hs/lib/src/Prelude.hs
+:load ../smart-design-hs/lib/src/Prelude.hs
 import Prelude
 :set -XImplicitPrelude
-:load exe/executable/cty.hs
+:load executable/cty.hs

--- a/scripts/ghci-cty.sh
+++ b/scripts/ghci-cty.sh
@@ -1,17 +1,16 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash ../shell.nix
 
-# This is a bit convoluted because the Prelude is from design-hs:
+# This is a bit convoluted because the Prelude is from smart-design-hs:
 #   - -XNoImplicitPrelude is set here on the command-line
-#   - The ghci.conf file will load design-hs's Prelude
+#   - The ghci.conf file will load smart-design-hs's Prelude
 #   - Then set again -XImplicitPrelude
 #   - Then load what we want: cty.hs
 
 ghc --interactive \
-  -i../design-hs/lib/src/ \
-  -iexe/executable/ \
-  -iexe/src/ \
-  -ilib/src/ \
+  -i../smart-design-hs/lib/src/ \
+  -iexecutable/ \
+  -isrc/ \
   -hide-package base \
   -XNoImplicitPrelude \
   -XHaskell2010 \

--- a/scripts/ghci-parse.conf
+++ b/scripts/ghci-parse.conf
@@ -1,4 +1,4 @@
-:load ../design-hs/lib/src/Prelude.hs
+:load ../smart-design-hs/lib/src/Prelude.hs
 import Prelude
 :set -XImplicitPrelude
-:load exe/executable/cty-parse.hs
+:load executable/cty-parse.hs

--- a/scripts/ghci-parse.sh
+++ b/scripts/ghci-parse.sh
@@ -1,17 +1,16 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash ../shell.nix
 
-# This is a bit convoluted because the Prelude is from design-hs:
+# This is a bit convoluted because the Prelude is from smart-design-hs:
 #   - -XNoImplicitPrelude is set here on the command-line
-#   - The ghci.conf file will load design-hs's Prelude
+#   - The ghci.conf file will load smart-design-hs's Prelude
 #   - Then set again -XImplicitPrelude
 #   - Then load what we want: cty-parse.hs
 
 ghc --interactive \
-  -i../design-hs/lib/src/ \
-  -iexe/executable/ \
-  -iexe/src/ \
-  -ilib/src/ \
+  -i../smart-design-hs/lib/src/ \
+  -iexecutable/ \
+  -isrc/ \
   -hide-package base \
   -XNoImplicitPrelude \
   -XHaskell2010 \

--- a/scripts/ghci-repl.conf
+++ b/scripts/ghci-repl.conf
@@ -1,4 +1,4 @@
-:load ../design-hs/lib/src/Prelude.hs
+:load ../smart-design-hs/lib/src/Prelude.hs
 import Prelude
 :set -XImplicitPrelude
-:load exe/executable/cty-repl.hs
+:load executable/cty-repl.hs

--- a/scripts/ghci-repl.sh
+++ b/scripts/ghci-repl.sh
@@ -1,17 +1,16 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash ../shell.nix
 
-# This is a bit convoluted because the Prelude is from design-hs:
+# This is a bit convoluted because the Prelude is from smart-design-hs:
 #   - -XNoImplicitPrelude is set here on the command-line
-#   - The ghci.conf file will load design-hs's Prelude
+#   - The ghci.conf file will load smart-design-hs's Prelude
 #   - Then set again -XImplicitPrelude
 #   - Then load what we want: cty-repl.hs
 
 ghc --interactive \
-  -i../design-hs/lib/src/ \
-  -iexe/executable/ \
-  -iexe/src/ \
-  -ilib/src/ \
+  -i../smart-design-hs/lib/src/ \
+  -iexecutable/ \
+  -isrc/ \
   -hide-package base \
   -XNoImplicitPrelude \
   -XHaskell2010 \

--- a/scripts/ghci-serve.conf
+++ b/scripts/ghci-serve.conf
@@ -1,0 +1,5 @@
+:load ../smart-design-hs/lib/src/Prelude.hs
+import Prelude
+:set -XImplicitPrelude
+:load executable/cty-serve.hs
+:main

--- a/scripts/ghci-serve.sh
+++ b/scripts/ghci-serve.sh
@@ -1,0 +1,33 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash ../shell.nix
+
+# This is a bit convoluted because the Prelude is from smart-design-hs:
+#   - -XNoImplicitPrelude is set here on the command-line
+#   - The ghci.conf file will load smart-design-hs's Prelude
+#   - Then set again -XImplicitPrelude
+#   - Then load what we want: cty-serve.hs
+
+ghc --interactive \
+  -i../smart-design-hs/lib/src/ \
+  -iexecutable/ \
+  -isrc/ \
+  -hide-package base \
+  -XNoImplicitPrelude \
+  -XHaskell2010 \
+  -XStrictData \
+  -XMultiParamTypeClasses \
+  -XDerivingStrategies \
+  -XDerivingVia \
+  -XDeriveGeneric \
+  -XRecordWildCards \
+  -XTypeSynonymInstances \
+  -XFlexibleInstances \
+  -XFlexibleContexts \
+  -XUndecidableInstances \
+  -XLambdaCase \
+  -XTypeApplications \
+  -XScopedTypeVariables \
+  -XGADTs \
+  -XOverloadedStrings \
+  -XPackageImports \
+  -ghci-script scripts/ghci-serve.conf

--- a/scripts/ghci-sock.conf
+++ b/scripts/ghci-sock.conf
@@ -1,4 +1,4 @@
-:load ../design-hs/lib/src/Prelude.hs
+:load ../smart-design-hs/lib/src/Prelude.hs
 import Prelude
 :set -XImplicitPrelude
 :load exe/executable/cty-sock.hs

--- a/scripts/ghci-sock.sh
+++ b/scripts/ghci-sock.sh
@@ -1,14 +1,14 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash ../shell.nix
 
-# This is a bit convoluted because the Prelude is from design-hs:
+# This is a bit convoluted because the Prelude is from smart-design-hs:
 #   - -XNoImplicitPrelude is set here on the command-line
-#   - The ghci.conf file will load design-hs's Prelude
+#   - The ghci.conf file will load smart-design-hs's Prelude
 #   - Then set again -XImplicitPrelude
 #   - Then load what we want: cty-sock.hs
 
 ghc --interactive \
-  -i../design-hs/lib/src/ \
+  -i../smart-design-hs/lib/src/ \
   -iexe/executable/ \
   -iexe/src/ \
   -ilib/src/ \

--- a/scripts/ghci.conf
+++ b/scripts/ghci.conf
@@ -1,4 +1,4 @@
 :load ../smart-design-hs/lib/src/Prelude.hs
 import Prelude
 :set -XImplicitPrelude
-:load exe/executable/cty-interactive.hs
+:load executable/cty-interactive.hs

--- a/scripts/ghci.conf
+++ b/scripts/ghci.conf
@@ -1,4 +1,4 @@
-:load ../design-hs/lib/src/Prelude.hs
+:load ../smart-design-hs/lib/src/Prelude.hs
 import Prelude
 :set -XImplicitPrelude
 :load exe/executable/cty-interactive.hs

--- a/scripts/ghci.sh
+++ b/scripts/ghci.sh
@@ -1,14 +1,14 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash ../shell.nix
 
-# This is a bit convoluted because the Prelude is from design-hs:
+# This is a bit convoluted because the Prelude is from smart-design-hs:
 #   - -XNoImplicitPrelude is set here on the command-line
-#   - The ghci.conf file will load design-hs's Prelude
+#   - The ghci.conf file will load smart-design-hs's Prelude
 #   - Then set again -XImplicitPrelude
 #   - Then load what we want: cty-interactive.hs
 
 ghc --interactive \
-  -i../design-hs/lib/src/ \
+  -i../smart-design-hs/lib/src/ \
   -iexe/executable/ \
   -iexe/src/ \
   -ilib/src/ \

--- a/scripts/ghci.sh
+++ b/scripts/ghci.sh
@@ -9,9 +9,8 @@
 
 ghc --interactive \
   -i../smart-design-hs/lib/src/ \
-  -iexe/executable/ \
-  -iexe/src/ \
-  -ilib/src/ \
+  -iexecutable/ \
+  -isrc/ \
   -hide-package base \
   -XNoImplicitPrelude \
   -XHaskell2010 \

--- a/scripts/run-example.sh
+++ b/scripts/run-example.sh
@@ -4,7 +4,7 @@
 # See ghci.sh for comments.
 
 ghc --interactive \
-  -i../design-hs/lib/src/ \
+  -i../smart-design-hs/lib/src/ \
   -iexe/executable/ \
   -iexe/src/ \
   -ilib/src/ \

--- a/src/Prototype/Exe/Server/Private/Helpers.hs
+++ b/src/Prototype/Exe/Server/Private/Helpers.hs
@@ -10,8 +10,7 @@ module Prototype.Exe.Server.Private.Helpers
 import qualified Prototype.Exe.Data.User       as User
 import           Servant.API
 import qualified Servant.HTML.Blaze            as B
-import qualified "design-hs-lib" Smart.Server.Page
-                                               as SS.P
+import qualified Smart.Server.Page             as SS.P
 
 type GetUserPage pageData = UserPage Get pageData
 type PutUserPage pageData = UserPage Put pageData

--- a/src/Prototype/Exe/Server/Private/Pages.hs
+++ b/src/Prototype/Exe/Server/Private/Pages.hs
@@ -18,18 +18,14 @@ import           Network.HTTP.Types.Method
 import qualified Prototype.Exe.Data.User       as User
 import           Prototype.Exe.Server.Shared.Html.Helpers.Form
                                                 ( mkButton )
-import qualified "design-hs-lib" Smart.Html.Dsl
-                                               as Dsl
-import qualified "design-hs-lib" Smart.Html.Form
-                                               as Form
-import qualified "design-hs-lib" Smart.Html.Input
-                                               as Inp
-import qualified "design-hs-lib" Smart.Html.Shared.Types
-                                               as HTypes
+import qualified Smart.Html.Dsl                as Dsl
+import qualified Smart.Html.Form               as Form
+import qualified Smart.Html.Input              as Inp
+import qualified Smart.Html.Shared.Types       as HTypes
 import qualified Text.Blaze.Html5              as H
 import           Web.FormUrlEncoded             ( FromForm(..) )
 
--- | A simple welcome page. 
+-- | A simple welcome page.
 data WelcomePage = WelcomePage
 
 instance H.ToMarkup WelcomePage where

--- a/src/Prototype/Exe/Server/Public.hs
+++ b/src/Prototype/Exe/Server/Public.hs
@@ -30,8 +30,7 @@ import qualified Prototype.Exe.Server.Public.Pages
 import           Servant
 import qualified Servant.Auth.Server           as SAuth
 import qualified Servant.HTML.Blaze            as B
-import qualified "design-hs-lib" Smart.Server.Page
-                                               as SS.P
+import qualified Smart.Server.Page             as SS.P
 import           Web.FormUrlEncoded             ( FromForm(..) )
 
 -- | Minimal set of constraints needed on some monad @m@ to be satisfied to be able to run a public server.

--- a/src/Prototype/Exe/Server/Public/Pages.hs
+++ b/src/Prototype/Exe/Server/Public/Pages.hs
@@ -18,14 +18,12 @@ import           Network.HTTP.Types.Method
 import qualified Prototype.Exe.Data.User       as User
 import           Prototype.Exe.Server.Shared.Html.Helpers.Form
                                                 ( mkButton )
-import qualified "design-hs-lib" Smart.Html.Dsl
-                                               as Dsl
-import qualified "design-hs-lib" Smart.Html.Form
-                                               as Form
-import qualified "design-hs-lib" Smart.Html.Input
-                                               as Inp
-import qualified "design-hs-lib" Smart.Html.Shared.Types
-                                               as HTypes
+import qualified Smart.Html.Dsl                as Dsl
+import qualified Smart.Html.Errors             as Errors
+import qualified Smart.Html.Form               as Form
+import qualified Smart.Html.Input              as Inp
+import qualified Smart.Html.Render             as Render
+import qualified Smart.Html.Shared.Types       as HTypes
 import qualified Text.Blaze.Html5              as H
 
 -- | A simple login page. 

--- a/src/Prototype/Exe/Server/Shared/Html/Helpers/Form.hs
+++ b/src/Prototype/Exe/Server/Shared/Html/Helpers/Form.hs
@@ -5,10 +5,8 @@ module Prototype.Exe.Server.Shared.Html.Helpers.Form
 import           Network.HTTP.Types.Method      ( StdMethod
                                                 , renderStdMethod
                                                 )
-import qualified "design-hs-lib" Smart.Html.Button
-                                               as Btn
-import qualified "design-hs-lib" Smart.Html.Shared.Types
-                                               as HTypes
+import qualified Smart.Html.Button             as Btn
+import qualified Smart.Html.Shared.Types       as HTypes
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import           Text.Blaze.Html5.Attributes


### PR DESCRIPTION
- I've also added a script, `ghci-serve.sh` than I forgot to commit in the past
- I've removed the named package import for `"design-hs-lib"`. I think they made things clearer at some point but as I've renamed `smartcoop/design-hs` to `hypered/smart-design-hs`, it seems I can get my scripts to properly load its code. (Also, one file was not using this convention. I hope this is ok for you.)