### PR TITLE
Some code reorganization

### DIFF
--- a/bin/cty-interactive.hs
+++ b/bin/cty-interactive.hs
@@ -44,7 +44,8 @@ runWithConf conf = do
     -- the server and repl processes are different: for the server, we are conserving the exception with which the the server process exited.
     -- this exception is also used to end the repl process.
     $ let serverProcess = do
-            err <- P.startServer runtime
+            -- TODO Parse the server config.
+            err <- P.startServer P.defaultServerConf runtime
             P.endServer _rLoggers err
             -- re-report the error. 
             pure err

--- a/bin/cty-interactive.hs
+++ b/bin/cty-interactive.hs
@@ -9,6 +9,7 @@ import qualified Control.Concurrent.Async      as Async
 import qualified Curiosity.Parse               as P
 import qualified Curiosity.Process             as P
 import qualified Curiosity.Runtime             as Rt
+import           Data.Default.Class             ( def )
 import qualified Options.Applicative           as A
 
 
@@ -50,7 +51,8 @@ runWithConf conf = do
             -- re-report the error. 
             pure err
 
-          replProcess = P.startRepl runtime >>= P.endRepl
+          -- TODO Parse the REPL config.
+          replProcess = P.startRepl def runtime >>= P.endRepl
       in  Async.withAsync serverProcess $ \serverRef -> do
             Async.withAsync replProcess $ \replRef -> do
               -- wait for the server process to exit. 

--- a/bin/cty-interactive.hs
+++ b/bin/cty-interactive.hs
@@ -5,12 +5,12 @@ module Main
   ) where
 
 import           Commence.Multilogging          ( flushAndCloseLoggers )
+import qualified Control.Concurrent.Async      as Async
 import qualified Curiosity.Parse               as P
 import qualified Curiosity.Process             as P
 import qualified Curiosity.Runtime             as Rt
-import qualified Control.Concurrent.Async      as Async
 import qualified Options.Applicative           as A
-import qualified Servant.Auth.Server           as Srv
+
 
 --------------------------------------------------------------------------------
 main :: IO ExitCode
@@ -32,8 +32,7 @@ runWithConf :: Rt.Conf -> IO ExitCode
 runWithConf conf = do
   putStrLn @Text
     "Booting runtime; the rest of the startup logs will be in the configured logging outputs."
-  jwk                     <- Srv.generateKey
-  runtime@Rt.Runtime {..} <- Rt.boot conf jwk >>= either throwIO pure
+  runtime@Rt.Runtime {..} <- Rt.boot conf >>= either throwIO pure
 
   let handleExceptions = (`catch` P.shutdown runtime . Just)
       reportServerEnd  = P.startupLogInfo

--- a/bin/cty-repl.hs
+++ b/bin/cty-repl.hs
@@ -6,7 +6,6 @@ import qualified Curiosity.Parse               as P
 import qualified Curiosity.Process             as P
 import qualified Curiosity.Runtime             as Rt
 import qualified Options.Applicative           as A
-import qualified Servant.Auth.Server           as Srv
 
 
 --------------------------------------------------------------------------------
@@ -24,8 +23,7 @@ mainParserInfo =
 
 runWithConf :: Rt.Conf -> IO ExitCode
 runWithConf conf = do
-  jwk                     <- Srv.generateKey
-  runtime@Rt.Runtime {..} <- Rt.boot conf jwk >>= either throwIO pure
+  runtime@Rt.Runtime {..} <- Rt.boot conf >>= either throwIO pure
 
   let handleExceptions = (`catch` P.shutdown runtime . Just)
 

--- a/bin/cty-repl.hs
+++ b/bin/cty-repl.hs
@@ -5,6 +5,7 @@ module Main
 import qualified Curiosity.Parse               as P
 import qualified Curiosity.Process             as P
 import qualified Curiosity.Runtime             as Rt
+import           Data.Default.Class             ( def )
 import qualified Options.Applicative           as A
 
 
@@ -28,5 +29,6 @@ runWithConf conf = do
   let handleExceptions = (`catch` P.shutdown runtime . Just)
 
   handleExceptions $ do
-    P.startRepl runtime >>= P.endRepl
+    -- TODO Parse the REPL config.
+    P.startRepl def runtime >>= P.endRepl
     P.shutdown runtime Nothing

