### PR TITLE
Revisit user profile

### DIFF
--- a/curls/login-no-username.sh
+++ b/curls/login-no-username.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+
+set -e
+
+BASE_URL="http://127.0.0.1:9000"
+
+# Try to login with no corresponding username.
+# TODO With an existing user but wrong password.
+
+# TODO
+# This should return a proper HTML page.
+# This should return 403 Forbidden ?
+
+rm cookies.txt
+curl --cookie-jar cookies.txt -d username="alice" -d password="secret" "${BASE_URL}/a/login"
+echo

--- a/curls/signup.sh
+++ b/curls/signup.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+
+set -e
+
+BASE_URL="http://127.0.0.1:9000"
+
+# Create a new user.
+
+# TODO If the username already exists, this returns a UserProfile {..}.
+# TODO This should not return a 200 Ok.
+
+curl --cookie-jar cookies.txt -d username="alice" -d password="a" -d email-addr="alice@example.com" "${BASE_URL}/a/signup"
+echo
+
+# Get logged in.
+
+# This should return a 303 See Other and a Location.
+# This should return a JWT-Cookie.
+
+curl -v --cookie-jar cookies.txt -d username="alice" -d password="a" "${BASE_URL}/a/login"
+echo

--- a/executable/Prototype/Exe/Exe/Parse2.hs
+++ b/executable/Prototype/Exe/Exe/Parse2.hs
@@ -124,18 +124,15 @@ parserUser = A.subparser
   )
 
 parserCreateUser :: A.Parser Command
-parserCreateUser =
-  UpdateUser
-    .   U.UserCreate
-    <$> (   U.UserProfile
-        <$> (   U.UserCreds
-            <$> A.argument A.str
-                           (A.metavar "USERNAME" <> A.help "A username")
-            <*> A.argument A.str
-                           (A.metavar "PASSWORD" <> A.help "A password")
-            )
-        <*> A.argument A.str (A.metavar "EMAIL" <> A.help "An email address")
-        )
+parserCreateUser = do
+  username <- A.argument A.str (A.metavar "USERNAME" <> A.help "A username")
+  password <- A.argument A.str (A.metavar "PASSWORD" <> A.help "A password")
+  email    <- A.argument A.str (A.metavar "EMAIL" <> A.help "An email address")
+  return $ UpdateUser . U.UserCreate $ U.UserProfile
+    "USER-0" -- TODO
+    (U.UserCreds username password)
+    "TODO"
+    email
 
 parserDeleteUser :: A.Parser Command
 parserDeleteUser = UpdateUser . U.UserDelete . U.UserId <$> A.argument

--- a/executable/Prototype/Exe/Exe/Parse2.hs
+++ b/executable/Prototype/Exe/Exe/Parse2.hs
@@ -130,7 +130,7 @@ parserCreateUser = do
   email    <- A.argument A.str (A.metavar "EMAIL" <> A.help "An email address")
   return $ UpdateUser . U.UserCreate $ U.UserProfile
     "USER-0" -- TODO
-    (U.UserCreds username password)
+    (U.Credentials username password)
     "TODO"
     email
 

