### PR TITLE
Fix the User Id generation

### DIFF
--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -31,6 +31,7 @@ data Command =
     -- ^ Parse a single command.
   | State
     -- ^ Show the full state.
+  | UserCreate U.Signup
   | SelectUser (S.DBSelect U.UserProfile)
   | UpdateUser (S.DBUpdate U.UserProfile)
   | ShowId Text
@@ -197,12 +198,11 @@ parserCreateUser = do
   email <- A.argument A.str (A.metavar "EMAIL" <> A.help "An email address")
   tosConsent <- A.switch
     (A.help "Indicate if the user being created consents to the TOS.")
-  return $ UpdateUser . U.UserCreate $ U.UserProfile
-    "USER-0" -- TODO
-    (U.Credentials username password)
-    "TODO"
+  return $ UserCreate $ U.Signup
+    username
+    password
     email
-    tosConsent
+    tosConsent -- TODO This doesn't seem to appear in --help.
 
 parserDeleteUser :: A.Parser Command
 parserDeleteUser = UpdateUser . U.UserDelete . U.UserId <$> A.argument

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -20,7 +20,6 @@ module Curiosity.Data.User
   , userProfileEmailAddr
   , userTosConsent
   , UserId(..)
-  , genRandomUserId
   , UserName(..)
   , Password(..)
   -- * Export all DB ops.
@@ -42,7 +41,6 @@ import qualified Data.Text.Lazy                as LT
 import qualified Network.HTTP.Types            as HTTP
 import qualified Servant.Auth.Server           as SAuth
 import qualified Smart.Server.Page.Navbar      as Nav
-import qualified System.Random                 as Rand
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
@@ -162,18 +160,6 @@ newtype UserId = UserId Text
                         , H.ToValue
                         ) via Text
                deriving FromForm via W.Wrapped "user-id" Text
-
--- | Randomly generated and character based user-id.
--- TODO Generate this sequentially instead.
-genRandomUserId :: forall m . MonadIO m => Int -> m UserId
-genRandomUserId len =
-  liftIO
-    $   UserId
-    .   T.pack
-    .   ("USER-" <>)
-    .   take (abs len)
-    .   Rand.randomRs ('0', '9')
-    <$> Rand.getStdGen
 
 instance Nav.IsNavbarContent UserProfile where
   navbarMarkup UserProfile {..} = do

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -229,6 +229,10 @@ handleCommand runtime display command = do
         runAppMSafe runtime $ ask >>= Data.readFullStmDbInHaskFromRuntime
       display $ show output
       pure ExitSuccess
+    Command.UserCreate input -> do
+      output <- runAppMSafe runtime $ withRuntimeAtomically createUser input
+      display $ show output
+      pure ExitSuccess
     Command.SelectUser select -> do
       output <- runAppMSafe runtime $ S.dbSelect select
       display $ show output

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -264,9 +264,7 @@ handleSignup input@User.Signup {..} =
   ML.localEnv (<> "HTTP" <> "Signup")
     $   do
           ML.info $ "Signing up new user: " <> show username <> "..."
-          -- TODO Generate deterministically within STM.
-          newId <- User.genRandomUserId 10
-          Rt.withRuntimeAtomically Rt.createUser (newId, input)
+          Rt.withRuntimeAtomically Rt.createUser input
     >>= \case
           Right uid -> do
             ML.info


### PR DESCRIPTION
- The function used to generate IDs was not updating the random generator, thus always generating the same IDs.
- In the `cty user create` CLI, the User Id was hard-coded to `USER-0`.
- Now, the function is creating sequential numbers, and this is done in STM, instead of the IO monad.