### PR TITLE
Display some errors in HTML (instead of plain text)

### DIFF
--- a/bin/cty-repl-2.hs
+++ b/bin/cty-repl-2.hs
@@ -7,7 +7,6 @@ import qualified Curiosity.Command             as Command
 import qualified Curiosity.Parse               as P
 import qualified Curiosity.Process             as P
 import qualified Curiosity.Runtime             as Rt
-import           Data.List                      ( words )
 import qualified Data.Text                     as T
 import qualified Options.Applicative           as A
 import qualified System.Console.Haskeline      as HL
@@ -50,7 +49,10 @@ repl runtime = HL.runInputT HL.defaultSettings loop
     Just "quit" -> pure ()
     Just input  -> do
       let result =
-            A.execParserPure A.defaultPrefs Command.parserInfo $ words input
+            A.execParserPure A.defaultPrefs Command.parserInfo
+              $ map T.unpack
+              $ words
+              $ T.pack input
       case result of
         A.Success command ->
           Rt.handleCommand runtime output' command >> pure ()

--- a/bin/cty-run.hs
+++ b/bin/cty-run.hs
@@ -26,7 +26,7 @@ mainParserInfo =
 
 runWithConf :: Rt.Conf -> IO ExitCode
 runWithConf conf = do
-  runtime@Rt.Runtime {..} <- Rt.boot conf >>= either throwIO pure
+  runtime <- Rt.boot conf >>= either throwIO pure
 
   let handleExceptions = (`catch` P.shutdown runtime . Just)
 

--- a/bin/cty-sock.hs
+++ b/bin/cty-sock.hs
@@ -13,7 +13,7 @@ import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Parse               as P
 import qualified Curiosity.Runtime             as Rt
 import qualified Data.ByteString.Char8         as B
-import           Network.Socket          hiding ( recv )
+import           Network.Socket
 import           Network.Socket.ByteString      ( recv
                                                 , sendAll
                                                 )
@@ -33,7 +33,7 @@ mainParserInfo =
 
 runWithConf conf = do
   putStrLn @Text "Creating runtime..."
-  runtime@Rt.Runtime {..} <- Rt.boot conf >>= either throwIO pure
+  runtime <- Rt.boot conf >>= either throwIO pure
 
   putStrLn @Text "Creating curiosity.sock..."
   sock <- socket AF_UNIX Stream 0

--- a/bin/cty-sock.hs
+++ b/bin/cty-sock.hs
@@ -66,9 +66,9 @@ repl runtime conn = do
     _              -> do
       let result = A.execParserPure A.defaultPrefs Command.parserInfo command
       case result of