--- a/executable/cty-sock.hs
+++ b/executable/cty-sock.hs
@@ -76,7 +76,7 @@ repl runtime conn = do
       output <- Rt.runExeAppMSafe runtime $ IS.execModification
         (Data.ModifyUser
           (User.UserCreate $ User.UserProfile "USER-0"
-                                              (User.UserCreds "alice" "pass")
+                                              (User.Credentials "alice" "pass")
                                               "Alice"
                                               "alice@example.com"
           )

--- a/executable/cty-sock.hs
+++ b/executable/cty-sock.hs
@@ -75,8 +75,10 @@ repl runtime conn = do
 
       output <- Rt.runExeAppMSafe runtime $ IS.execModification
         (Data.ModifyUser
-          ( User.UserCreate
-          $ User.UserProfile (User.UserCreds "alice" "pass") "Alice"
+          (User.UserCreate $ User.UserProfile "USER-0"
+                                              (User.UserCreds "alice" "pass")
+                                              "Alice"
+                                              "alice@example.com"
           )
         )
 

--- a/src/Prototype/Exe/Data/User.hs
+++ b/src/Prototype/Exe/Data/User.hs
@@ -8,7 +8,7 @@ Description: User related datatypes
 -}
 module Prototype.Exe.Data.User
   ( Signup(..)
-  , UserCreds(..)
+  , Credentials(..)
   , userCredsName
   , userCredsPassword
   , UserProfile'(..)
@@ -72,17 +72,18 @@ instance FromForm Signup where
       <*> parseUnique "password"   f
       <*> parseUnique "email-addr" f
 
--- | User's credentials.
-data UserCreds = UserCreds
+-- | Represents user credentials. This is used both for user login and within
+-- the application state.
+data Credentials = Credentials
   { _userCredsName     :: UserName
   , _userCredsPassword :: Password
   }
   deriving (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
-instance FromForm UserCreds where
+instance FromForm Credentials where
   fromForm f =
-    UserCreds <$> parseUnique "username" f <*> parseUnique "password" f
+    Credentials <$> parseUnique "username" f <*> parseUnique "password" f
 
 data UserProfile' creds userDisplayName userEmailAddr = UserProfile
   { _userProfileId          :: UserId
@@ -93,7 +94,7 @@ data UserProfile' creds userDisplayName userEmailAddr = UserProfile
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
-type UserProfile = UserProfile' UserCreds UserDisplayName UserEmailAddr
+type UserProfile = UserProfile' Credentials UserDisplayName UserEmailAddr
 
 -- | The username is an identifier (i.e. it is unique).
 newtype UserName = UserName Text
@@ -233,7 +234,7 @@ userProfileParser =
     <*> (userEmailAddrParser <* P.space)
 
 userCredsParser =
-  UserCreds <$> (userNameParser <* P.space) <*> userPasswordParser
+  Credentials <$> (userNameParser <* P.space) <*> userPasswordParser
 
 data UserErr = UserExists Text
              | UserNotFound Text
@@ -257,5 +258,5 @@ instance Errs.IsRuntimeErr UserErr where
     UserNotFound      msg -> msg
     IncorrectPassword msg -> msg
 
-makeLenses ''UserCreds
+makeLenses ''Credentials
 makeLenses ''UserProfile'

--- a/src/Prototype/Exe/Data/User.hs
+++ b/src/Prototype/Exe/Data/User.hs
@@ -7,7 +7,8 @@ Module: Prototype.Exe.Data.User
 Description: User related datatypes
 -}
 module Prototype.Exe.Data.User
-  ( UserCreds(..)
+  ( CreateData(..)
+  , UserCreds(..)
   , userCredsName
   , userCredsPassword
   , UserProfile'(..)
@@ -54,6 +55,12 @@ import           Web.HttpApiData                ( FromHttpApiData(..) )
 
 
 --------------------------------------------------------------------------------
+data CreateData = CreateData
+  { username             :: UserName
+  , password             :: Password
+  }
+  deriving (Generic, Eq, Show, FromForm)
+
 -- | User's credentials.
 data UserCreds = UserCreds
   { _userCredsName     :: UserName

--- a/src/Prototype/Exe/Data/User.hs
+++ b/src/Prototype/Exe/Data/User.hs
@@ -7,7 +7,7 @@ Module: Prototype.Exe.Data.User
 Description: User related datatypes
 -}
 module Prototype.Exe.Data.User
-  ( CreateData(..)
+  ( Signup(..)
   , UserCreds(..)
   , userCredsName
   , userCredsPassword
@@ -55,7 +55,8 @@ import           Web.HttpApiData                ( FromHttpApiData(..) )
 
 
 --------------------------------------------------------------------------------
-data CreateData = CreateData
+-- | Represents the input data used for user registration.
+data Signup = Signup
   { username             :: UserName
   , password             :: Password
   }

--- a/src/Prototype/Exe/Data/User.hs
+++ b/src/Prototype/Exe/Data/User.hs
@@ -15,6 +15,7 @@ module Prototype.Exe.Data.User
   , userProfileCreds
   , userProfileId
   , userProfileDisplayName
+  , userProfileEmailAddr
   , UserId(..)
   , genRandomUserId
   , UserName(..)

--- a/src/Prototype/Exe/Form/Login.hs
+++ b/src/Prototype/Exe/Form/Login.hs
@@ -12,9 +12,6 @@ import           Text.Blaze                     ( customAttribute )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
-import           Web.FormUrlEncoded             ( FromForm(..)
-                                                , parseUnique
-                                                )
 
 
 --------------------------------------------------------------------------------

--- a/src/Prototype/Exe/Form/Login.hs
+++ b/src/Prototype/Exe/Form/Login.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 module Prototype.Exe.Form.Login
-  ( Input(..)
-  , Page(..)
+  ( Page(..)
   , ResultPage(..)
   ) where
 
@@ -16,17 +15,6 @@ import qualified Text.Blaze.Html5.Attributes   as A
 import           Web.FormUrlEncoded             ( FromForm(..)
                                                 , parseUnique
                                                 )
-
-
---------------------------------------------------------------------------------
-data Input = Input
-  { username :: Text
-  , password :: Text
-  }
-  deriving (Eq, Show)
-
-instance FromForm Input where
-  fromForm f = Input <$> parseUnique "username" f <*> parseUnique "password" f
 
 
 --------------------------------------------------------------------------------

--- a/src/Prototype/Exe/Form/Login.hs
+++ b/src/Prototype/Exe/Form/Login.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 module Prototype.Exe.Form.Login
-  ( Input
+  ( Input(..)
   , Page(..)
   , ResultPage(..)
   ) where

--- a/src/Prototype/Exe/Form/Signup.hs
+++ b/src/Prototype/Exe/Form/Signup.hs
@@ -31,7 +31,7 @@ instance FromForm Input where
   fromForm f =
     Input
       <$> parseUnique "username"     f
-      <*> parseUnique "email"        f
+      <*> parseUnique "email-addr"   f
       <*> parseUnique "password"     f
       <*> parseUnique "i-understand" f
 
@@ -87,14 +87,14 @@ signupPage Page {..} = Dsl.SingletonCanvas $ do
                     H.div ! A.class_ "o-form-group" $ do
                       H.label
                         ! A.class_ "o-form-group__label"
-                        ! A.for "email"
+                        ! A.for "email-addr"
                         $ "Email address"
                       H.div
                         ! A.class_ "o-form-group__controls"
                         $ H.input
                         ! A.class_ "c-input"
-                        ! A.id "email"
-                        ! A.name "email"
+                        ! A.id "email-addr"
+                        ! A.name "email-addr"
                         ! A.type_ "email"
                     H.div ! A.class_ "o-form-group" $ do
                       H.label

--- a/src/Prototype/Exe/Form/Signup.hs
+++ b/src/Prototype/Exe/Form/Signup.hs
@@ -12,9 +12,6 @@ import           Text.Blaze                     ( customAttribute )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
-import           Web.FormUrlEncoded             ( FromForm(..)
-                                                , parseUnique
-                                                )
 
 
 --------------------------------------------------------------------------------

--- a/src/Prototype/Exe/Form/Signup.hs
+++ b/src/Prototype/Exe/Form/Signup.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 module Prototype.Exe.Form.Signup
-  ( Input
-  , Page(..)
+  ( Page(..)
   , ResultPage(..)
   ) where
 
@@ -16,24 +15,6 @@ import qualified Text.Blaze.Html5.Attributes   as A
 import           Web.FormUrlEncoded             ( FromForm(..)
                                                 , parseUnique
                                                 )
-
-
---------------------------------------------------------------------------------
-data Input = Input
-  { username     :: Text
-  , emailAddress :: Text
-  , password     :: Text
-  , iUnderstand  :: Text -- TODO Bool
-  }
-  deriving (Eq, Show)
-
-instance FromForm Input where
-  fromForm f =
-    Input
-      <$> parseUnique "username"     f
-      <*> parseUnique "email-addr"   f
-      <*> parseUnique "password"     f
-      <*> parseUnique "i-understand" f
 
 
 --------------------------------------------------------------------------------

--- a/src/Prototype/Exe/Runtime.hs
+++ b/src/Prototype/Exe/Runtime.hs
@@ -115,13 +115,13 @@ instance S.DBStorage ExeAppM User.UserProfile where
       ML.localEnv (<> "Storage" <> "UserProfile" <> "UserCreate") $ do
         ML.info
           $  "Creating new user: "
-          <> (show . User._userCredsId $ User._userCreds newProfile)
+          <> (show . User._userCredsName $ User._userProfileCreds newProfile)
           <> "..."
         onUserIdExists newProfileId createNew existsErr
      where
       newProfileId = S.dbId newProfile
       createNew    = onUserNameExists
-        (newProfile ^. User.userProfileName)
+        (newProfile ^. User.userProfileCreds ^. User.userCredsName)
         (do
           result <- withUserStorage
             $ modifyUserProfiles newProfileId (newProfile :)
@@ -137,7 +137,7 @@ instance S.DBStorage ExeAppM User.UserProfile where
       -- generate a new and random user-id
       newId <- User.genRandomUserId 10
       let newProfile =
-            User.UserProfile (User.UserCreds newId password) userName
+            User.UserProfile newId (User.UserCreds userName password) "TODO" "TOTO@example.com"
       S.dbUpdate $ User.UserCreate newProfile
 
     User.UserDelete id -> onUserIdExists id (userNotFound $ show id) deleteUser
@@ -151,7 +151,7 @@ instance S.DBStorage ExeAppM User.UserProfile where
       updateUser
      where
       updateUser _ = withUserStorage $ modifyUserProfiles id replaceOlder
-      setPassword = set (User.userCreds . User.userCredsPassword) newPass
+      setPassword = set (User.userProfileCreds . User.userCredsPassword) newPass
       replaceOlder users =
         [ if S.dbId u == id then setPassword u else u | u <- users ]
 
@@ -168,7 +168,7 @@ instance S.DBStorage ExeAppM User.UserProfile where
          where
           passwordsMatch = storedPass =:= passInput
           User.Password storedPass =
-            u ^. User.userCreds . User.userCredsPassword
+            u ^. User.userProfileCreds . User.userCredsPassword
         _ -> userNotFound $ "No user with userName = " <> userName ^. coerced
 
     User.SelectUserById id ->
@@ -177,7 +177,7 @@ instance S.DBStorage ExeAppM User.UserProfile where
 
     User.SelectUserByUserName userName ->
       withUserStorage $ liftIO . STM.readTVarIO >=> pure . filter
-        ((== userName) . User._userProfileName)
+        ((== userName) . User._userCredsName . User._userProfileCreds)
 
 -- | Support for logging for the example application 
 instance ML.MonadAppNameLogMulti ExeAppM where

--- a/src/Prototype/Exe/Runtime.hs
+++ b/src/Prototype/Exe/Runtime.hs
@@ -133,11 +133,11 @@ instance S.DBStorage ExeAppM User.UserProfile where
         ML.info "User already exists."
         Errs.throwError' . User.UserExists $ show err
 
-    User.UserCreateGeneratingUserId userName password -> do
+    User.UserCreateGeneratingUserId username password email -> do
       -- generate a new and random user-id
       newId <- User.genRandomUserId 10
       let newProfile =
-            User.UserProfile newId (User.UserCreds userName password) "TODO" "TOTO@example.com"
+            User.UserProfile newId (User.UserCreds username password) "TODO" email
       S.dbUpdate $ User.UserCreate newProfile
 
     User.UserDelete id -> onUserIdExists id (userNotFound $ show id) deleteUser

--- a/src/Prototype/Exe/Runtime.hs
+++ b/src/Prototype/Exe/Runtime.hs
@@ -137,7 +137,7 @@ instance S.DBStorage ExeAppM User.UserProfile where
       -- generate a new and random user-id
       newId <- User.genRandomUserId 10
       let newProfile =
-            User.UserProfile newId (User.UserCreds username password) "TODO" email
+            User.UserProfile newId (User.Credentials username password) "TODO" email
       S.dbUpdate $ User.UserCreate newProfile
 
     User.UserDelete id -> onUserIdExists id (userNotFound $ show id) deleteUser

--- a/src/Prototype/Exe/Server.hs
+++ b/src/Prototype/Exe/Server.hs
@@ -193,9 +193,9 @@ type Public = "a" :> "signup"
 publicT :: forall m . Pub.PublicServerC m => ServerT Public m
 publicT = handleSignup :<|> authenticateUser
 
-handleSignup (User.Signup userName password) = env $ do
-  ML.info $ "Signing up new user: " <> show userName <> "..."
-  ids <- S.dbUpdate $ User.UserCreateGeneratingUserId userName password
+handleSignup (User.Signup username password email) = env $ do
+  ML.info $ "Signing up new user: " <> show username <> "..."
+  ids <- S.dbUpdate $ User.UserCreateGeneratingUserId username password email
   case headMay ids of
     Just uid -> do
       ML.info $ "User created: " <> show uid <> ". Sending success result."

--- a/src/Prototype/Exe/Server.hs
+++ b/src/Prototype/Exe/Server.hs
@@ -186,12 +186,6 @@ custom404 _request sendResponse = sendResponse $ Wai.responseLBS
 
 
 --------------------------------------------------------------------------------
-data CreateData = CreateData
-  { username             :: User.UserName
-  , password             :: User.Password
-  }
-  deriving (Generic, Eq, Show, FromForm)
-
 -- brittany-disable-next-binding
 -- | A publicly available login page.
 type Public = "a" :> "login"
@@ -200,7 +194,7 @@ type Public = "a" :> "login"
                                               NoContent
                                             )
             :<|> "a" :> "signup"
-                 :> ReqBody '[FormUrlEncoded] CreateData
+                 :> ReqBody '[FormUrlEncoded] User.CreateData
                  :> Post '[B.HTML] (SS.P.Page 'SS.P.Public Void Pages.SignupResultPage)
 
 publicT :: forall m . Pub.PublicServerC m => ServerT Public m
@@ -239,7 +233,7 @@ authenticateUser creds@User.UserCreds {..} =
       . mappend "User login failed: "
       . show
 
-processSignup (CreateData userName password) = env $ do
+processSignup (User.CreateData userName password) = env $ do
   ML.info $ "Signing up new user: " <> show userName <> "..."
   ids <- S.dbUpdate $ User.UserCreateGeneratingUserId userName password
   ML.info $ "Users created: " <> show ids

--- a/src/Prototype/Exe/Server.hs
+++ b/src/Prototype/Exe/Server.hs
@@ -65,14 +65,15 @@ type Exe = Auth.UserAuthentication :> Get '[B.HTML] (PageEither
              :<|> "login" :> Get '[B.HTML] Login.Page
              :<|> "signup" :> Get '[B.HTML] Signup.Page
 
-             :<|> "a" :> "login"
+             -- Temporarily let the old handlers in Public.hs use the "a" prefix.
+             :<|> "b" :> "login"
                   :> ReqBody '[FormUrlEncoded] Login.Input
                   :> Post '[B.HTML] Login.ResultPage
-             :<|> "a" :> "signup"
+             :<|> "b" :> "signup"
                   :> ReqBody '[FormUrlEncoded] Signup.Input
                   :> Post '[B.HTML] Signup.ResultPage
 
-             :<|> "public" :> Pub.Public
+             :<|> Pub.Public
              :<|> "private" :> Priv.Private
              :<|> Raw -- catchall for custom 404
 

--- a/src/Prototype/Exe/Server.hs
+++ b/src/Prototype/Exe/Server.hs
@@ -46,7 +46,6 @@ import           Smart.Server.Page              ( PageEither )
 import qualified Smart.Server.Page             as SS.P
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Renderer.Utf8       ( renderMarkup )
-import           Web.FormUrlEncoded             ( FromForm(..) )
 
 
 --------------------------------------------------------------------------------

--- a/src/Prototype/Exe/Server.hs
+++ b/src/Prototype/Exe/Server.hs
@@ -200,7 +200,7 @@ type Public = "a" :> "login"
 publicT :: forall m . Pub.PublicServerC m => ServerT Public m
 publicT = authenticateUser :<|> processSignup
 
-authenticateUser creds@User.UserCreds {..} =
+authenticateUser User.UserCreds {..} =
   env $ findMatchingUsers <&> headMay >>= \case
     Just u -> do
       -- get the config. to get the cookie and JWT settings.
@@ -215,12 +215,12 @@ authenticateUser creds@User.UserCreds {..} =
       case mApplyCookies of
         Nothing -> do
           ML.warning "Auth failed."
-          unauthdErr $ creds ^. User.userCredsName
+          unauthdErr _userCredsName
         Just applyCookies -> do
           ML.info "User logged in"
           pure . addHeader @"Location" "/" $ applyCookies
             NoContent
-    Nothing -> unauthdErr $ creds ^. User.userCredsName -- no users found
+    Nothing -> unauthdErr _userCredsName -- no users found
  where
   env               = ML.localEnv (<> "Login" <> show _userCredsName)
   findMatchingUsers = do

--- a/src/Prototype/Exe/Server/Private.hs
+++ b/src/Prototype/Exe/Server/Private.hs
@@ -46,15 +46,12 @@ type PrivateServerC m
 type Private = Auth.UserAuthentication :> UserPages
 -- brittany-disable-next-binding
 type UserPages
-  = "welcome" :> H.GetUserPage Pages.WelcomePage
-    :<|> "user" :> "profile" :> H.GetUserPage Pages.ProfilePage
+  = "user" :> "profile" :> H.GetUserPage Pages.ProfilePage
     :<|> EditUser
 
 privateT :: forall m . PrivateServerC m => ServerT Private m
-privateT authResult = showWelcomePage :<|> showProfilePage :<|> editUser
+privateT authResult = showProfilePage :<|> editUser
  where
-  showWelcomePage =
-    withUser $ \profile -> pure $ SS.P.AuthdPage profile Pages.WelcomePage
   showProfilePage = withUser $ \profile ->
     pure . SS.P.AuthdPage profile . Pages.ProfilePage $ "./profile"
   editUser Pages.EditProfileForm {..} = withUser $ \profile ->

--- a/src/Prototype/Exe/Server/Private.hs
+++ b/src/Prototype/Exe/Server/Private.hs
@@ -62,7 +62,7 @@ privateT authResult = showWelcomePage :<|> showProfilePage :<|> editUser
       Just newPass ->
         let updatedProfile =
               profile
-                &  User.userCreds
+                &  User.userProfileCreds
                 .  User.userCredsPassword
                 %~ (`fromMaybe` _editPassword)
         in  S.dbUpdate (User.UserPasswordUpdate (S.dbId profile) newPass)

--- a/src/Prototype/Exe/Server/Public.hs
+++ b/src/Prototype/Exe/Server/Public.hs
@@ -78,22 +78,22 @@ publicT =
         mApplyCookies <- liftIO $ SAuth.acceptLogin
           _confCookie
           jwtSettings
-          (u ^. User.userCreds . User.userCredsId)
+          (u ^. User.userProfileId)
         ML.info "Applying cookies."
         case mApplyCookies of
           Nothing -> do
             ML.warning "Auth failed."
-            unauthdErr $ u ^. User.userCreds . User.userCredsId
+            unauthdErr $ creds ^. User.userCredsName
           Just applyCookies -> do
             ML.info "User logged in"
             pure . addHeader @"Location" "/private/welcome" $ applyCookies
               NoContent
-      Nothing -> unauthdErr $ creds ^. User.userCredsId -- no users found
+      Nothing -> unauthdErr $ creds ^. User.userCredsName -- no users found
    where
-    env               = ML.localEnv (<> "Login" <> show _userCredsId)
+    env               = ML.localEnv (<> "Login" <> show _userCredsName)
     findMatchingUsers = do
       ML.info "Login with UserId failed, falling back to UserName based auth."
-      S.dbSelect $ User.UserLoginWithUserName (_userCredsId ^. coerced) -- UserId -> UserName 
+      S.dbSelect $ User.UserLoginWithUserName _userCredsName
                                               _userCredsPassword
 
   showSignupPage = pure . SS.P.PublicPage $ Pages.SignupPage "./signup/create"

--- a/src/Prototype/Exe/Server/Public.hs
+++ b/src/Prototype/Exe/Server/Public.hs
@@ -86,7 +86,7 @@ publicT =
             unauthdErr $ creds ^. User.userCredsName
           Just applyCookies -> do
             ML.info "User logged in"
-            pure . addHeader @"Location" "/private/welcome" $ applyCookies
+            pure . addHeader @"Location" "/" $ applyCookies
               NoContent
       Nothing -> unauthdErr $ creds ^. User.userCredsName -- no users found
    where

--- a/src/Prototype/Exe/Server/Public.hs
+++ b/src/Prototype/Exe/Server/Public.hs
@@ -16,22 +16,15 @@ module Prototype.Exe.Server.Public
   ) where
 
 import qualified Commence.Multilogging         as ML
-import qualified Commence.Runtime.Errors       as Errs
 import qualified Commence.Runtime.Storage      as S
-import qualified Commence.Server.Auth          as Auth
-import           Control.Lens
 import "exceptions" Control.Monad.Catch         ( MonadMask )
 import qualified Prototype.Exe.Data.User       as User
 import qualified Prototype.Exe.Runtime         as Rt
-import qualified Prototype.Exe.Server.Public.Pages
-                                               as Pages
-import           Servant
-import qualified Servant.Auth.Server           as SAuth
-import qualified Servant.HTML.Blaze            as B
-import qualified Smart.Server.Page             as SS.P
-import           Web.FormUrlEncoded             ( FromForm(..) )
 
--- | Minimal set of constraints needed on some monad @m@ to be satisfied to be able to run a public server.
+
+--------------------------------------------------------------------------------
+-- | Minimal set of constraints needed on some monad @m@ to be satisfied to be
+-- able to run a public server.
 type PublicServerC m
   = ( MonadMask m
     , ML.MonadAppNameLogMulti m

--- a/src/Prototype/Exe/Server/Public/Pages.hs
+++ b/src/Prototype/Exe/Server/Public/Pages.hs
@@ -41,14 +41,14 @@ instance H.ToMarkup LoginPage where
         )
    where
     username =
-      ( "UserID or UserName"
-      , Inp.PlainTextInput HTypes.Enabled "_userCredsId" "_userCredsId" Nothing
+      ( "Username"
+      , Inp.PlainTextInput HTypes.Enabled "username" "username" Nothing
       )
     password =
       ( "Password"
       , Inp.PasswordInput HTypes.Enabled
-                          "_userCredsPassword"
-                          "_userCredsPassword"
+                          "password"
+                          "password"
                           Nothing
       )
     loginButton = mkButton "Login" submitUrl POST

--- a/src/Prototype/Exe/Server/Public/Pages.hs
+++ b/src/Prototype/Exe/Server/Public/Pages.hs
@@ -6,80 +6,19 @@ The goal is to exemplify the use of our DSL for some simple pages and to have so
 
 -}
 module Prototype.Exe.Server.Public.Pages
-  ( LoginPage(..)
-  , SignupPage(..)
-  , SignupResultPage(..)
+  ( SignupResultPage(..)
   , LandingPage(..)
   , NotFoundPage(..)
   ) where
 
 import           Control.Lens
-import           Network.HTTP.Types.Method
 import qualified Prototype.Exe.Data.User       as User
-import           Prototype.Exe.Server.Shared.Html.Helpers.Form
-                                                ( mkButton )
 import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Errors             as Errors
-import qualified Smart.Html.Form               as Form
-import qualified Smart.Html.Input              as Inp
 import qualified Smart.Html.Pages.LandingPage  as Pages
 import qualified Smart.Html.Render             as Render
 import qualified Smart.Html.Shared.Types       as HTypes
 import qualified Text.Blaze.Html5              as H
-
--- | A simple login page.
-newtype LoginPage  = LoginPage { _loginPageAuthSubmitURL :: H.AttributeValue }
-
--- | For the `LoginPage` markup, we now rely on our DSL to render the login page to our liking
-instance H.ToMarkup LoginPage where
-  toMarkup (LoginPage submitUrl) = do
-    H.form
-      . H.toMarkup @Dsl.HtmlCanvas
-      $ (       Form.InputGroup [username, password]
-        Dsl.::~ loginButton
-        Dsl.::~ Dsl.EmptyCanvas
-        )
-   where
-    username =
-      ( "Username"
-      , Inp.PlainTextInput HTypes.Enabled "username" "username" Nothing
-      )
-    password =
-      ( "Password"
-      , Inp.PasswordInput HTypes.Enabled
-                          "password"
-                          "password"
-                          Nothing
-      )
-    loginButton = mkButton "Login" submitUrl POST
-
-newtype SignupPage = SignupPage { _signupPageSubmitURL :: H.AttributeValue }
-
-instance H.ToMarkup SignupPage where
-  toMarkup (SignupPage submitUrl) = do
-    H.form
-      . H.toMarkup @Dsl.HtmlCanvas
-      $ (       Form.InputGroup
-            [ username
-            , password "Password"         "password"
-            , password "Confirm Password" "passwordConfirmation"
-            ]
-        Dsl.::~ submitButton
-        Dsl.::~ Dsl.EmptyCanvas
-        )
-   where
-    username =
-      ( "Username"
-      , Inp.PlainTextInput HTypes.Enabled "username" "username" Nothing
-      )
-    password fieldName inputName =
-      ( HTypes.Title fieldName
-      , Inp.PasswordInput HTypes.Enabled
-                          (HTypes.Id inputName)
-                          (HTypes.Name inputName)
-                          Nothing
-      )
-    submitButton = mkButton "Register" submitUrl POST
 
 data SignupResultPage = SignupSuccess User.UserId
                       | SignupFailed Text
@@ -87,7 +26,7 @@ data SignupResultPage = SignupSuccess User.UserId
 instance H.ToMarkup SignupResultPage where
   toMarkup = \case
     SignupSuccess userId -> withText $ "Signed up as: " <> userId ^. coerced
-    SignupFailed  msg    -> withText msg
+    SignupFailed  msg    -> withText $ "Failed sign up: " <> msg
    where
     withText msg =
       H.toMarkup @Dsl.HtmlCanvas $ Dsl.SingletonCanvas (HTypes.Title $ msg)


### PR DESCRIPTION
This should be merged after https://github.com/hypered/curiosity/pull/3. Its branch is the target of this PR.

The main goal of this PR was to connect the design from the previous PR to the actual Servant handlers. One little challenge was to use the `/` route to both display the landing page, but also the user homepage (currently called "welcome" page) when the user is logged. Doing so messed a bit the concept of `PublicServerC` and `publicT` and I have moved some code around.

I wanted to put all the code related to a form, e.g. the login form, in a single file, `Login.hs`: the HTML bits, the Servant handler, and the data types to represent the inputs. But as you have used the same data type, `UserCreds`, to both represent the login input, but also the credentials as stored in database, I let those things in `User.hs`.

The handlers are in `Server.hs`. I guess we'll want to move them elsewhere, either in `Login.hs` and `Signup.hs`, or maybe something like a `UserManagement.hs` ?

I've tried to name things in a more "regular" way. So `CreateData` is now `Login`, and `UserCreds` is now `Credentials`. They are imported qualified, so this works well.

Most importantly, I've changed a bit the `UserProfile` structure: username is a (unique) identifier, exactly like your GitHub username, and intended for e.g. URLs. There is a clear "display name", e.g. for emails. But there is also a "real" database ID.

It would be great that you play with the application, especially in conjunction with the two shell scripts I've added to make cURL calls. There are some TODOs that I don't really know how to solve (some `Nothing` cases that are never triggered because an exception is throwed instead, returning something else than a 200 OK in some cases, ...)

B.t.w., I've deployed this branch to http://smartcoop.sh/.