### PR TITLE
Add some documentation

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -5,18 +5,29 @@ title: Curiosity
 
 # About
 
-Curiosity is a prototype system to think, discuss, and communicate the future
-of Smart Belgium's developments. A running instance of Curiosity is made
+Curiosity is an ever-evolving prototype system to think, discuss, and
+communicate the future of Smart Belgium's developments. The complete system is
+packaged as a [virtual machine image](/documentation/machine). It is exposed to
+end-users as a web application and a running instance of Curiosity is made
 available at [`smartcoop.sh`](//smartcoop.sh) for demonstration purpose.
-
-## Open source
-
-Curiosity is an open source project and available on
-[GitHub](https://github.com/hypered/curiosity).
 
 ## Experimental
 
 Curiosity is being developed to inform further developments, and is not
 intended to be a production system. It will evolve during the next few months
-as we try to nail down as precisely as possible what the best solution for
-Smart Beligum is.
+as we try to nail down as precisely as possible what the best solutions for
+Smart Belgium are.
+
+## Open source
+
+Curiosity is an open source project distributed under a 2-clause BSD license.
+It is available on [GitHub](https://github.com/hypered/curiosity).
+
+## Documented
+
+To achieve our goals in making Curiosity a central place to inform future
+developments, the complete documentation is part of the virtual machine image.
+The documentation is comprised of HTML pages, visible at
+[`smartcoop.sh`](//smartcoop.sh/documentation), and [man
+pages](/documentation/man-pages), available from the terminal within the
+virtual machine.

--- a/content/documentation.md
+++ b/content/documentation.md
@@ -7,5 +7,8 @@ title: Curiosity
 
 - [About](/about)
 - [Command-line interfaces](/documentation/clis)
+- [Deployment](/documentation/deployment)
 - [Forms](/documentation/forms)
+- [Man pages](/documentation/man-pages)
 - [Sitemap](/documentation/sitemap)
+- [Virtual machine image](/documentation/machine)

--- a/content/documentation/deployment.md
+++ b/content/documentation/deployment.md
@@ -1,0 +1,9 @@
+---
+title: Curiosity
+---
+
+
+# Deployment on DigitalOcean
+
+See the [README
+file](https://github.com/hypered/curiosity#the-smartcoopsh-host).

--- a/content/documentation/machine.md
+++ b/content/documentation/machine.md
@@ -1,0 +1,20 @@
+---
+title: Curiosity
+---
+
+
+# Virtual machine image
+
+Curiosity is packaged as a virtual machine image. The image contains everything
+(e.g. the web application, a reverse proxy, helper programs and documentation).
+
+The same image can be built for different environments. For instance we use KVM
+for local development and the virtual machine available at
+[`smartcoop.sh`](//smartcoop.sh) for demonstration purpose is
+[deployed](/documentation/deployment) at DigitalOcean.
+
+## Built with Nix
+
+The build system used for Curiosity is [Nix](https://nixos.org/). It ensures
+that the complete system, or its different parts, can be built reliably from
+source.

--- a/content/documentation/man-pages.md
+++ b/content/documentation/man-pages.md
@@ -1,0 +1,32 @@
+---
+title: Curiosity
+---
+
+
+# Man pages
+
+In addition of HTML pages, parts of the documentation for Curiosity are
+available as [man pages](https://en.wikipedia.org/wiki/Man_page).
+
+Each command-line tool has its own man page. An easy way to find out what those
+tools are, is to start typing `cty` at a virtual machine prompt then hit the
+`TAB` key twice to see the proposed auto-completion. There is also a more
+general man page available as `man curiosity`.
+
+Assuming an SSH access to `smartcoop.sh`, here is a possible session
+demonstrating the above:
+
+```
+$ ssh root@smartcoop.sh
+[root@curiosity-1:~]# cty<TAB><TAB>
+cty              cty-parse        cty-serve        
+cty-interactive  cty-repl         cty-sock
+[root@curiosity-1:~]# man cty
+[root@curiosity-1:~]# man curiosity
+```
+
+For convenience, the man pages are also rendered as HTML pages:
+
+- [`curiosity(7)`](/documentation/clis/curiosity.7)
+- [`cty(1)`](/documentation/clis/cty.1)
+- [`cty-serve(1)`](/documentation/clis/cty-serve.1)


### PR DESCRIPTION
The result is deployed at [`smartcoop.sh`](http://smartcoop.sh/documentation).