-        A.Success           x   -> print x >> sendAll conn (show x <> "\n")
-        A.Failure           err -> print err
-        A.CompletionInvoked _   -> print @IO @Text "Shouldn't happen"
+        A.Success x -> print x >> sendAll conn (B.pack $ show x <> "\n")
+        A.Failure err -> print err
+        A.CompletionInvoked _ -> print @IO @Text "Shouldn't happen"
 
       output <- Rt.runAppMSafe runtime $ IS.execModification
         (Data.ModifyUser

--- a/curls/login-no-username.sh
+++ b/curls/login-no-username.sh
@@ -8,7 +8,7 @@ BASE_URL="http://127.0.0.1:9000"
 # TODO With an existing user but wrong password.
 
 # This should return 401 Unauthorized.
-# TODO This should return a proper HTML page.
+# This should return a proper HTML page.
 
 rm -f cookies.txt
 curl -v --cookie-jar cookies.txt -d username="alice" -d password="secret" "${BASE_URL}/a/login"

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -2,13 +2,13 @@
     "brittany": {
         "branch": "master",
         "repo": "https://github.com/lspitzner/brittany",
-        "rev": "434f9f8e49b847ef3e648672c5564b6dd0d3be67",
+        "rev": "0aa04af4eba499b81fdfb401d98414e7731583cc",
         "type": "git"
     },
     "commence": {
         "branch": "main",
         "repo": "git@github.com:hypered/commence.git",
-        "rev": "543a346cc220eab385edb31645862e2e945c2f92",
+        "rev": "9318349ab25edcc1280c797056e0453cccc5b488",
         "type": "git"
     },
     "design-hs": {
@@ -30,25 +30,27 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
+        "branch": "master",
         "description": "Easy dependency management for Nix projects",
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "ba57d5a29b4e0f2085917010380ef3ddc3cf380f",
-        "sha256": "1kpsvc53x821cmjg1khvp1nz7906gczq8mp83664cr15h94sh8i4",
+        "rev": "82e5cd1ad3c387863f0545d7591512e76ab0fc41",
+        "sha256": "090l219mzc0gi33i3psgph6s2pwsc8qy4lyrqjdj4qzkvmaj65a7",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/ba57d5a29b4e0f2085917010380ef3ddc3cf380f.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/82e5cd1ad3c387863f0545d7591512e76ab0fc41.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-20.03",
+        "branch": "nixos-22.05",
+        "description": "Nix Packages collection",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
-        "repo": "nixpkgs-channels",
-        "rev": "4b6bfecc0bd",
-        "sha256": "0wi8641v4345jcqk7myq3dknczps1gbsf48q314wavl5kga8r67f",
+        "repo": "nixpkgs",
+        "rev": "f0fa012b649a47e408291e96a15672a4fe925d65",
+        "sha256": "1396yvf3ayhdyyx6wsyivpj5afbs119pqsqv6wxjx1liwr8h74w0",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/4b6bfecc0bd.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f0fa012b649a47e408291e96a15672a4fe925d65.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,7 +14,7 @@
     "design-hs": {
         "branch": "main",
         "repo": "git@github.com:hypered/smart-design-hs.git",
-        "rev": "d6b7a4d58fd55e79555845b97cfe1c2d6e51b53d",
+        "rev": "e689e8492c1d385587550cd6decc3fde83170190",
         "type": "git"
     },
     "gitignore": {

--- a/src/Curiosity/Html/Errors.hs
+++ b/src/Curiosity/Html/Errors.hs
@@ -4,6 +4,7 @@ Description: Error pages.
 -}
 module Curiosity.Html.Errors
   ( NotFoundPage(..)
+  , ErrorPage(..)
   ) where
 
 import qualified Smart.Html.Dsl                as Dsl
@@ -18,3 +19,11 @@ data NotFoundPage = NotFoundPage
 instance H.ToMarkup NotFoundPage where
   toMarkup NotFoundPage = do
     Render.renderCanvas $ Dsl.SingletonCanvas Errors.NotFound
+
+
+--------------------------------------------------------------------------------
+data ErrorPage = ErrorPage Int Text Text
+
+instance H.ToMarkup ErrorPage where
+  toMarkup (ErrorPage code title subtitle) = do
+    Render.renderCanvas . Dsl.SingletonCanvas $ Errors.Error code title subtitle

--- a/src/Curiosity/Process.hs
+++ b/src/Curiosity/Process.hs
@@ -26,14 +26,9 @@ import qualified Data.Text                     as T
 startRepl :: Repl.ReplConf -> Rt.Runtime -> IO Repl.ReplLoopResult
 startRepl conf rt@Rt.Runtime {..} = runSafeMapErrs $ do
   startupLogInfo _rLoggers "Starting up REPL..."
-  Repl.startReadEvalPrintLoop conf
-                              handleReplInputs
-                              (Rt.runAppMSafe rt)
+  Repl.startReadEvalPrintLoop conf handleReplInputs (Rt.runAppMSafe rt)
  where
-  handleReplInputs =
-    -- TypeApplications not needed below, but left for clarity.
-    IS.execAnyInputOnState @(Data.StmDb Rt.Runtime) @ 'IS.Repl @Rt.AppM
-      >=> either displayErr pure
+  handleReplInputs = IS.execAnyInputOnState >=> either displayErr pure
   runSafeMapErrs =
     fmap (either Repl.ReplExitOnGeneralException identity) . Rt.runAppMSafe rt
   displayErr (Data.ParseFailed err) =

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -102,12 +102,12 @@ runAppMSafe
   => Runtime
   -> AppM a
   -> m (Either Errs.RuntimeErr a)
-runAppMSafe rt (AppM op') =
+runAppMSafe runtime AppM {..} =
   liftIO
     . fmap (join . first Errs.RuntimeException)
     . try @SomeException
     . runExceptT
-    $ runReaderT op' rt
+    $ runReaderT runAppM runtime
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -46,6 +46,7 @@ import           Data.Aeson                     ( FromJSON
                                                 )
 import qualified Data.ByteString.Lazy          as BS
 import qualified Data.Text                     as T
+import           Prelude                 hiding ( Handler )
 import qualified Network.HTTP.Types            as HTTP
 import qualified Network.Wai                   as Wai
 import qualified Network.Wai.Handler.Warp      as Warp
@@ -498,14 +499,8 @@ serveData path = serveDirectoryWith settings
 serveErrors :: ServerC m => m Text
 serveErrors = Errs.throwError' $ ServerErr "Intentional 500."
 
--- TODO This seems present in newer version of Servant.
--- We're on nixos-20.03. When updating sources.json to nixos-20.09 or 22.05,
--- monal-log is marked as broken. Maybe we can use monad-logger instead.
--- There is also monad-logger-extra from Obsidian Systems than can log to
--- multiple destinations.
---
--- errorFormatters :: Server.ErrorFormatters
--- errorFormatters = defaultErrorFormatters
+errorFormatters :: Server.ErrorFormatters
+errorFormatters = defaultErrorFormatters
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -11,9 +11,8 @@ Description: Server root module, split up into public and private sub-modules.
 
 -}
 module Curiosity.Server
-  (
+  ( App
     -- * Top level server types.
-    App
   , ServerConf(..)
   , serverT
   , serve
@@ -45,11 +44,11 @@ import           Data.Aeson                     ( FromJSON
                                                 , eitherDecode
                                                 )
 import qualified Data.ByteString.Lazy          as BS
-import qualified Data.Text                     as T
-import           Prelude                 hiding ( Handler )
+import qualified Data.Text.Lazy                as LT
 import qualified Network.HTTP.Types            as HTTP
 import qualified Network.Wai                   as Wai
 import qualified Network.Wai.Handler.Warp      as Warp
+import           Prelude                 hiding ( Handler )
 import           Servant                 hiding ( serve )
 import qualified Servant.Auth.Server           as SAuth
 import qualified Servant.HTML.Blaze            as B
@@ -58,6 +57,8 @@ import           Smart.Server.Page              ( PageEither )
 import qualified Smart.Server.Page             as SS.P
 import           System.FilePath                ( (</>) )
 import qualified Text.Blaze.Html5              as H
+import qualified Text.Blaze.Renderer.Text      as R
+                                                ( renderMarkup )
 import           Text.Blaze.Renderer.Utf8       ( renderMarkup )
 import           WaiAppStatic.Storage.Filesystem
                                                 ( defaultWebAppSettings )
@@ -162,7 +163,8 @@ type ServerC m
 
 
 --------------------------------------------------------------------------------
-type ServerSettings = '[SAuth.CookieSettings , SAuth.JWTSettings]
+type ServerSettings
+  = '[SAuth.CookieSettings , SAuth.JWTSettings , ErrorFormatters]
 
 -- | This is the main function of this module. It runs a Warp server, serving
 -- our @App@ API definition.
@@ -172,7 +174,7 @@ run
   => ServerConf
   -> Rt.Runtime -- ^ Runtime to use for running the server.
   -> m ()
-run conf@ServerConf {..} runtime@Rt.Runtime {..} = liftIO $ do
+run conf@ServerConf {..} runtime = liftIO $ do
   jwk <- SAuth.generateKey
   let jwtSettings = _serverMkJwtSettings jwk
   Warp.run _serverPort $ waiApp jwtSettings
@@ -183,7 +185,11 @@ run conf@ServerConf {..} runtime@Rt.Runtime {..} = liftIO $ do
                                jwtS
                                _serverStaticDir
                                _serverDataDir
-  ctx jwtS = _serverCookie Server.:. jwtS Server.:. Server.EmptyContext
+  ctx jwtS =
+    _serverCookie
+      Server.:. jwtS
+      Server.:. errorFormatters
+      Server.:. Server.EmptyContext
 
 -- | Turn our @serverT@ definition into a Wai application, suitable for
 -- Warp.run.
@@ -307,7 +313,6 @@ handleLogin conf jwtSettings input =
     >>= \case
           Right u -> do
             ML.info "Found user, applying authentication cookies..."
-            Rt.Conf {..}  <- asks Rt._rConf
             -- TODO I think jwtSettings could be retrieved with
             -- Servant.Server.getContetEntry. This would avoid threading
             -- jwtSettings evereywhere.
@@ -511,4 +516,8 @@ instance Errs.IsRuntimeErr ServerErr where
   errCode ServerErr{} = "ERR.INTERNAL"
   httpStatus ServerErr{} = HTTP.internalServerError500
   userMessage = Just . \case
-    ServerErr msg -> T.unwords ["Internal server error: ", msg]
+    ServerErr msg ->
+      LT.toStrict . R.renderMarkup . H.toMarkup $ Pages.ErrorPage
+        500
+        "Internal server error"
+        msg

--- a/src/WaiAppStatic/Storage/Filesystem/Extended.hs
+++ b/src/WaiAppStatic/Storage/Filesystem/Extended.hs
@@ -47,9 +47,7 @@ import           WaiAppStatic.Types             ( File(..)
                                                 , toPiece
                                                 )
 
-import           System.IO                      ( IOMode(..)
-                                                , withBinaryFile
-                                                )
+import           System.IO                      ( withBinaryFile )
 
 import           Crypto.Hash                    ( Digest
                                                 , MD5


### PR DESCRIPTION
Hi @asheshambasta,

~Can we bump things in `sources.json` so that we get a newer version of Servant ?~

~I'd like to apply [this documentation](https://docs.servant.dev/en/stable/cookbook/custom-errors/CustomErrors.html) but it seems the [error formatter module](https://hackage.haskell.org/package/servant-server-0.19.1/docs/Servant-Server-Internal-ErrorFormatter.html) doesn't exist in our project. Bumping the version triggers a `marked as broken` for `monad-log`. I guess we have to fix that, or maybe start using `monad-logger` (and possibly `monad-logger-extra`). What do you think is better ?~ (I've updated our dependencies and now use to https://github.com/hypered/monad-log)

Finally, even though I've bumped the dependencies, I've simply generated HTML instead of Text in some specific error data types. I guess we'll need some fancy `throwError` alternative that can inspect the Accept header and generate the right error content.