### PR TITLE
Nix attribute to build a Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,13 @@ access to man pages. By default, running the image will run Bash.
 ```
 $ nix-build -A docker
 $ docker load < result
-$ docker run --privileged -it curiosity:vsj9an994jjrw47kv9fj0icjs2f6xq6r
+$ docker run --privileged -it -p 9000:9000 curiosity:vsj9an994jjrw47kv9fj0icjs2f6xq6r
 ```
 
 Note: the image tag will be different as it depends on the actual image
 content.
+
+Note: `-p 9000:9000` is necessary only for `cty serve`.
 
 # Virtual machine images
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ Right (UsersVisualised [UserProfile {_userCreds = UserCreds {_userCredsId = User
 
 ```
 
+# Docker image
+
+A Docker image can be built to experiment with the `cty` program, and have
+access to man pages. By default, running the image will run Bash.
+
+```
+$ nix-build -A docker
+$ docker load < result
+$ docker run --privileged -it curiosity:vsj9an994jjrw47kv9fj0icjs2f6xq6r
+```
+
+Note: the image tag will be different as it depends on the actual image
+content.
+
 # Virtual machine images
 
 ## QEMU

--- a/default.nix
+++ b/default.nix
@@ -43,9 +43,15 @@ in rec
                   # to set MANPATH below.
                   # I guess it would work if it was packaged with the binaries.
       ];
+      # Setting the CURIOSITY_STATIC_DIR and CURIOSITY_DATA_DIR is not strictly
+      # necessary as this shell is usually run from the source repository, and
+      # the default paths will work (provided the _site/ directory has been
+      # built. But this makes the shell usable even without those conditions.
       shellHook = ''
         source <(cty             --bash-completion-script `which cty`)
         source <(cty-sock        --bash-completion-script `which cty-sock`)
+        export CURIOSITY_STATIC_DIR=${content}
+        export CURIOSITY_DATA_DIR=${data}
         export MANPATH=${man-pages}/share/man
       '';
     };

--- a/default.nix
+++ b/default.nix
@@ -31,6 +31,7 @@ in rec
     toplevel = os.config.system.build.toplevel;
     image = os.config.system.build.digitalOceanImage;
     runvm = qemu.config.system.build.vm;
+    docker = (import ./docker { inherit nixpkgs; });
 
     # A shell to try out our binaries
     # TODO Can this be defined in shell.nix instead ?

--- a/docker/default.nix
+++ b/docker/default.nix
@@ -33,12 +33,11 @@ nixpkgs.dockerTools.buildImage {
   config = {
     Cmd = [
       "${bash-wrapper}/bin/bash-wrapper"
-      # "${binaries}/bin/cty" "serve"
-      # "--static-dir" "${(import ../.).content}"
-      # "--data-dir" "${(import ../.).data}"
     ];
     Env = [
         "MANPATH=${man-pages}/share/man"
+        "CURIOSITY_STATIC_DIR=${(import ../.).content}"
+        "CURIOSITY_DATA_DIR=${(import ../.).data}"
     ];
     ExposedPorts = {
       "9000/tcp" = {};

--- a/docker/default.nix
+++ b/docker/default.nix
@@ -1,0 +1,51 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+let
+  binaries = (import ../.).binaries;
+  man-pages = (import ../.).man-pages;
+
+  bash-wrapper = nixpkgs.writeTextFile {
+    name = "bash-wrapper";
+    executable = true;
+    destination = "/bin/bash-wrapper";
+    text = ''
+      #!${nixpkgs.bashInteractive}/bin/bash
+      # TODO Running the following line manually works, but here, the exec
+      # call on the last line will no retain its effect.
+      source <(cty --bash-completion-script /bin/cty)
+      echo "Welcome to the Curiosity environment."
+      echo "Run \`man curiosity\` for the manual."
+      exec ${nixpkgs.bashInteractive}/bin/bash
+    '';
+  };
+in
+
+nixpkgs.dockerTools.buildImage {
+  name = "curiosity";
+  # cat (from coreutils) and gzip are necessary for man
+  contents = [
+    bash-wrapper
+    binaries
+    nixpkgs.bashInteractive
+    nixpkgs.coreutils
+    nixpkgs.gzip
+    nixpkgs.man
+  ];
+  config = {
+    Cmd = [
+      "${bash-wrapper}/bin/bash-wrapper"
+      # "${binaries}/bin/cty" "serve"
+      # "--static-dir" "${(import ../.).content}"
+      # "--data-dir" "${(import ../.).data}"
+    ];
+    Env = [
+        "MANPATH=${man-pages}/share/man"
+    ];
+    ExposedPorts = {
+      "9000/tcp" = {};
+    };
+  };
+  runAsRoot = ''
+    # /tmp is for the curiosity.log file
+    mkdir -p /tmp
+  '';
+}

--- a/machine/configuration.nix
+++ b/machine/configuration.nix
@@ -50,6 +50,8 @@ in
   programs.bash.interactiveShellInit = ''
     source <(cty             --bash-completion-script `which cty`)
     source <(cty-sock        --bash-completion-script `which cty-sock`)
+    export CURIOSITY_STATIC_DIR=${(import ../.).content}
+    export CURIOSITY_DATA_DIR=${(import ../.).data}
   '';
 
   users.users.curiosity = {


### PR DESCRIPTION
The goal is to provide an environment similar to what we have with `nix-shell default.nix -A shell`, i.e. our binaries with tab-completion and man pages. The static and data directories locations are baked in the image as environment variables, so that `cty serve` works without providing the `--data-dir` or `--static-dir` options.

Things that I'm not happy with:

- I can get the tab completion working when I run the appropriate lines within a running container, but I don't know how to automatically run those lines.
- `man cu<TAB>` doesn't auto-complete.