### PR TITLE
DBStorage illustration

### DIFF
--- a/curls/login-no-username.sh
+++ b/curls/login-no-username.sh
@@ -7,10 +7,9 @@ BASE_URL="http://127.0.0.1:9000"
 # Try to login with no corresponding username.
 # TODO With an existing user but wrong password.
 
-# TODO
-# This should return a proper HTML page.
-# This should return 403 Forbidden ?
+# This should return 401 Unauthorized.
+# TODO This should return a proper HTML page.
 
 rm -f cookies.txt
-curl --cookie-jar cookies.txt -d username="alice" -d password="secret" "${BASE_URL}/a/login"
+curl -v --cookie-jar cookies.txt -d username="alice" -d password="secret" "${BASE_URL}/a/login"
 echo

--- a/curls/login-no-username.sh
+++ b/curls/login-no-username.sh
@@ -11,6 +11,6 @@ BASE_URL="http://127.0.0.1:9000"
 # This should return a proper HTML page.
 # This should return 403 Forbidden ?
 
-rm cookies.txt
+rm -f cookies.txt
 curl --cookie-jar cookies.txt -d username="alice" -d password="secret" "${BASE_URL}/a/login"
 echo

--- a/curls/signup.sh
+++ b/curls/signup.sh
@@ -6,10 +6,7 @@ BASE_URL="http://127.0.0.1:9000"
 
 # Create a new user.
 
