### PR TITLE
Add a blocklist for usernames

### DIFF
--- a/content/documentation.md
+++ b/content/documentation.md
@@ -15,5 +15,6 @@ title: Curiosity
 - [Messages](/documentation/messages)
 - [Objects](/documentation/objects)
 - [Sitemap](/documentation/sitemap)
+- [Validation rules](/documentation/validation)
 - [Views](/documentation/views)
 - [Virtual machine image](/documentation/machine)

--- a/content/documentation/validation.md
+++ b/content/documentation/validation.md
@@ -1,0 +1,12 @@
+---
+title: Curiosity
+---
+
+
+# Validation rules
+
+Usernames from the following list cannot be used:
+
+<!--# include virtual="/partials/username-blocklist" -->
+
+The list [as JSON](/partials/username-blocklist.json).

--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -7,6 +7,10 @@
       # enableACME = true;
       locations = {
         "/".proxyPass = "http://127.0.0.1:9000";
+        "/documentation" = {
+          proxyPass = "http://127.0.0.1:9000";
+          extraConfig = "ssi on;";
+        };
       };
     };
   };

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -27,6 +27,7 @@ module Curiosity.Data.User
   , Storage.DBSelect(..)
   -- * Errors
   , UserErr(..)
+  , usernameBlocklist
   ) where
 
 import qualified Commence.Runtime.Errors       as Errs
@@ -224,3 +225,29 @@ instance Errs.IsRuntimeErr UserErr where
 
 makeLenses ''Credentials
 makeLenses ''UserProfile'
+
+
+--------------------------------------------------------------------------------
+-- | In addition of dynamic rules (e.g. the username should not already be
+-- taken), we disallow some names because they might be used later by the
+-- system or the company, or cause confusion (because usernames are used as
+-- e.g. smartcoop.sh/<username>).
+usernameBlocklist :: [UserName]
+usernameBlocklist =
+  [ "a"
+  , "about"
+  , "data"
+  , "documentation"
+  , "echo"
+  , "errors"
+  , "forms"
+  , "login"
+  , "messages"
+  , "settings"
+  , "signup"
+  , "smart"
+  , "smartcoop" -- In a real syste, I guess this one should be a username that
+                -- we ensure is created.
+  , "state"
+  , "views"
+  ]

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -96,6 +96,9 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                   :> ReqBody '[FormUrlEncoded] User.Signup
                   :> Post '[B.HTML] Signup.ResultPage
 
+             :<|> "partials" :> "username-blocklist" :> Get '[B.HTML] H.Html
+             :<|> "partials" :> "username-blocklist.json" :> Get '[JSON] [Text]
+
              :<|> "login" :> Get '[B.HTML] Login.Page
              :<|> "signup" :> Get '[B.HTML] Signup.Page
 
@@ -126,6 +129,8 @@ serverT conf jwtS root dataDir =
     :<|> showStateAsJson
     :<|> echoLogin
     :<|> echoSignup
+    :<|> partialUsernameBlocklist
+    :<|> partialUsernameBlocklistAsJson
     :<|> showLoginPage
     :<|> showSignupPage
     :<|> publicT conf jwtS
@@ -226,6 +231,14 @@ messageSignupSuccess = pure Signup.SignupSuccess
 echoSignup :: ServerC m => User.Signup -> m Signup.ResultPage
 echoSignup input = pure $ Signup.Success $ show input
 
+
+--------------------------------------------------------------------------------
+partialUsernameBlocklist :: ServerC m => m H.Html
+partialUsernameBlocklist = pure $
+  H.ul $ mapM_ (H.li . H.code . H.toHtml) User.usernameBlocklist
+
+partialUsernameBlocklistAsJson :: ServerC m => m [Text]
+partialUsernameBlocklistAsJson = pure $ map show User.usernameBlocklist
 
 --------------------------------------------------------------------------------
 showLoginPage :: ServerC m => m Login.Page


### PR DESCRIPTION
The main goal is to show how hard-coded data, here a list of usernames, can be both used in some business-logic (i.e. exclude some username from sign up), and also re-used as-is (without copy/pasting) in the documentation.

To achieve this, we use the Server-side include feature of Nginx, which allows us to refer (using a special comment) to some route, to include its returned data verbatim in some documentation page. The route returns some HTML, but without the doctype, header or body tags. We call that "partials".