### PR TITLE
Allow multiple servers on the same VM

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,7 @@ let
       "${toString sources.nixpkgs}/nixos/modules/virtualisation/digital-ocean-image.nix"
       ./machine/disk-size.nix
       ./machine/https.nix
+      ./modules/play.nix
     ];
   };
 

--- a/modules/curiosity.nix
+++ b/modules/curiosity.nix
@@ -10,7 +10,8 @@
         serve \
         --server-port 9100 \
         --static-dir ${(import ../.).content} \
-        --data-dir ${(import ../.).data}
+        --data-dir ${(import ../.).data} \
+        --log /tmp/curiosity.log
     '';
   };
 }

--- a/modules/curiosity.nix
+++ b/modules/curiosity.nix
@@ -8,7 +8,7 @@
         --memory \
         --user system \
         serve \
-        --server-port 9000 \
+        --server-port 9100 \
         --static-dir ${(import ../.).content} \
         --data-dir ${(import ../.).data}
     '';

--- a/modules/play.nix
+++ b/modules/play.nix
@@ -2,11 +2,11 @@
 {
   services.nginx = {
     enable = true;
-    virtualHosts."smartcoop.sh" = {
+    virtualHosts."play.smartcoop.sh" = {
       locations = {
-        "/".proxyPass = "http://127.0.0.1:9100";
+        "/".proxyPass = "http://127.0.0.1:9000";
         "/documentation" = {
-          proxyPass = "http://127.0.0.1:9100";
+          proxyPass = "http://127.0.0.1:9000";
           extraConfig = "ssi on;";
         };
         # TODO How to avoid hard-coding this 0.1.0.0 path ?

--- a/src/Curiosity/Parse.hs
+++ b/src/Curiosity/Parse.hs
@@ -72,7 +72,7 @@ defaultConf =
   let _confDbFile = Nothing in Conf { _confLogging = defaultLoggingConf, .. }
 
 defaultLoggingConf :: ML.LoggingConf
-defaultLoggingConf = mkLoggingConf "/tmp/curiosity.log"
+defaultLoggingConf = mkLoggingConf "./curiosity.log"
 
 mkLoggingConf :: FilePath -> ML.LoggingConf
 mkLoggingConf path =
@@ -86,9 +86,16 @@ flspec path = FL.FileLogSpec path 5000 0
 confParser :: A.Parser Conf
 confParser = do
   _confDbFile <- dbFileParser
+  _confLogFile <- A.strOption
+    (  A.long "log"
+    <> A.value "./curiosity.log"
+    <> A.metavar "PATH"
+    <> A.help
+         "A file where to write logs."
+    )
   pure Conf {
       -- FIXME: ML.parseLoggingConf never terminates, should be fixed.
-              _confLogging = defaultLoggingConf, .. }
+              _confLogging = mkLoggingConf _confLogFile, .. }
 
 serverParser :: A.Parser ServerConf
 serverParser = do


### PR DESCRIPTION
This makes it possible to run `cty serve` as the `alice` Linux user, along side the main `cty serve` of the VM:

- The VM server uses the port 9100 and `/tmp/curiosity.log`
- By default `cty serve` uses port 9000 and `./curiosity.log`

Previously, the default port was already used by the main server, and the log file was locked by the main server. The later is probably something that should be fixed properly.