--- a/bin/cty-serve.hs
+++ b/bin/cty-serve.hs
@@ -14,21 +14,22 @@ import qualified Options.Applicative           as A
 main :: IO ExitCode
 main = A.execParser mainParserInfo >>= runWithConf
 
-mainParserInfo :: A.ParserInfo Srv.ServerConf
+mainParserInfo :: A.ParserInfo (Rt.Conf, Srv.ServerConf)
 mainParserInfo =
-  A.info (P.serverParser <**> A.helper)
+  A.info (parser <**> A.helper)
     $  A.fullDesc
     <> A.header "cty-serve - Curiosity HTTP server"
     <> A.progDesc
          "Curiosity is a prototype application to explore the design space \
          \of a web application for Smart."
+ where
+  parser = (,) <$> P.confParser <*> P.serverParser
 
-runWithConf :: Srv.ServerConf -> IO ExitCode
-runWithConf conf = do
-  -- TODO Parse the runtime config.
-  runtime@Rt.Runtime {..} <- Rt.boot P.defaultConf >>= either throwIO pure
+runWithConf :: (Rt.Conf, Srv.ServerConf) -> IO ExitCode
+runWithConf (conf, serverConf) = do
+  runtime@Rt.Runtime {..} <- Rt.boot conf >>= either throwIO pure
 
-  P.startServer conf runtime >>= P.endServer _rLoggers
+  P.startServer serverConf runtime >>= P.endServer _rLoggers
 
   mPowerdownErrs <- Rt.powerdown runtime
 

--- a/bin/cty-serve.hs
+++ b/bin/cty-serve.hs
@@ -6,6 +6,7 @@ module Main
 import qualified Curiosity.Parse               as P
 import qualified Curiosity.Process             as P
 import qualified Curiosity.Runtime             as Rt
+import qualified Curiosity.Server              as Srv
 import qualified Options.Applicative           as A
 
 
@@ -13,20 +14,21 @@ import qualified Options.Applicative           as A
 main :: IO ExitCode
 main = A.execParser mainParserInfo >>= runWithConf
 
-mainParserInfo :: A.ParserInfo Rt.Conf
+mainParserInfo :: A.ParserInfo Srv.ServerConf
 mainParserInfo =
-  A.info (P.confParser <**> A.helper)
+  A.info (P.serverParser <**> A.helper)
     $  A.fullDesc
     <> A.header "cty-serve - Curiosity HTTP server"
     <> A.progDesc
          "Curiosity is a prototype application to explore the design space \
          \of a web application for Smart."
 
-runWithConf :: Rt.Conf -> IO ExitCode
+runWithConf :: Srv.ServerConf -> IO ExitCode
 runWithConf conf = do
-  runtime@Rt.Runtime {..} <- Rt.boot conf >>= either throwIO pure
+  -- TODO Parse the runtime config.
+  runtime@Rt.Runtime {..} <- Rt.boot P.defaultConf >>= either throwIO pure
 
-  P.startServer runtime >>= P.endServer _rLoggers
+  P.startServer conf runtime >>= P.endServer _rLoggers
 
   mPowerdownErrs <- Rt.powerdown runtime
 

--- a/bin/cty-serve.hs
+++ b/bin/cty-serve.hs
@@ -7,7 +7,6 @@ import qualified Curiosity.Parse               as P
 import qualified Curiosity.Process             as P
 import qualified Curiosity.Runtime             as Rt
 import qualified Options.Applicative           as A
-import qualified Servant.Auth.Server           as Srv
 
 
 --------------------------------------------------------------------------------
@@ -25,8 +24,7 @@ mainParserInfo =
 
 runWithConf :: Rt.Conf -> IO ExitCode
 runWithConf conf = do
-  jwk                     <- Srv.generateKey
-  runtime@Rt.Runtime {..} <- Rt.boot conf jwk >>= either throwIO pure
+  runtime@Rt.Runtime {..} <- Rt.boot conf >>= either throwIO pure
 
   P.startServer runtime >>= P.endServer _rLoggers
 

--- a/bin/cty-sock.hs
+++ b/bin/cty-sock.hs
@@ -73,7 +73,7 @@ repl runtime conn = do
         A.Failure           err -> print err
         A.CompletionInvoked _   -> print @IO @Text "Shouldn't happen"
 
