### PR TITLE
Design: landpage, login form, and signup form

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,9 +12,9 @@
         "type": "git"
     },
     "design-hs": {
-        "branch": "main",
+        "branch": "noteed/feature/add-landing-page",
         "repo": "git@github.com:hypered/smart-design-hs.git",
-        "rev": "4ec712eae1116b1ed3d5916c8893e771a2f5fa2f",
+        "rev": "75dbe60896bbf92d60910c18e5f01aa7a737eb2e",
         "type": "git"
     },
     "gitignore": {

--- a/prototype-hs-exe.cabal
+++ b/prototype-hs-exe.cabal
@@ -89,6 +89,7 @@ library
     Prototype.Exe.Runtime
     Prototype.Exe.Data.Todo
     Prototype.Exe.Data.User
+    Prototype.Exe.Form.Signup
     Prototype.Exe.Server
     Prototype.Exe.Server.Shared.Html.Helpers.Form
     Prototype.Exe.Server.Public

--- a/prototype-hs-exe.cabal
+++ b/prototype-hs-exe.cabal
@@ -89,6 +89,7 @@ library
     Prototype.Exe.Runtime
     Prototype.Exe.Data.Todo
     Prototype.Exe.Data.User
+    Prototype.Exe.Form.Login
     Prototype.Exe.Form.Signup
     Prototype.Exe.Server
     Prototype.Exe.Server.Shared.Html.Helpers.Form

--- a/src/Prototype/Exe/Form/Login.hs
+++ b/src/Prototype/Exe/Form/Login.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE DeriveAnyClass #-}
+module Prototype.Exe.Form.Login
+  ( Input
+  , Page(..)
+  , ResultPage(..)
+  ) where
+
+import           Smart.Html.Dsl                 ( HtmlCanvas )
+import qualified Smart.Html.Dsl                as Dsl
+import qualified Smart.Html.Render             as Render
+import           Smart.Html.Shared.Html.Icons
+import           Text.Blaze                     ( customAttribute )
+import qualified Text.Blaze.Html5              as H
+import           Text.Blaze.Html5               ( (!) )
+import qualified Text.Blaze.Html5.Attributes   as A
+import           Web.FormUrlEncoded             ( FromForm(..)
+                                                , parseUnique
+                                                )
+
+
+--------------------------------------------------------------------------------
+data Input = Input
+  { username :: Text
+  , password :: Text
+  }
+  deriving (Eq, Show)
+
+instance FromForm Input where
+  fromForm f = Input <$> parseUnique "username" f <*> parseUnique "password" f
+
+
+--------------------------------------------------------------------------------
+data Page = Page
+  { loginSubmitURL :: H.AttributeValue
+  }
+
+instance H.ToMarkup Page where
+  toMarkup = Render.renderCanvas . loginPage
+
+loginPage :: Page -> HtmlCanvas
+loginPage Page {..} = Dsl.SingletonCanvas $ do
+  H.header
+    ! A.class_ "o-container-vertical"
+    $ H.div
+    ! A.class_ "o-container"
+    $ H.div
+    ! A.class_ "c-brand c-brand--xsmall"
+    $ H.a
+    ! A.href "/"
+    $ H.img
+    ! A.src "https://design.smart.coop/images/logo.svg"
+    ! A.alt "Smart"
+  H.main
+    ! A.class_ "o-container-vertical"
+    $ H.div
+    ! A.class_ "o-container o-container--small"
+    $ do
+        H.div
+          ! A.class_ "c-panel"
+          $ H.div
+          ! A.class_ "c-panel__body"
+          $ H.form
+          $ do
+              H.h3 ! A.class_ "c-h2" $ "Log in to your account"
+              H.div
+                ! A.class_ "o-form-group-layout o-form-group-layout--standard"
+                $ do
+                    H.div ! A.class_ "o-form-group" $ do
+                      H.label
+                        ! A.class_ "o-form-group__label"
+                        ! A.for "username"
+                        $ "Username"
+                      H.div
+                        ! A.class_ "o-form-group__controls"
+                        $ H.input
+                        ! A.class_ "c-input"
+                        ! A.id "username"
+                        ! A.name "username"
+                        ! A.type_ "text"
+                    H.div ! A.class_ "o-form-group" $ do
+                      H.label
+                        ! A.class_ "o-form-group__label"
+                        ! A.for "password"
+                        $ "Password"
+                      H.div
+                        ! A.class_ "o-form-group__controls"
+                        $ H.div
+                        ! A.class_ "c-input-with-icon"
+                        $ do
+                            H.input
+                              ! A.class_ "c-input"
+                              ! A.id "password"
+                              ! A.name "password"
+                              ! A.type_ "password"
+                            H.button
+                              ! A.class_ "c-input-with-icon__toggle"
+                              ! customAttribute "data-password-toggle" "1"
+                              $ do
+                                  H.div
+                                    ! A.class_ "o-svg-icon o-svg-icon-eye"
+                                    $ H.toMarkup svgIconEye
+                                  H.div
+                                    ! A.class_ "o-svg-icon o-svg-icon-eye-off"
+                                    $ H.toMarkup svgIconEyeOff
+                    H.div
+                      ! A.class_ "o-form-group"
+                      $ H.button
+                      ! A.class_ "c-button c-button--primary c-button--block"
+                      ! A.formaction loginSubmitURL
+                      ! A.formmethod "POST"
+                      $ H.span
+                      ! A.class_ "c-button__content"
+                      $ "Log in"
+                    H.div ! A.class_ "o-form-group u-ta-center" $ ""
+        H.div ! A.class_ "c-content u-text-center u-spacer-top-l" $ do
+          H.a ! A.class_ "u-text-muted" ! A.href "/signup" $ "Sign up"
+          " | "
+          H.a
+            ! A.class_ "u-text-muted"
+            ! A.href "/password-reset"
+            $ "Forgot password"
+
+
+--------------------------------------------------------------------------------
+data ResultPage = Success Text
+                | Failure Text
+
+instance H.ToMarkup ResultPage where
+  toMarkup = \case
+    Success msg -> withText msg
+    Failure msg -> withText msg
+   where
+    withText msg =
+      Render.renderCanvas $ Dsl.SingletonCanvas $ H.code $ H.toMarkup msg

--- a/src/Prototype/Exe/Form/Signup.hs
+++ b/src/Prototype/Exe/Form/Signup.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE DeriveAnyClass #-}
+module Prototype.Exe.Form.Signup
+  ( Input
+  , Page(..)
+  , ResultPage(..)
+  ) where
+
+import           Smart.Html.Dsl                 ( HtmlCanvas )
+import qualified Smart.Html.Dsl                as Dsl
+import qualified Smart.Html.Render             as Render
+import           Smart.Html.Shared.Html.Icons
+import           Text.Blaze                     ( customAttribute )
+import qualified Text.Blaze.Html5              as H
+import           Text.Blaze.Html5               ( (!) )
+import qualified Text.Blaze.Html5.Attributes   as A
+import           Web.FormUrlEncoded             ( FromForm(..)
+                                                , parseUnique
+                                                )
+
+
+--------------------------------------------------------------------------------
+data Input = Input
+  { username     :: Text
+  , emailAddress :: Text
+  , password     :: Text
+  , iUnderstand  :: Text -- TODO Bool
+  }
+  deriving (Eq, Show)
+
+instance FromForm Input where
+  fromForm f =
+    Input
+      <$> parseUnique "username"     f
+      <*> parseUnique "email"        f
+      <*> parseUnique "password"     f
+      <*> parseUnique "i-understand" f
+
+
+--------------------------------------------------------------------------------
+data Page = Page
+  { signupSubmitURL :: H.AttributeValue
+  }
+
+instance H.ToMarkup Page where
+  toMarkup = Render.renderCanvas . signupPage
+
+signupPage :: Page -> HtmlCanvas
+signupPage Page {..} = Dsl.SingletonCanvas $ do
+  H.header
+    ! A.class_ "o-container-vertical"
+    $ H.div
+    ! A.class_ "o-container"
+    $ H.div
+    ! A.class_ "c-brand c-brand--xsmall"
+    $ H.a
+    ! A.href "/"
+    $ H.img
+    ! A.src "https://design.smart.coop/images/logo.svg"
+    ! A.alt "Smart"
+  H.main
+    ! A.class_ "o-container-vertical"
+    $ H.div
+    ! A.class_ "o-container o-container--small"
+    $ do
+        H.div
+          ! A.class_ "c-panel"
+          $ H.div
+          ! A.class_ "c-panel__body"
+          $ H.form
+          $ do
+              H.h3 ! A.class_ "c-h2" $ "Create your account"
+              H.div
+                ! A.class_ "o-form-group-layout o-form-group-layout--standard"
+                $ do
+                    H.div ! A.class_ "o-form-group" $ do
+                      H.label
+                        ! A.class_ "o-form-group__label"
+                        ! A.for "username"
+                        $ "Username"
+                      H.div
+                        ! A.class_ "o-form-group__controls"
+                        $ H.input
+                        ! A.class_ "c-input"
+                        ! A.id "username"
+                        ! A.name "username"
+                        ! A.type_ "text"
+                    H.div ! A.class_ "o-form-group" $ do
+                      H.label
+                        ! A.class_ "o-form-group__label"
+                        ! A.for "email"
+                        $ "Email address"
+                      H.div
+                        ! A.class_ "o-form-group__controls"
+                        $ H.input
+                        ! A.class_ "c-input"
+                        ! A.id "email"
+                        ! A.name "email"
+                        ! A.type_ "email"
+                    H.div ! A.class_ "o-form-group" $ do
+                      H.label
+                        ! A.class_ "o-form-group__label"
+                        ! A.for "password"
+                        $ "Password"
+                      H.div
+                        ! A.class_ "o-form-group__controls"
+                        $ H.div
+                        ! A.class_ "c-input-with-icon"
+                        $ do
+                            H.input
+                              ! A.class_ "c-input"
+                              ! A.id "password"
+                              ! A.name "password"
+                              ! A.type_ "password"
+                            H.button
+                              ! A.class_ "c-input-with-icon__toggle"
+                              ! customAttribute "data-password-toggle" "1"
+                              $ do
+                                  H.div
+                                    ! A.class_ "o-svg-icon o-svg-icon-eye"
+                                    $ H.toMarkup svgIconEye
+                                  H.div
+                                    ! A.class_ "o-svg-icon o-svg-icon-eye-off"
+                                    $ H.toMarkup svgIconEyeOff
+                    H.div ! A.class_ "o-form-group" $ do
+                      H.div ! A.class_ "c-checkbox" $ do
+                        H.label $ do
+                          H.input
+                            ! A.id "i-understand"
+                            ! A.name "i-understand"
+                            ! A.type_ "checkbox"
+                          H.div $ do
+                            "I understand that this site is up for "
+                            "demonstration purpose only, and that data are "
+                            "regularly erased."
+                            H.a ! A.href "#" $ "Read more."
+                    H.div
+                      ! A.class_ "o-form-group"
+                      $ H.button
+                      ! A.class_ "c-button c-button--primary c-button--block"
+                      ! A.formaction signupSubmitURL
+                      ! A.formmethod "POST"
+                      $ H.span
+                      ! A.class_ "c-button__content"
+                      $ "Sign up"
+                    H.div ! A.class_ "o-form-group u-ta-center" $ ""
+        H.div ! A.class_ "c-content u-text-center u-spacer-top-l" $ do
+          H.a ! A.class_ "u-text-muted" ! A.href "#" $ "Log in"
+
+
+--------------------------------------------------------------------------------
+data ResultPage = Success Text
+                | Failure Text
+
+instance H.ToMarkup ResultPage where
+  toMarkup = \case
+    Success msg -> withText msg
+    Failure msg -> withText msg
+   where
+    withText msg =
+      Render.renderCanvas $ Dsl.SingletonCanvas $ H.code $ H.toMarkup msg

--- a/src/Prototype/Exe/Server.hs
+++ b/src/Prototype/Exe/Server.hs
@@ -23,6 +23,7 @@ import qualified Network.HTTP.Types            as HTTP
 import qualified Network.Wai                   as Wai
 import qualified Network.Wai.Handler.Warp      as Warp
 import           Prototype.Exe.Data.User        ( )
+import qualified Prototype.Exe.Form.Login      as Login
 import qualified Prototype.Exe.Form.Signup     as Signup
 import qualified Prototype.Exe.Runtime         as Rt
 import qualified Prototype.Exe.Server.Private  as Priv
@@ -40,14 +41,26 @@ type ServerSettings = '[Srv.CookieSettings , Srv.JWTSettings]
 
 -- brittany-disable-next-binding 
 type Exe = Get '[B.HTML] Pages.LandingPage
+             :<|> "forms" :> "login" :> Get '[B.HTML] Login.Page
              :<|> "forms" :> "signup" :> Get '[B.HTML] Signup.Page
+
+             :<|> "echo" :> "login"
+                  :> ReqBody '[FormUrlEncoded] Login.Input
+                  :> Post '[B.HTML] Login.ResultPage
              :<|> "echo" :> "signup"
                   :> ReqBody '[FormUrlEncoded] Signup.Input
                   :> Post '[B.HTML] Signup.ResultPage
+
+             :<|> "login" :> Get '[B.HTML] Login.Page
              :<|> "signup" :> Get '[B.HTML] Signup.Page
+
+             :<|> "a" :> "login"
+                  :> ReqBody '[FormUrlEncoded] Login.Input
+                  :> Post '[B.HTML] Login.ResultPage
              :<|> "a" :> "signup"
                   :> ReqBody '[FormUrlEncoded] Signup.Input
                   :> Post '[B.HTML] Signup.ResultPage
+
              :<|> "public" :> Pub.Public
              :<|> "private" :> Priv.Private
              :<|> Raw -- catchall for custom 404
@@ -55,9 +68,13 @@ type Exe = Get '[B.HTML] Pages.LandingPage
 exampleT :: forall m . Pub.PublicServerC m => ServerT Exe m
 exampleT =
   showLandingPage
+    :<|> documentLoginPage
     :<|> documentSignupPage
+    :<|> echoLogin
     :<|> echoSignup
+    :<|> showLoginPage
     :<|> showSignupPage
+    :<|> handleLogin
     :<|> handleSignup
     :<|> Pub.publicT
     :<|> Priv.privateT
@@ -96,6 +113,8 @@ runExeServer runtime@Rt.Runtime {..} = liftIO $ Warp.run port waiApp
 showLandingPage :: Pub.PublicServerC m => m Pages.LandingPage
 showLandingPage = pure Pages.LandingPage
 
+
+--------------------------------------------------------------------------------
 showSignupPage :: Pub.PublicServerC m => m Signup.Page
 showSignupPage = pure $ Signup.Page "/a/signup"
 
@@ -108,6 +127,22 @@ handleSignup _ = pure $ Signup.Failure "TODO handleSignup"
 echoSignup :: Pub.PublicServerC m => Signup.Input -> m Signup.ResultPage
 echoSignup input = pure $ Signup.Success $ show input
 
+
+--------------------------------------------------------------------------------
+showLoginPage :: Pub.PublicServerC m => m Login.Page
+showLoginPage = pure $ Login.Page "/a/login"
+
+documentLoginPage :: Pub.PublicServerC m => m Login.Page
+documentLoginPage = pure $ Login.Page "/echo/login"
+
+handleLogin :: Pub.PublicServerC m => Login.Input -> m Login.ResultPage
+handleLogin _ = pure $ Login.Failure "TODO handleLogin"
+
+echoLogin :: Pub.PublicServerC m => Login.Input -> m Login.ResultPage
+echoLogin input = pure $ Login.Success $ show input
+
+
+--------------------------------------------------------------------------------
 custom404 :: Application
 custom404 _request sendResponse = sendResponse $ Wai.responseLBS
   HTTP.status404

--- a/src/Prototype/Exe/Server.hs
+++ b/src/Prototype/Exe/Server.hs
@@ -23,6 +23,7 @@ import qualified Network.HTTP.Types            as HTTP
 import qualified Network.Wai                   as Wai
 import qualified Network.Wai.Handler.Warp      as Warp
 import           Prototype.Exe.Data.User        ( )
+import qualified Prototype.Exe.Form.Signup     as Signup
 import qualified Prototype.Exe.Runtime         as Rt
 import qualified Prototype.Exe.Server.Private  as Priv
 import qualified Prototype.Exe.Server.Public   as Pub
@@ -39,13 +40,28 @@ type ServerSettings = '[Srv.CookieSettings , Srv.JWTSettings]
 
 -- brittany-disable-next-binding 
 type Exe = Get '[B.HTML] Pages.LandingPage
+             :<|> "forms" :> "signup" :> Get '[B.HTML] Signup.Page
+             :<|> "echo" :> "signup"
+                  :> ReqBody '[FormUrlEncoded] Signup.Input
+                  :> Post '[B.HTML] Signup.ResultPage
+             :<|> "signup" :> Get '[B.HTML] Signup.Page
+             :<|> "a" :> "signup"
+                  :> ReqBody '[FormUrlEncoded] Signup.Input
+                  :> Post '[B.HTML] Signup.ResultPage
              :<|> "public" :> Pub.Public
              :<|> "private" :> Priv.Private
              :<|> Raw -- catchall for custom 404
 
 exampleT :: forall m . Pub.PublicServerC m => ServerT Exe m
 exampleT =
-  showLandingPage :<|> Pub.publicT :<|> Priv.privateT :<|> pure custom404
+  showLandingPage
+    :<|> documentSignupPage
+    :<|> echoSignup
+    :<|> showSignupPage
+    :<|> handleSignup
+    :<|> Pub.publicT
+    :<|> Priv.privateT
+    :<|> pure custom404
 
 -- | Run as a Wai Application
 exampleApplication
@@ -79,6 +95,18 @@ runExeServer runtime@Rt.Runtime {..} = liftIO $ Warp.run port waiApp
 
 showLandingPage :: Pub.PublicServerC m => m Pages.LandingPage
 showLandingPage = pure Pages.LandingPage
+
+showSignupPage :: Pub.PublicServerC m => m Signup.Page
+showSignupPage = pure $ Signup.Page "/a/signup"
+
+documentSignupPage :: Pub.PublicServerC m => m Signup.Page
+documentSignupPage = pure $ Signup.Page "/echo/signup"
+
+handleSignup :: Pub.PublicServerC m => Signup.Input -> m Signup.ResultPage
+handleSignup _ = pure $ Signup.Failure "TODO handleSignup"
+
+echoSignup :: Pub.PublicServerC m => Signup.Input -> m Signup.ResultPage
+echoSignup input = pure $ Signup.Success $ show input
 
 custom404 :: Application
 custom404 _request sendResponse = sendResponse $ Wai.responseLBS

--- a/src/Prototype/Exe/Server/Public/Pages.hs
+++ b/src/Prototype/Exe/Server/Public/Pages.hs
@@ -26,7 +26,7 @@ import qualified Smart.Html.Render             as Render
 import qualified Smart.Html.Shared.Types       as HTypes
 import qualified Text.Blaze.Html5              as H
 
--- | A simple login page. 
+-- | A simple login page.
 newtype LoginPage  = LoginPage { _loginPageAuthSubmitURL :: H.AttributeValue }
 
 -- | For the `LoginPage` markup, we now rely on our DSL to render the login page to our liking
@@ -101,4 +101,5 @@ data NotFoundPage = NotFoundPage
 
 instance H.ToMarkup NotFoundPage where
   toMarkup NotFoundPage = do
-    H.code "404 Not found."
+    Render.renderCanvas $
+      Dsl.SingletonCanvas Errors.NotFound

--- a/src/Prototype/Exe/Server/Public/Pages.hs
+++ b/src/Prototype/Exe/Server/Public/Pages.hs
@@ -22,6 +22,7 @@ import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Errors             as Errors
 import qualified Smart.Html.Form               as Form
 import qualified Smart.Html.Input              as Inp
+import qualified Smart.Html.Pages.LandingPage  as Pages
 import qualified Smart.Html.Render             as Render
 import qualified Smart.Html.Shared.Types       as HTypes
 import qualified Text.Blaze.Html5              as H
@@ -95,7 +96,8 @@ data LandingPage = LandingPage
 
 instance H.ToMarkup LandingPage where
   toMarkup LandingPage = do
-    H.code "Welcome."
+    Render.renderCanvas $
+      Pages.landingPage
 
 data NotFoundPage = NotFoundPage
 


### PR DESCRIPTION
This follows https://github.com/hypered/curiosity/pull/2. The PR targets its branch so the diff is the same as when that branch is merged in `main`.

It is also dependent on https://github.com/hypered/smart-design-hs/pull/2.

This adds a proper landing page, a nicer login form, and a nicer signup form. The signup form has also a field for an email address.

In addition, I've added some routes to expose forms for documentation purposes. This doesn't do much yet, but the intent is to be able to show forms even when no logged in, or show them already filled with some values, possibly together with validation error messages, or submit them but only trigger the validation mechanism or inspect the generated data, without running the complete server logic.