### PR TITLE
State.json: use PrettyJSON.

### DIFF
--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -20,6 +20,7 @@ module Curiosity.Server
   , ServerSettings
   ) where
 
+import qualified Commence.JSON.Pretty          as JP
 import qualified Commence.Multilogging         as ML
 import qualified Commence.Runtime.Errors       as Errs
 import qualified Commence.Runtime.Storage      as S
@@ -90,7 +91,7 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
              :<|> "messages" :> "signup" :> Get '[B.HTML] Signup.SignupResultPage
 
              :<|> "state" :> Get '[B.HTML] Login.ResultPage -- TODO Proper type.
-             :<|> "state.json" :> Get '[JSON] (HaskDb Rt.Runtime)
+             :<|> "state.json" :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls, 'JP.CleanupFieldNames] (HaskDb Rt.Runtime))
 
              :<|> "echo" :> "login"
                   :> ReqBody '[FormUrlEncoded] User.Login
@@ -566,11 +567,17 @@ showState = do
 
 -- TODO The passwords are displayed in clear. Would be great to have the option
 -- to hide/show them.
-showStateAsJson :: ServerC m => m (HaskDb Rt.Runtime)
+showStateAsJson
+  :: ServerC m
+  => m
+       ( JP.PrettyJSON
+           '[ 'JP.DropNulls , 'JP.CleanupFieldNames]
+           (HaskDb Rt.Runtime)
+       )
 showStateAsJson = do
   stmDb <- asks Rt._rDb
   db    <- readFullStmDbInHask stmDb
-  pure db
+  pure $ JP.PrettyJSON db
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -91,7 +91,7 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
              :<|> "messages" :> "signup" :> Get '[B.HTML] Signup.SignupResultPage
 
              :<|> "state" :> Get '[B.HTML] Login.ResultPage -- TODO Proper type.
-             :<|> "state.json" :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls, 'JP.CleanupFieldNames] (HaskDb Rt.Runtime))
+             :<|> "state.json" :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] (HaskDb Rt.Runtime))
 
              :<|> "echo" :> "login"
                   :> ReqBody '[FormUrlEncoded] User.Login
@@ -568,12 +568,7 @@ showState = do
 -- TODO The passwords are displayed in clear. Would be great to have the option
 -- to hide/show them.
 showStateAsJson
-  :: ServerC m
-  => m
-       ( JP.PrettyJSON
-           '[ 'JP.DropNulls , 'JP.CleanupFieldNames]
-           (HaskDb Rt.Runtime)
-       )
+  :: ServerC m => m (JP.PrettyJSON '[ 'JP.DropNulls] (HaskDb Rt.Runtime))
 showStateAsJson = do
   stmDb <- asks Rt._rDb
   db    <- readFullStmDbInHask stmDb


### PR DESCRIPTION
1. Drops nulls.

~2. Removes underscores leading field names.~

--

The idea behind the design is to have a composable and extensible JSON
prettification system.

--

Before merging this, we should merge
https://github.com/hypered/commence/pull/6.

-- Depends on:

- [ ] https://github.com/hypered/commence/pull/6
