### PR TITLE
Run a script and explore the intermediate steps

### DIFF
--- a/bin/cty-repl-2.hs
+++ b/bin/cty-repl-2.hs
@@ -53,7 +53,7 @@ repl runtime = HL.runInputT HL.defaultSettings loop
             A.execParserPure A.defaultPrefs Command.parserInfo $ words input
       case result of
         A.Success command ->
-          Command.handleCommand runtime output' command >> pure ()
+          Rt.handleCommand runtime output' command >> pure ()
         A.Failure           err -> output' $ show err
         A.CompletionInvoked _   -> output' "Shouldn't happen"
 

--- a/bin/cty-run.hs
+++ b/bin/cty-run.hs
@@ -50,7 +50,7 @@ interpret runtime path = do
             $ map T.unpack input
       case result of
         A.Success command -> do
-          Command.handleCommand runtime output' command
+          Rt.handleCommand runtime output' command
           loop rest
         A.Failure err -> do
           output' $ show err

--- a/bin/cty.hs
+++ b/bin/cty.hs
@@ -8,7 +8,6 @@ module Main
 
 import qualified Curiosity.Command             as Command
 import qualified Curiosity.Data                as Data
-import qualified Curiosity.Parse               as P
 import qualified Curiosity.Runtime             as Rt
 import qualified Data.ByteString.Char8         as B
 import qualified Data.ByteString.Lazy          as BS
@@ -51,7 +50,7 @@ run (Command.CommandWithTarget command target) = do
   case target of
     Command.StateFileTarget path -> do
       runtime@Rt.Runtime {..} <-
-        Rt.boot P.defaultConf { Rt._confDbFile = Just path }
+        Rt.boot Rt.defaultConf { Rt._confDbFile = Just path }
           >>= either throwIO pure
 
       exitCode <- Command.handleCommand runtime putStrLn command

--- a/bin/cty.hs
+++ b/bin/cty.hs
@@ -53,7 +53,7 @@ run (Command.CommandWithTarget command target) = do
         Rt.boot Rt.defaultConf { Rt._confDbFile = Just path }
           >>= either throwIO pure
 
-      exitCode <- Command.handleCommand runtime putStrLn command
+      exitCode <- Rt.handleCommand runtime putStrLn command
 
       Rt.powerdown runtime
       -- TODO shutdown runtime, loggers, save state, ...

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -6,15 +6,10 @@ module Curiosity.Command
   , CommandTarget(..)
   , parserInfo
   , parserInfoWithTarget
-  , handleCommand
   ) where
 
-import qualified Commence.InteractiveState.Class
-                                               as IS
 import qualified Commence.Runtime.Storage      as S
-import qualified Curiosity.Data                as Data
 import qualified Curiosity.Data.User           as U
-import qualified Curiosity.Runtime             as Rt
 import qualified Options.Applicative           as A
 
 
@@ -154,32 +149,3 @@ parserGetUser = SelectUser . U.SelectUserById . U.UserId <$> A.argument
 parserShowId :: A.Parser Command
 parserShowId =
   ShowId <$> A.argument A.str (A.metavar "ID" <> A.help "An object ID")
-
-
---------------------------------------------------------------------------------
--- | Handle a single command. The @display@ function and the return type
--- provide some flexibility, so this function can be used in both `cty` and
--- `cty-repl-2`.
-handleCommand
-  :: MonadIO m => Rt.Runtime -> (Text -> m ()) -> Command -> m ExitCode
-handleCommand runtime display command = do
-  case command of
-    State -> do
-      output <-
-        Rt.runAppMSafe runtime . IS.execVisualisation $ Data.VisualiseFullStmDb
-      display $ show output
-      return ExitSuccess
-    SelectUser select -> do
-      output <-
-        Rt.runAppMSafe runtime . IS.execVisualisation $ Data.VisualiseUser
-          select
-      display $ show output
-      return ExitSuccess
-    UpdateUser update -> do
-      output <- Rt.runAppMSafe runtime . IS.execModification $ Data.ModifyUser
-        update
-      display $ show output
-      return ExitSuccess
-    _ -> do
-      display $ "Unhandled command " <> show command
-      return $ ExitFailure 1

--- a/src/Curiosity/Parse.hs
+++ b/src/Curiosity/Parse.hs
@@ -7,14 +7,11 @@ module Curiosity.Parse
 
 import qualified Commence.InteractiveState.Repl
                                                as Repl
-import qualified Commence.Multilogging         as ML
-import           Control.Monad.Log             as L
 import qualified Curiosity.Runtime             as Rt
 import qualified Curiosity.Server              as Srv
 import           Data.Default.Class
 import qualified Options.Applicative           as A
 import qualified Servant.Auth.Server           as SAuth
-import qualified System.Log.FastLogger         as FL
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -108,13 +108,20 @@ boot
   => Conf -- ^ configuration to boot with.
   -> m (Either Errs.RuntimeErr Runtime)
 boot _rConf = do
-
   _rLoggers <- ML.makeDefaultLoggersWithConf $ _rConf ^. confLogging
-
   eDb       <- instantiateDb _rConf
   pure $ case eDb of
     Left  err  -> Left err
     Right _rDb -> Right Runtime { .. }
+
+-- | Create a runtime from a given state.
+boot' :: MonadIO m => Data.HaskDb Runtime -> FilePath -> m Runtime
+boot' db logsPath = do
+  let loggingConf = mkLoggingConf logsPath
+      _rConf      = defaultConf { _confLogging = loggingConf }
+  _rDb      <- Data.instantiateStmDb db
+  _rLoggers <- ML.makeDefaultLoggersWithConf loggingConf
+  pure $ Runtime { .. }
 
 -- | Power down the application: attempting to save the DB state in given file, if possible, and reporting errors otherwise.
 powerdown :: MonadIO m => Runtime -> m (Maybe Errs.RuntimeErr)


### PR DESCRIPTION
- Currently this PR has only a new `interpret` function.
- The goal is to use that function to:
   - Read a script from the `scenarios/` directory
   - Apply that function to generate intermediate states, one per command (or step) in the script
   - Serve those states read-only, just like the live state. E.g. given a live route `/alice`, a intermediate state route could be `/scenarios/some-file.txt/steps/5/alice`
   - This would allow one to check e.g. for differences with `/scenarios/some-file.txt/steps/8/alice`
   - The exposed route would be the ones that don't rely on a session, and assuming full-access (e.g. `/settings/profile` would't make sense).