-      output <- Rt.runExeAppMSafe runtime $ IS.execModification
+      output <- Rt.runAppMSafe runtime $ IS.execModification
         (Data.ModifyUser
           (User.UserCreate $ User.UserProfile "USER-0"
                                               (User.Credentials "alice" "pass")

--- a/bin/cty-sock.hs
+++ b/bin/cty-sock.hs
@@ -18,7 +18,6 @@ import           Network.Socket.ByteString      ( recv
                                                 , sendAll
                                                 )
 import qualified Options.Applicative           as A
-import qualified Servant.Auth.Server           as Srv
 
 
 --------------------------------------------------------------------------------
@@ -34,9 +33,7 @@ mainParserInfo =
 
 runWithConf conf = do
   putStrLn @Text "Creating runtime..."
-  jwt                     <- Srv.generateKey
-  runtime@Rt.Runtime {..} <- Rt.boot conf jwt >>= either throwIO pure
-  -- TODO jwt should'nt be in the runtime, but in the HTTP layer
+  runtime@Rt.Runtime {..} <- Rt.boot conf >>= either throwIO pure
 
   putStrLn @Text "Creating curiosity.sock..."
   sock <- socket AF_UNIX Stream 0
@@ -75,10 +72,11 @@ repl runtime conn = do
 
       output <- Rt.runAppMSafe runtime $ IS.execModification
         (Data.ModifyUser
-          (User.UserCreate $ User.UserProfile "USER-0"
-                                              (User.Credentials "alice" "pass")
-                                              "Alice"
-                                              "alice@example.com"
+          (User.UserCreate $ User.UserProfile
+            "USER-0"
+            (User.Credentials "alice" "pass")
+            "Alice"
+            "alice@example.com"
           )
         )
 

--- a/bin/cty.hs
+++ b/bin/cty.hs
@@ -47,7 +47,6 @@ run (P.CommandWithTarget command target) = do
       runtime@Rt.Runtime {..} <-
         Rt.boot P.defaultConf { Rt._confDbFile = Just path }
           >>= either throwIO pure
-      -- TODO jwt should'nt be in the runtime, but in the HTTP layer
 
       case command of
         P.State -> do

--- a/bin/cty.hs
+++ b/bin/cty.hs
@@ -54,19 +54,19 @@ run (P.CommandWithTarget command target) = do
       case command of
         P.State -> do
           output <-
-            Rt.runExeAppMSafe runtime
+            Rt.runAppMSafe runtime
             . IS.execVisualisation
             $ Data.VisualiseFullStmDb
           print output
         P.SelectUser select -> do
           output <-
-            Rt.runExeAppMSafe runtime
+            Rt.runAppMSafe runtime
             . IS.execVisualisation
             $ Data.VisualiseUser select
           print output
         P.UpdateUser update -> do
           output <-
-            Rt.runExeAppMSafe runtime . IS.execModification $ Data.ModifyUser
+            Rt.runAppMSafe runtime . IS.execModification $ Data.ModifyUser
               update
           print output
         _ -> do

--- a/bin/cty.hs
+++ b/bin/cty.hs
@@ -15,7 +15,6 @@ import qualified Curiosity.Runtime             as Rt
 import qualified Data.ByteString.Lazy          as BS
 import qualified Data.Text                     as T
 import qualified Options.Applicative           as A
-import qualified Servant.Auth.Server           as Srv
 import           System.Directory               ( doesFileExist )
 
 
@@ -45,9 +44,8 @@ run (P.CommandWithTarget P.Init (P.StateFileTarget path)) = do
 run (P.CommandWithTarget command target) = do
   case target of
     P.StateFileTarget path -> do
-      jwt                     <- Srv.generateKey
       runtime@Rt.Runtime {..} <-
-        Rt.boot P.defaultConf { Rt._confDbFile = Just path } jwt
+        Rt.boot P.defaultConf { Rt._confDbFile = Just path }
           >>= either throwIO pure
       -- TODO jwt should'nt be in the runtime, but in the HTTP layer
 
@@ -60,9 +58,8 @@ run (P.CommandWithTarget command target) = do
           print output
         P.SelectUser select -> do
           output <-
-            Rt.runAppMSafe runtime
-            . IS.execVisualisation
-            $ Data.VisualiseUser select
+            Rt.runAppMSafe runtime . IS.execVisualisation $ Data.VisualiseUser
+              select
           print output
         P.UpdateUser update -> do
           output <-

--- a/src/Curiosity/Parse.hs
+++ b/src/Curiosity/Parse.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ApplicativeDo #-}
 module Curiosity.Parse
   ( confParser
+  , replParser
   , serverParser
   , defaultConf
   , defaultServerConf
@@ -21,7 +22,6 @@ import qualified System.Log.FastLogger         as FL
 --------------------------------------------------------------------------------
 confParser :: A.Parser Conf
 confParser = do
-  _confRepl   <- replParser
   _confDbFile <- dbFileParser
   pure Conf
     {
@@ -34,8 +34,7 @@ confParser = do
 
 defaultConf :: Conf
 defaultConf =
-  let _confRepl   = Repl.ReplConf "> " False ["exit", "quit"]
-      _confDbFile = Nothing
+  let _confDbFile = Nothing
   in  Conf
         { _confLogging = ML.LoggingConf [FL.LogFile flspec 1024]
                                         "Curiosity"

--- a/src/Curiosity/Parse.hs
+++ b/src/Curiosity/Parse.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE ApplicativeDo #-}
 module Curiosity.Parse
   ( confParser
+  , serverParser
   , defaultConf
+  , defaultServerConf
   ) where
 
 import qualified Commence.InteractiveState.Repl
@@ -9,6 +11,7 @@ import qualified Commence.InteractiveState.Repl
 import qualified Commence.Multilogging         as ML
 import           Control.Monad.Log             as L
 import           Curiosity.Runtime
+import           Curiosity.Server
 import           Data.Default.Class
 import qualified Options.Applicative           as A
 import qualified Servant.Auth.Server           as Srv
@@ -18,7 +21,6 @@ import qualified System.Log.FastLogger         as FL
 --------------------------------------------------------------------------------
 confParser :: A.Parser Conf
 confParser = do
-  _confServer <- serverParser
   _confRepl   <- replParser
   _confDbFile <- dbFileParser
   pure Conf
@@ -32,18 +34,7 @@ confParser = do
 
 defaultConf :: Conf
 defaultConf =
-  let _confServer = ServerConf
-        { _serverPort          = 9000
-        , _serverStaticDir     = "./_site/"
-        , _serverDataDir       = "./data/"
-        , _serverCookie        = Srv.defaultCookieSettings
-                                   { Srv.cookieIsSecure    = Srv.NotSecure
-                                   , Srv.cookieXsrfSetting = Nothing
-                                   , Srv.cookieSameSite    = Srv.SameSiteStrict
-                                   }
-        , _serverMkJwtSettings = Srv.defaultJWTSettings
-        }
-      _confRepl   = Repl.ReplConf "> " False ["exit", "quit"]
+  let _confRepl   = Repl.ReplConf "> " False ["exit", "quit"]
       _confDbFile = Nothing
   in  Conf
         { _confLogging = ML.LoggingConf [FL.LogFile flspec 1024]
@@ -51,6 +42,19 @@ defaultConf =
                                         L.levelInfo
         , ..
         }
+
+defaultServerConf :: ServerConf
+defaultServerConf = ServerConf
+  { _serverPort          = 9000
+  , _serverStaticDir     = "./_site/"
+  , _serverDataDir       = "./data/"
+  , _serverCookie        = Srv.defaultCookieSettings
+                             { Srv.cookieIsSecure    = Srv.NotSecure
+                             , Srv.cookieXsrfSetting = Nothing
+                             , Srv.cookieSameSite    = Srv.SameSiteStrict
+                             }
+  , _serverMkJwtSettings = Srv.defaultJWTSettings
+  }
 
 flspec = FL.FileLogSpec "/tmp/curiosity.log" 5000 0
 

--- a/src/Curiosity/Process.hs
+++ b/src/Curiosity/Process.hs
@@ -35,8 +35,8 @@ startRepl rt@Rt.Runtime {..} = runSafeMapErrs $ do
     -- TypeApplications not needed below, but left for clarity.
     IS.execAnyInputOnState @(Data.StmDb Rt.Runtime) @ 'IS.Repl @Rt.AppM
       >=> either displayErr pure
-  runSafeMapErrs = fmap (either Repl.ReplExitOnGeneralException identity)
-    . Rt.runAppMSafe rt
+  runSafeMapErrs =
+    fmap (either Repl.ReplExitOnGeneralException identity) . Rt.runAppMSafe rt
   displayErr (Data.ParseFailed err) =
     pure . IS.ReplOutputStrict . Errs.displayErr $ err
 
@@ -47,7 +47,7 @@ endRepl res = putStrLn @Text $ T.unlines ["REPL process ended: " <> show res]
 --------------------------------------------------------------------------------
 startServer :: Rt.Runtime -> IO Errs.RuntimeErr
 startServer runtime@Rt.Runtime {..} = do
-  let Rt.ServerConf port _ _ = runtime ^. Rt.rConf . Rt.confServer
+  let Rt.ServerConf port _ _ _ _ = runtime ^. Rt.rConf . Rt.confServer
   startupLogInfo _rLoggers $ "Starting up server on port " <> show port <> "..."
   try @SomeException (Srv.run runtime) >>= pure . either
     Errs.RuntimeException

--- a/src/Curiosity/Process.hs
+++ b/src/Curiosity/Process.hs
@@ -29,14 +29,14 @@ startRepl rt@Rt.Runtime {..} = runSafeMapErrs $ do
   startupLogInfo _rLoggers "Starting up REPL..."
   Repl.startReadEvalPrintLoop (rt ^. Rt.rConf . Rt.confRepl)
                               handleReplInputs
-                              (Rt.runExeAppMSafe rt)
+                              (Rt.runAppMSafe rt)
  where
   handleReplInputs =
     -- TypeApplications not needed below, but left for clarity.
-    IS.execAnyInputOnState @(Data.StmDb Rt.Runtime) @ 'IS.Repl @Rt.ExeAppM
+    IS.execAnyInputOnState @(Data.StmDb Rt.Runtime) @ 'IS.Repl @Rt.AppM
       >=> either displayErr pure
   runSafeMapErrs = fmap (either Repl.ReplExitOnGeneralException identity)
-    . Rt.runExeAppMSafe rt
+    . Rt.runAppMSafe rt
   displayErr (Data.ParseFailed err) =
     pure . IS.ReplOutputStrict . Errs.displayErr $ err
 

--- a/src/Curiosity/Process.hs
+++ b/src/Curiosity/Process.hs
@@ -45,11 +45,11 @@ endRepl res = putStrLn @Text $ T.unlines ["REPL process ended: " <> show res]
 
 
 --------------------------------------------------------------------------------
-startServer :: Rt.Runtime -> IO Errs.RuntimeErr
-startServer runtime@Rt.Runtime {..} = do
-  let Rt.ServerConf port _ _ _ _ = runtime ^. Rt.rConf . Rt.confServer
+startServer :: Srv.ServerConf -> Rt.Runtime -> IO Errs.RuntimeErr
+startServer conf runtime@Rt.Runtime {..} = do
+  let Srv.ServerConf port _ _ _ _ = conf
   startupLogInfo _rLoggers $ "Starting up server on port " <> show port <> "..."
-  try @SomeException (Srv.run runtime) >>= pure . either
+  try @SomeException (Srv.run conf runtime) >>= pure . either
     Errs.RuntimeException
     (const $ Errs.RuntimeException UserInterrupt)
   -- FIXME: improve this, incorrect error reporting here.

--- a/src/Curiosity/Process.hs
+++ b/src/Curiosity/Process.hs
@@ -15,7 +15,6 @@ import qualified Commence.InteractiveState.Repl
                                                as Repl
 import qualified Commence.Multilogging         as ML
 import qualified Commence.Runtime.Errors       as Errs
-import           Control.Lens
 import qualified Control.Monad.Log             as L
 import qualified Curiosity.Data                as Data
 import qualified Curiosity.Runtime             as Rt
@@ -24,10 +23,10 @@ import qualified Data.Text                     as T
 
 
 --------------------------------------------------------------------------------
-startRepl :: Rt.Runtime -> IO Repl.ReplLoopResult
-startRepl rt@Rt.Runtime {..} = runSafeMapErrs $ do
+startRepl :: Repl.ReplConf -> Rt.Runtime -> IO Repl.ReplLoopResult
+startRepl conf rt@Rt.Runtime {..} = runSafeMapErrs $ do
   startupLogInfo _rLoggers "Starting up REPL..."
-  Repl.startReadEvalPrintLoop (rt ^. Rt.rConf . Rt.confRepl)
+  Repl.startReadEvalPrintLoop conf
                               handleReplInputs
                               (Rt.runAppMSafe rt)
  where

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -4,7 +4,6 @@
 module Curiosity.Runtime
   ( Conf(..)
   , IOErr(..)
-  , confRepl
   , confLogging
   , confDbFile
   , Runtime(..)
@@ -23,8 +22,6 @@ module Curiosity.Runtime
   , appMHandlerNatTrans
   ) where
 
-import qualified Commence.InteractiveState.Repl
-                                               as Repl
 import qualified Commence.Multilogging         as ML
 import qualified Commence.Runtime.Errors       as Errs
 import qualified Commence.Runtime.Storage      as S
@@ -49,8 +46,7 @@ import           System.Directory               ( doesFileExist )
 --------------------------------------------------------------------------------
 -- | Application config.
 data Conf = Conf
-  { _confRepl    :: Repl.ReplConf -- ^ Config. for the REPL.
-  , _confLogging :: ML.LoggingConf -- ^ Logging configuration.
+  { _confLogging :: ML.LoggingConf -- ^ Logging configuration.
   , _confDbFile  :: Maybe FilePath
     -- ^ An optional filepath to write the DB to, or read it from. If the file
     -- is absent, it will be created on server exit, with the latest DB state

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -5,10 +5,8 @@ module Curiosity.Runtime
   ( Conf(..)
   , IOErr(..)
   , confRepl
-  , confServer
   , confLogging
   , confDbFile
-  , ServerConf(..)
   , Runtime(..)
   , rConf
   , rDb
@@ -37,7 +35,6 @@ import "exceptions" Control.Monad.Catch         ( MonadCatch
                                                 , MonadMask
                                                 , MonadThrow
                                                 )
-import qualified Crypto.JOSE.JWK               as JWK
 import qualified Curiosity.Data                as Data
 import qualified Curiosity.Data.Todo           as Todo
 import qualified Curiosity.Data.User           as User
@@ -46,26 +43,13 @@ import qualified Data.List                     as L
 import qualified Data.Text                     as T
 import qualified Network.HTTP.Types            as HTTP
 import qualified Servant
-import qualified Servant.Auth.Server           as SAuth
 import           System.Directory               ( doesFileExist )
 
 
 --------------------------------------------------------------------------------
--- | HTTP server config.
-data ServerConf = ServerConf
-  { _serverPort          :: Int
-  , _serverStaticDir     :: FilePath
-  , _serverDataDir       :: FilePath
-  , _serverCookie        :: SAuth.CookieSettings
-    -- ^ Settings for setting cookies as a server (for authentication etc.).
-  , _serverMkJwtSettings :: JWK.JWK -> SAuth.JWTSettings
-    -- ^ JWK settings to use, depending on the key employed.
-  }
-
 -- | Application config.
 data Conf = Conf
   { _confRepl    :: Repl.ReplConf -- ^ Config. for the REPL.
-  , _confServer  :: ServerConf -- ^ Config. for the HTTP server.
   , _confLogging :: ML.LoggingConf -- ^ Logging configuration.
   , _confDbFile  :: Maybe FilePath
     -- ^ An optional filepath to write the DB to, or read it from. If the file

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -149,7 +149,7 @@ run runtime@Rt.Runtime {..} = liftIO $ Warp.run port waiApp
  where
   Rt.ServerConf port root dataDir = runtime ^. Rt.rConf . Rt.confServer
   waiApp =
-    serve @Rt.ExeAppM (Rt.exampleAppMHandlerNatTrans runtime) ctx root dataDir
+    serve @Rt.AppM (Rt.appMHandlerNatTrans runtime) ctx root dataDir
   ctx =
     _rConf
       ^.        Rt.confCookie


### PR DESCRIPTION
- This renames `ExeAppM` to `AppM`
- This regroups related code in `Runtime.hs` together (without changing the code)
- This separates the server config and the REPL config out of the `Runtime` data type