-# TODO If the username already exists, this returns a UserProfile {..}.
-# TODO This should not return a 200 Ok.
-
-curl --cookie-jar cookies.txt -d username="alice" -d password="a" -d email-addr="alice@example.com" "${BASE_URL}/a/signup"
+curl -v --cookie-jar cookies.txt -d username="alice" -d password="a" -d email-addr="alice@example.com" "${BASE_URL}/a/signup"
 echo
 
 # Get logged in.

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -172,7 +172,7 @@ instance Storage.DBStorageOps UserProfile where
   data DBSelect UserProfile =
     -- | Attempt a user-login using the more ambiguous but more friendly
     -- `UserName` and `Password.
-    UserLoginWithUserName UserName Password
+    UserLoginWithUserName Credentials
     -- | Select a user with a known `UserId`.
     | SelectUserById UserId
     -- | Select a user with `UserName`.
@@ -208,8 +208,10 @@ dbSelectParser = P.tryAlts
   userLoginWithUserName =
     P.withTrailSpaces "UserLoginWithUserName"
       *> (   UserLoginWithUserName
-         <$> (userNameParser <* P.space)
-         <*> userPasswordParser
+         <$> (   Credentials
+             <$> (userNameParser <* P.space)
+             <*> userPasswordParser
+             )
          )
   selectUserById =
     P.withTrailSpaces "SelectUserById" *> userIdParser <&> SelectUserById

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -249,25 +249,25 @@ userCredsParser =
 
 data UserErr = UserExists Text
              | UserNotFound Text
-             | IncorrectPassword Text
+             | IncorrectUsernameOrPassword
              deriving Show
 
 instance Errs.IsRuntimeErr UserErr where
   errCode = errCode' . \case
-    UserExists{}        -> "USER_EXISTS"
-    UserNotFound{}      -> "USER_NOT_FOUND"
-    IncorrectPassword{} -> "INCORRECT_PASSWORD"
-    where errCode' = mappend "ERR.USER."
+    UserExists{}                -> "USER_EXISTS"
+    UserNotFound{}              -> "USER_NOT_FOUND"
+    IncorrectUsernameOrPassword -> "INCORRECT_CREDENTIALS"
+    where errCode' = mappend "ERR.USER"
 
   httpStatus = \case
-    UserExists{}        -> HTTP.conflict409
-    UserNotFound{}      -> HTTP.notFound404
-    IncorrectPassword{} -> HTTP.unauthorized401
+    UserExists{}                -> HTTP.conflict409
+    UserNotFound{}              -> HTTP.notFound404
+    IncorrectUsernameOrPassword -> HTTP.unauthorized401
 
   userMessage = Just . \case
-    UserExists        msg -> msg
-    UserNotFound      msg -> msg
-    IncorrectPassword msg -> msg
+    UserExists   msg            -> msg
+    UserNotFound msg            -> msg
+    IncorrectUsernameOrPassword -> "Incorrect username or password."
 
 makeLenses ''Credentials
 makeLenses ''UserProfile'

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -164,7 +164,7 @@ instance Storage.DBIdentity UserProfile where
 instance Storage.DBStorageOps UserProfile where
   data DBUpdate UserProfile =
     UserCreate UserProfile
-    | UserCreateGeneratingUserId UserName Password UserEmailAddr
+    | UserCreateGeneratingUserId Signup
     | UserDelete UserId
     | UserPasswordUpdate UserId Password
     deriving (Show, Eq)
@@ -188,9 +188,11 @@ dbUpdateParser = P.tryAlts
   userCreateGeneratingUserId =
     P.withTrailSpaces "UserCreateGeneratingUserId"
       *> (   UserCreateGeneratingUserId
-         <$> userNameParser
-         <*> userPasswordParser
-         <*> userEmailAddrParser
+         <$> (   Signup
+             <$> userNameParser
+             <*> userPasswordParser
+             <*> userEmailAddrParser
+             )
          )
   userDelete = P.withTrailSpaces "UserDelete" *> userIdParser <&> UserDelete
   userUpdate =
@@ -249,25 +251,25 @@ userProfileParser =
 userCredsParser =
   Credentials <$> (userNameParser <* P.space) <*> userPasswordParser
 
-data UserErr = UserExists Text
+data UserErr = UserExists
              | UserNotFound Text
              | IncorrectUsernameOrPassword
              deriving Show
 
 instance Errs.IsRuntimeErr UserErr where
   errCode = errCode' . \case
-    UserExists{}                -> "USER_EXISTS"
+    UserExists                  -> "USER_EXISTS"
     UserNotFound{}              -> "USER_NOT_FOUND"
     IncorrectUsernameOrPassword -> "INCORRECT_CREDENTIALS"
     where errCode' = mappend "ERR.USER"
 
   httpStatus = \case
-    UserExists{}                -> HTTP.conflict409
+    UserExists                  -> HTTP.conflict409
     UserNotFound{}              -> HTTP.notFound404
     IncorrectUsernameOrPassword -> HTTP.unauthorized401
 
   userMessage = Just . \case
-    UserExists   msg            -> msg
+    UserExists                  -> "User exists (same username or ID)"
     UserNotFound msg            -> msg
     IncorrectUsernameOrPassword -> "Incorrect username or password."
 

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -338,7 +338,7 @@ instance S.DBStorage AppM User.UserProfile where
   dbSelect = \case
 
     User.UserLoginWithUserName input -> do
-      mprofile <- withRuntimeAtomically $ \rt -> checkCredentials rt input
+      mprofile <- withRuntimeAtomically checkCredentials input
       case mprofile of
         Right profile -> pure [profile]
         Left  err     -> Errs.throwError' err
@@ -347,8 +347,7 @@ instance S.DBStorage AppM User.UserProfile where
         ((== id) . S.dbId)
 
     User.SelectUserByUserName username -> do
-      mprofile <- withRuntimeAtomically
-        $ \rt -> selectUserByUsername rt username
+      mprofile <- withRuntimeAtomically selectUserByUsername username
       case mprofile of
         Just profile -> pure [profile]
         Nothing      -> pure []
@@ -391,7 +390,7 @@ onUserNameExists userName onNone onExisting =
 userNotFound =
   Errs.throwError' . User.UserNotFound . mappend "User not found: "
 
-withRuntimeAtomically f = ask >>= \rt -> liftIO . STM.atomically $ f rt
+withRuntimeAtomically f a = ask >>= \rt -> liftIO . STM.atomically $ f rt a
 
 withUserStorage f = asks (Data._dbUserProfiles . _rDb) >>= f
 

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -22,6 +22,9 @@ module Curiosity.Runtime
   , saveDb
   , saveDbAs
   , runAppMSafe
+  , withRuntimeAtomically
+  -- * High-level operations
+  , checkCredentials
   -- * Servant compat
   , appMHandlerNatTrans
   ) where

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -511,7 +511,7 @@ newtype IOErr = FileDoesntExistErr FilePath
   deriving Show
 
 instance Errs.IsRuntimeErr IOErr where
-  errCode FileDoesntExistErr{} = "ERR.FILE_DOENST_EXIST"
+  errCode FileDoesntExistErr{} = "ERR.FILE_NOT_FOUND"
   httpStatus FileDoesntExistErr{} = HTTP.notFound404
   userMessage = Just . \case
     FileDoesntExistErr fpath -> T.unwords ["File doesn't exist:", T.pack fpath]

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -375,7 +375,7 @@ checkCredentials runtime username passInput = do
   mprofile <- selectUserByUsername runtime username
   case mprofile of
     Just profile | checkPassword profile passInput -> pure $ Right profile
-    _ -> pure . Left . User.UserNotFound $ "Incorrect username or password."
+    _ -> pure $ Left User.IncorrectUsernameOrPassword
 
 checkPassword profile (User.Password passInput) = storedPass =:= passInput
  where

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -24,6 +24,7 @@ module Curiosity.Runtime
   , runAppMSafe
   , withRuntimeAtomically
   -- * High-level operations
+  , createUser
   , checkCredentials
   -- * Servant compat
   , appMHandlerNatTrans
@@ -221,7 +222,7 @@ appMHandlerNatTrans rt appM =
       unwrapReaderT          = (`runReaderT` rt) . runAppM $ appM
       -- Map our errors to `ServantError`
       runtimeErrToServantErr = withExceptT Errs.asServantError
-  in
+  in 
       -- Re-wrap as servant `Handler`
       Servant.Handler $ runtimeErrToServantErr unwrapReaderT
 
@@ -284,36 +285,18 @@ interpret = loop []
 instance S.DBStorage AppM User.UserProfile where
   dbUpdate = \case
 
-    User.UserCreate newProfile ->
-      ML.localEnv (<> "Storage" <> "UserProfile" <> "UserCreate") $ do
-        ML.info
-          $  "Creating new user: "
-          <> (show . User._userCredsName $ User._userProfileCreds newProfile)
-          <> "..."
-        onUserIdExists newProfileId createNew existsErr
-     where
-      newProfileId = S.dbId newProfile
-      createNew    = onUserNameExists
-        (newProfile ^. User.userProfileCreds . User.userCredsName)
-        (do
-          result <- withUserStorage
-            $ modifyUserProfiles newProfileId (newProfile :)
-          ML.info "User created."
-          pure result
-        )
-        existsErr
-      existsErr err = do
-        ML.info "User already exists."
-        Errs.throwError' . User.UserExists $ show err
+    User.UserCreate input -> do
+      muid <- withRuntimeAtomically createUserFull input
+      case muid of
+        Right uid -> pure [uid]
+        Left  err -> Errs.throwError' err
 
-    User.UserCreateGeneratingUserId username password email -> do
-      -- generate a new and random user-id
-      newId <- User.genRandomUserId 10
-      let newProfile = User.UserProfile newId
-                                        (User.Credentials username password)
-                                        "TODO"
-                                        email
-      S.dbUpdate $ User.UserCreate newProfile
+    User.UserCreateGeneratingUserId input -> do
+      newId <- User.genRandomUserId 10 -- TODO Generate deterministically within STM.
+      muid  <- withRuntimeAtomically createUser (newId, input)
+      case muid of
+        Right uid -> pure [uid]
+        Left  err -> Errs.throwError' err
 
     User.UserDelete id -> onUserIdExists id (userNotFound $ show id) deleteUser
      where
@@ -331,10 +314,6 @@ instance S.DBStorage AppM User.UserProfile where
       replaceOlder users =
         [ if S.dbId u == id then setPassword u else u | u <- users ]
 
-   where
-    modifyUserProfiles id f userProfiles =
-      liftIO $ STM.atomically (STM.modifyTVar userProfiles f) $> [id]
-
   dbSelect = \case
 
     User.UserLoginWithUserName input -> do
@@ -342,6 +321,7 @@ instance S.DBStorage AppM User.UserProfile where
       case mprofile of
         Right profile -> pure [profile]
         Left  err     -> Errs.throwError' err
+
     User.SelectUserById id ->
       withUserStorage $ liftIO . STM.readTVarIO >=> pure . filter
         ((== id) . S.dbId)
@@ -351,6 +331,17 @@ instance S.DBStorage AppM User.UserProfile where
       case mprofile of
         Just profile -> pure [profile]
         Nothing      -> pure []
+
+
+modifyUserProfiles id f userProfiles =
+  liftIO $ STM.atomically (STM.modifyTVar userProfiles f) $> [id]
+
+selectUserById runtime id = do
+  let usersTVar = Data._dbUserProfiles $ _rDb runtime
+  users' <- STM.readTVar usersTVar
+  case filter ((== id) . S.dbId) users' of
+    [profile] -> pure $ Just profile
+    _         -> pure Nothing
 
 selectUserByUsername
   :: Runtime -> User.UserName -> STM (Maybe User.UserProfile)
@@ -363,6 +354,40 @@ selectUserByUsername runtime username = do
     of
       [u] -> pure $ Just u
       _   -> pure Nothing
+
+createUser
+  :: Runtime
+  -> (User.UserId, User.Signup)
+  -> STM (Either User.UserErr User.UserId)
+createUser runtime (newId, User.Signup {..}) = do
+  let newProfile =
+        User.UserProfile newId (User.Credentials username password) "TODO" email
+  createUserFull runtime newProfile
+
+createUserFull
+  :: Runtime -> User.UserProfile -> STM (Either User.UserErr User.UserId)
+createUserFull runtime newProfile = do
+  mprofile <- selectUserById runtime newProfileId
+  case mprofile of
+    Just profile -> existsErr
+    Nothing      -> createNew
+ where
+  newProfileId = S.dbId newProfile
+  createNew    = do
+    mprofile <- selectUserByUsername
+      runtime
+      (newProfile ^. User.userProfileCreds . User.userCredsName)
+    case mprofile of
+      Just profile -> existsErr
+      Nothing      -> do
+        modifyUsers runtime (newProfile :)
+        pure $ Right newProfileId
+  existsErr = pure . Left $ User.UserExists
+
+modifyUsers :: Runtime -> ([User.UserProfile] -> [User.UserProfile]) -> STM ()
+modifyUsers runtime f = do
+  let usersTVar = Data._dbUserProfiles $ _rDb runtime
+  STM.modifyTVar usersTVar f
 
 checkCredentials
   :: Runtime -> User.Credentials -> STM (Either User.UserErr User.UserProfile)
@@ -382,10 +407,6 @@ checkPassword profile (User.Password passInput) = storedPass =:= passInput
 
 onUserIdExists id onNone onExisting =
   S.dbSelect (User.SelectUserById id) <&> headMay >>= maybe onNone onExisting
-onUserNameExists userName onNone onExisting =
-  S.dbSelect (User.SelectUserByUserName userName)
-    <&> headMay
-    >>= maybe onNone onExisting
 
 userNotFound =
   Errs.throwError' . User.UserNotFound . mappend "User not found: "

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -287,12 +287,14 @@ handleLogin
   -> SAuth.JWTSettings
   -> User.Credentials
   -> m (Headers H.PostAuthHeaders NoContent)
-handleLogin conf jwtSettings User.Credentials {..} =
+handleLogin conf jwtSettings input =
   env
     $   do
-          ML.info $ "Logging in user: " <> show _userCredsName <> "..."
-          Rt.withRuntimeAtomically
-            $ \rt -> Rt.checkCredentials rt _userCredsName _userCredsPassword
+          ML.info
+            $  "Logging in user: "
+            <> show (User._userCredsName input)
+            <> "..."
+          Rt.withRuntimeAtomically $ \rt -> Rt.checkCredentials rt input
     >>= \case
           Right u -> do
             ML.info "Found user, applying authentication cookies..."


### PR DESCRIPTION
I tried to have our main operations run in the `STM` monad, so that we can compose them together, and then wrap in a single call to `atomically`. Idealy, one HTTP request, or one REPL or CLI command should result in a single call to `atomically`.

Furthermore, I tried to have proper return types, e.g. `Maybe`, `Either`, ... instead of something imprecise like `[UserProfile]` and using `throw` for error handling.

Those changes are then used in some Servant handlers. This solves a problem where some error cases were `throwned` instead of being represented by `Left` or `Nothing`.

On the other hand, this by-passes the `DBStorage` class, which begs the question: how to make it more useful, or do we simply discard it ?