### PR TITLE
Add documentation to the VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,21 @@ $ nix-build -A runvm
 $ result/bin/run-nixos-vm
 ```
 
-Within the VM, Nginx is setup as a reverse-proxy in front of `cty-serve`. You should be able to confirm that with e.g.:
+Within the VM, Nginx is setup as a reverse-proxy in front of `cty-serve`. You
+should be able to confirm that with e.g.:
 
 ```
 # curl -v 127.0.0.1
 # systemctl status nginx
 # systemctl status app
+```
+
+The VM contains other binaries to help interact with the system, and local
+documentation is available as man pages:
+
+```
+# cty --help
+# man curiosity
 ```
 
 Use `ctrl-a x` to quit QEMU.

--- a/content/default.nix
+++ b/content/default.nix
@@ -1,0 +1,22 @@
+{ nixpkgs ? <nixpkgs>
+}:
+
+let
+  pkgs = import nixpkgs {};
+
+in
+{
+  html.all = pkgs.stdenv.mkDerivation {
+    name = "content";
+    # TODO We only need content/, man/, scripts/
+    src = ../.;
+    nativeBuildInputs = [ pkgs.mandoc pkgs.pandoc ];
+    installPhase = ''
+      # Make sure we don't use an already built _site/.
+      rm -rf _site
+
+      make -f scripts/doc.Makefile
+      mv _site $out
+    '';
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -25,6 +25,7 @@ in with nixpkgs.haskellPackages;
     # Build with nix-build -A <attr>
     binaries = prototype-hs-exe;
     content = (import ./content {}).html.all;
+    man-pages = (import ./man {}).man-pages;
     toplevel = os.config.system.build.toplevel;
     image = os.config.system.build.digitalOceanImage;
     runvm = qemu.config.system.build.vm;

--- a/default.nix
+++ b/default.nix
@@ -24,6 +24,7 @@ in with nixpkgs.haskellPackages;
 
     # Build with nix-build -A <attr>
     binaries = prototype-hs-exe;
+    content = (import ./content {}).html.all;
     toplevel = os.config.system.build.toplevel;
     image = os.config.system.build.digitalOceanImage;
     runvm = qemu.config.system.build.vm;

--- a/executable/Prototype/Exe/Exe/Parse.hs
+++ b/executable/Prototype/Exe/Exe/Parse.hs
@@ -40,7 +40,7 @@ confParser = do
 
 defaultConf :: Conf
 defaultConf =
-  let _confServer = ServerConf 9000
+  let _confServer = ServerConf 9000 "./_site/"
       _confRepl   = Repl.ReplConf "> " False ["exit", "quit"]
       _confDbFile = Nothing
   in  Conf
@@ -59,11 +59,22 @@ defaultConf =
 flspec = FL.FileLogSpec "/tmp/curiosity.log" 5000 0
 
 serverParser :: A.Parser ServerConf
-serverParser = ServerConf . abs <$> A.option
-  A.auto
-  (A.long "server-port" <> A.value 9000 <> A.metavar "PORT" <> A.help
-    "Port to run the HTTP server on."
-  )
+serverParser =
+  ServerConf
+    .   abs
+    <$> A.option
+          A.auto
+          (A.long "server-port" <> A.value 9000 <> A.metavar "PORT" <> A.help
+            "Port to run the HTTP server on."
+          )
+    <*> A.strOption
+          (  A.long "static-dir"
+          <> A.value "./_site/"
+          <> A.metavar "DIR"
+          <> A.help
+               "A directory served as static assets, in particular HTML \
+            \documentation."
+          )
 
 replParser :: A.Parser Repl.ReplConf
 replParser = do

--- a/executable/Prototype/Exe/Exe/Process.hs
+++ b/executable/Prototype/Exe/Exe/Process.hs
@@ -47,7 +47,7 @@ endRepl res = putStrLn @Text $ T.unlines ["REPL process ended: " <> show res]
 --------------------------------------------------------------------------------
 startServer :: Rt.Runtime -> IO Errs.RuntimeErr
 startServer runtime@Rt.Runtime {..} = do
-  let Rt.ServerConf port = runtime ^. Rt.rConf . Rt.confServer
+  let Rt.ServerConf port _ = runtime ^. Rt.rConf . Rt.confServer
   startupLogInfo _rLoggers $ "Starting up server on port " <> show port <> "..."
   try @SomeException (Srv.runExeServer runtime) >>= pure . either
     Errs.RuntimeException

--- a/machine/configuration.nix
+++ b/machine/configuration.nix
@@ -13,4 +13,9 @@
     ../modules/app.nix
     ../modules/nginx.nix
   ];
+
+  environment.systemPackages = [
+    (import ../.).binaries
+    (import ../.).man-pages # TODO Man pages should come with .binaries ?
+  ];
 }

--- a/man/default.nix
+++ b/man/default.nix
@@ -1,0 +1,25 @@
+{ nixpkgs ? <nixpkgs>
+}:
+
+let
+  pkgs = import nixpkgs {};
+
+in
+{
+  man-pages = pkgs.stdenv.mkDerivation {
+    name = "man";
+    # TODO We only need man/, scripts/
+    src = ../.;
+    nativeBuildInputs = [ pkgs.pandoc ];
+    installPhase = ''
+      # Make sure we don't use an already built _site/.
+      rm -rf _site
+
+      make -f scripts/doc.Makefile man
+
+      mkdir -p $out/share/man/man{1,7}
+      mv cty.1.gz $out/share/man/man1/
+      mv curiosity.7.gz $out/share/man/man7/
+    '';
+  };
+}

--- a/modules/app.nix
+++ b/modules/app.nix
@@ -3,8 +3,9 @@
   systemd.services.app = {
     wantedBy = [ "multi-user.target" ];
     script = ''
-      ${(import ../.).prototype-hs-exe}/bin/cty-serve \
-        --server-port 9000
+      ${(import ../.).binaries}/bin/cty-serve \
+        --server-port 9000 \
+        --static-dir ${(import ../.).content}
     '';
   };
 }

--- a/scripts/doc.Makefile
+++ b/scripts/doc.Makefile
@@ -5,11 +5,12 @@ TARGETS := $(addprefix _site/, $(HTML_FILES:content/%=%))
 
 .PHONY: all
 all: $(TARGETS) \
+	man \
 	_site/robots.txt _site/humans.txt _site/.well-known/security.txt \
-	curiosity.7 cty.1 \
 	_site/documentation/clis/curiosity.7.html \
 	_site/documentation/clis/cty.1.html
 
+man: curiosity.7.gz cty.1.gz
 
 _site/%.html: content/%.md scripts/template.html
 	mkdir -p $(dir $@)
@@ -34,6 +35,12 @@ _site/documentation/clis/%.7.html: %.7
 
 %.7: man/%.7.md
 	pandoc --standalone --to man $< -o $@
+
+%.1.gz: %.1
+	gzip --keep $<
+
+%.7.gz: %.7
+	gzip --keep $<
 
 _site/robots.txt: content/robots.txt
 	cp $< $@

--- a/src/Prototype/Exe/Runtime.hs
+++ b/src/Prototype/Exe/Runtime.hs
@@ -51,8 +51,11 @@ import qualified Servant
 import qualified Servant.Auth.Server           as Srv
 import           System.Directory               ( doesFileExist )
 
-newtype ServerConf = ServerConf { _serverPort :: Int }
-                   deriving Show
+data ServerConf = ServerConf
+  { _serverPort      :: Int
+  , _serverStaticDir :: FilePath
+  }
+  deriving Show
 
 -- | Application config.
 data Conf = Conf

--- a/src/Prototype/Exe/Runtime.hs
+++ b/src/Prototype/Exe/Runtime.hs
@@ -136,8 +136,10 @@ instance S.DBStorage ExeAppM User.UserProfile where
     User.UserCreateGeneratingUserId username password email -> do
       -- generate a new and random user-id
       newId <- User.genRandomUserId 10
-      let newProfile =
-            User.UserProfile newId (User.Credentials username password) "TODO" email
+      let newProfile = User.UserProfile newId
+                                        (User.Credentials username password)
+                                        "TODO"
+                                        email
       S.dbUpdate $ User.UserCreate newProfile
 
     User.UserDelete id -> onUserIdExists id (userNotFound $ show id) deleteUser
@@ -151,7 +153,8 @@ instance S.DBStorage ExeAppM User.UserProfile where
       updateUser
      where
       updateUser _ = withUserStorage $ modifyUserProfiles id replaceOlder
-      setPassword = set (User.userProfileCreds . User.userCredsPassword) newPass
+      setPassword =
+        set (User.userProfileCreds . User.userCredsPassword) newPass
       replaceOlder users =
         [ if S.dbId u == id then setPassword u else u | u <- users ]
 

--- a/src/Prototype/Exe/Server.hs
+++ b/src/Prototype/Exe/Server.hs
@@ -26,7 +26,9 @@ import qualified Commence.Runtime.Storage      as S
 import           Control.Lens
 import qualified Data.ByteString.Lazy          as BL
                                                 ( hGetContents )
-import           Data.List                      ( init, last )
+import           Data.List                      ( init
+                                                , last
+                                                )
 import qualified Data.Text                     as T
 import qualified Network.HTTP.Types            as HTTP
 import qualified Network.Wai                   as Wai
@@ -74,11 +76,11 @@ import           System.IO                      ( IOMode(..)
                                                 , withBinaryFile
                                                 )
 
-import           Data.ByteArray.Encoding
 import           Crypto.Hash                    ( Digest
                                                 , MD5
                                                 , hashlazy
                                                 )
+import           Data.ByteArray.Encoding
 
 
 --------------------------------------------------------------------------------
@@ -173,8 +175,7 @@ showLandingPage = \case
       Just userProfile ->
         pure . SS.P.PageR $ SS.P.AuthdPage userProfile Pages.WelcomePage
   _ -> pure $ SS.P.PageL Pages.LandingPage
- where
-  authFailedErr = Errs.throwError' . User.UserNotFound
+  where authFailedErr = Errs.throwError' . User.UserNotFound
 
 
 --------------------------------------------------------------------------------
@@ -227,8 +228,7 @@ handleSignup User.Signup {..} = env $ do
       -- TODO This should not be a 200 OK result.
       ML.info $ "Failed to create a user. Sending failure result."
       pure . SS.P.PublicPage $ Pages.SignupFailed "Failed to create users."
- where
-  env = ML.localEnv (<> "HTTP" <> "Signup")
+  where env = ML.localEnv (<> "HTTP" <> "Signup")
 
 handleLogin User.Credentials {..} =
   env $ findMatchingUsers <&> headMay >>= \case
@@ -317,15 +317,18 @@ unsafeToPiece t = let Just p = toPiece t in p
 webAppLookup :: ETagLookup -> FilePath -> Pieces -> IO LookupResult
 webAppLookup hashFunc prefix pieces = fileHelperLR hashFunc fp lastPiece
  where
-  fp = pathFromPieces prefix pieces'
+  fp      = pathFromPieces prefix pieces'
   pieces' = initPieces ++ [lastPiece]
-  (initPieces, lastPiece) | null pieces = ([], unsafeToPiece "index.html")
-                          | Just (last pieces) == toPiece "" = (init pieces, unsafeToPiece "index.html")
-                          | otherwise   =
-                              let lastP = case fromPiece (last pieces) of
-                                    s | T.isSuffixOf ".txt" s -> last pieces
-                                    s -> unsafeToPiece $ s <> ".html"
-                              in (init pieces, lastP)
+  (initPieces, lastPiece)
+    | null pieces
+    = ([], unsafeToPiece "index.html")
+    | Just (last pieces) == toPiece ""
+    = (init pieces, unsafeToPiece "index.html")
+    | otherwise
+    = let lastP = case fromPiece (last pieces) of
+            s | T.isSuffixOf ".txt" s -> last pieces
+            s                         -> unsafeToPiece $ s <> ".html"
+      in  (init pieces, lastP)
 
 -- | Convenience wrapper for @fileHelper@.
 fileHelperLR


### PR DESCRIPTION
- HTML documentation is now built with Nix (although it re-uses the existing `Makefile`)
- Same for man pages
- The server now has a `--static-dir` option to specify which directory should be served for static assets (in particular the HTML documentation)
- The VM image is updated to contain and serve the documentation (in particular, it builds the documentation within the Nix store, and the resulting directory is passed to `cty-serve` using the new option)
- It is also updated to contain our binaries and man pages