### PR TITLE
Filter out files not required for the binaries

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -6,13 +6,31 @@ let
   contents = import ./contents.nix { nixpkgs = super; };
 
   inherit (super.lib.attrsets) mapAttrs;
-  inherit (import sources.gitignore { inherit lib; }) gitignoreSource;
+  inherit (import sources.gitignore { inherit lib; }) gitignoreFilter;
 
   ourOverrides = selfh: superh:
     let
 
+      customFilter = src:
+        let
+          # IMPORTANT: use the following let binding to memoize info about the
+          # Git directories.
+          # (The comment is from the original example at
+          # https://github.com/hercules-ci/gitignore.nix/blob/master/docs/gitignoreFilter.md)
+          gitIgnoredSrc = gitignoreFilter src;
+        in
+          path: type: gitIgnoredSrc path type;
+
+      cleanedSrc = src: lib.sources.sourceFilesBySuffices
+        ( lib.cleanSourceWith {
+            filter = customFilter src;
+            src = src;
+            name = "source";
+          })
+        [".cabal" ".hs" ".json"]; # Keep JSON files for the test suite.
+
       callCabalOn = name: dir:
-        selfh.callCabal2nix "${name}" (gitignoreSource dir) { };
+        selfh.callCabal2nix "${name}" (cleanedSrc dir) { };
 
     in mapAttrs callCabalOn contents.pkgList;
 


### PR DESCRIPTION
nix-build was doing unnecessary work because it didn't know that some
changed files would not impact the Haskell library and programs.

Here we apply a more aggressive filtering to reduce when nix-build would
actually rebuild the binaries.

This is based on this example: https://github.com/hercules-ci/gitignore.nix/blob/master/docs/gitignoreFilter.md to create a custom filter function, but then I simply combined it with `sourceFilesBySuffices`. Maybe this can be re-written more cleanly.