### PR TITLE
Make `cty` more user-friendly

### DIFF
--- a/scenarios/0.txt
+++ b/scenarios/0.txt
@@ -1,3 +1,4 @@
+reset                    # Make sure to start from a known state
 # Create an initial user
 user create alice secret alice@example.com --accept-tos
 user get USER-1 --short  # Display the created user

--- a/scenarios/0.txt
+++ b/scenarios/0.txt
@@ -1,0 +1,4 @@
+# Create an initial user
+user create alice secret alice@example.com --accept-tos
+user get USER-1 --short  # Display the created user
+quit                     # Exit the script, not required at the end

--- a/scenarios/1.txt
+++ b/scenarios/1.txt
@@ -1,0 +1,15 @@
+# This shows that the first user can verify an email address, but not the
+# second user.
+
+reset
+as alice
+user create alice secret alice@example.com --accept-tos
+user create bob secret bob@example.com --accept-tos
+user do set-email-addr-as-verified USER-2  # Will succeed.
+user do set-email-addr-as-verified USER-2  # This is already done.
+
+reset
+as bob
+user create alice secret alice@example.com --accept-tos
+user create bob secret bob@example.com --accept-tos
+user do set-email-addr-as-verified USER-2  # Will fail: missing right.

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -39,8 +39,9 @@ data Command =
   | State Bool
     -- ^ Show the full state. If True, use Haskell format instead of JSON.
   | CreateUser U.Signup
-  | SelectUser Bool U.UserId
-    -- ^ Show a give user. If True, use Haskell format instead of JSON.
+  | SelectUser Bool U.UserId Bool
+    -- ^ Show a give user. If True, use Haskell format instead of JSON. If
+    -- True, show only the user ID and username.
   | FilterUsers U.Predicate
   | UpdateUser (S.DBUpdate U.UserProfile)
   | SetUserEmailAddrAsVerified U.UserId
@@ -308,6 +309,7 @@ parserGetUser =
     <$> A.switch
           (A.long "hs" <> A.help "Use the Haskell format (default is JSON).")
     <*> A.argument A.str (A.metavar "USER-ID" <> A.help "A user ID")
+    <*> A.switch (A.long "short" <> A.help "Show only the ID and username.")
 
 parserUserLifeCycle :: A.Parser Command
 parserUserLifeCycle = A.subparser $ A.command

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -239,7 +239,7 @@ parserServe = Serve <$> P.confParser <*> P.serverParser
 parserRun :: A.Parser Command
 parserRun = Run <$> P.confParser <*> A.argument
   A.str
-  (A.metavar "FILE" <> A.help "Script to run.")
+  (A.metavar "FILE" <> A.action "file" <> A.help "Script to run.")
 
 parserParse :: A.Parser Command
 parserParse = Parse <$> (parserCommand <|> parserObject <|> parserFileName)

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -40,7 +40,7 @@ data Command =
     -- ^ Show the full state. If True, use Haskell format instead of JSON.
   | CreateUser U.Signup
   | SelectUser Bool U.UserId Bool
-    -- ^ Show a give user. If True, use Haskell format instead of JSON. If
+    -- ^ Show a given user. If True, use Haskell format instead of JSON. If
     -- True, show only the user ID and username.
   | FilterUsers U.Predicate
   | UpdateUser (S.DBUpdate U.UserProfile)
@@ -199,6 +199,12 @@ parser =
            )
 
       <> A.command
+           "users"
+           ( A.info (parserUsers <**> A.helper)
+           $ A.progDesc "Users-related commands"
+           )
+
+      <> A.command
            "queue"
            ( A.info (parserQueue <**> A.helper)
            $ A.progDesc "Display a queue's content"
@@ -286,6 +292,18 @@ parserUser = A.subparser
        $ A.progDesc "Perform a high-level operation on a user"
        )
   )
+
+parserUsers :: A.Parser Command
+parserUsers = do
+  predicate <-
+    (A.flag' U.PredicateEmailAddrToVerify $ A.long "email-addr-to-verify" <> A.help
+      "Show users with an email address to verify."
+    )
+    <|>
+    (A.flag' (U.PredicateHas U.CanVerifyEmailAddr) $ A.long "can-verify-email-addr" <> A.help
+      "Show users with the right to verify email addresses."
+    )
+  return $ FilterUsers predicate
 
 parserCreateUser :: A.Parser Command
 parserCreateUser = do

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -156,7 +156,7 @@ data AccessRight = CanVerifyEmailAddr
   deriving anyclass (ToJSON, FromJSON)
 
 -- | The username is an identifier (i.e. it is unique).
-newtype UserName = UserName Text
+newtype UserName = UserName { unUserName :: Text }
                  deriving ( Eq
                           , Show
                           , IsString
@@ -199,7 +199,7 @@ newtype Password = Password (Secret.Secret '[ 'Secret.ToJSONExp] Text)
                  deriving FromForm via W.Wrapped "password" Text
 
 -- | Record ID of the form USER-xxx.
-newtype UserId = UserId Text
+newtype UserId = UserId { unUserId :: Text }
                deriving (Eq, Show, SAuth.ToJWT, SAuth.FromJWT)
                deriving ( IsString
                         , FromJSON

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -220,9 +220,9 @@ handleRun conf user scriptPath = do
 interpret :: Rt.Runtime -> User.UserName -> FilePath -> IO ()
 interpret runtime user path = do
   content <- readFile path
-  loop . zip [1..] $ T.lines content
+  loop . zip [1 ..] $ T.lines content
  where
-  loop []            = pure ()
+  loop []                  = pure ()
   loop ((ln, line) : rest) = do
     let (prefix, comment) = T.breakOn "#" line
     case T.words prefix of
@@ -230,7 +230,7 @@ interpret runtime user path = do
       ["quit"] -> do
         output' $ show ln <> ": " <> prefix
         output' "Exiting."
-      input    -> do
+      input -> do
         output' $ show ln <> ": " <> prefix
         let result = A.execParserPure A.defaultPrefs Command.parserInfo
               $ map T.unpack input
@@ -271,7 +271,7 @@ handleViewQueues conf user queues = do
 handleShowId conf user i = do
   case T.splitOn "-" i of
     "USER" : _ -> do
-      handleCommand conf user (Command.SelectUser False $ User.UserId i)
+      handleCommand conf user (Command.SelectUser False (User.UserId i) False)
     prefix : _ -> do
       putStrLn $ "Unknown ID prefix " <> prefix <> "."
       exitFailure

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -226,7 +226,12 @@ interpret runtime user path = do
   loop ((ln, line) : rest) = do
     let (prefix, comment) = T.breakOn "#" line
     case T.words prefix of
-      []       -> loop rest
+      []        -> loop rest
+      ["reset"] -> do
+        output' $ show ln <> ": " <> prefix
+        output' "Resetting to the empty state."
+        Rt.reset runtime
+        loop rest
       ["quit"] -> do
         output' $ show ln <> ": " <> prefix
         output' "Exiting."

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -11,6 +11,7 @@ module Curiosity.Runtime
   , AppM(..)
   , boot
   , boot'
+  , reset
   , handleCommand
   , powerdown
   , readDb
@@ -117,6 +118,10 @@ boot' db logsPath = do
   _rDb      <- Data.instantiateStmDb db
   _rLoggers <- ML.makeDefaultLoggersWithConf loggingConf
   pure $ Runtime { .. }
+
+-- | Reset the database to the empty state
+reset runtime = do
+  Data.resetStmDb $ _rDb runtime
 
 -- | Power down the application: attempting to save the DB state in given file, if possible, and reporting errors otherwise.
 powerdown :: MonadIO m => Runtime -> m (Maybe Errs.RuntimeErr)

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -257,7 +257,7 @@ handleCommand runtime@Runtime {..} display user command = do
               pure ExitSuccess
             Left err -> display (show err) >> pure (ExitFailure 1)
         Left err -> display (show err) >> pure (ExitFailure 1)
-    Command.SelectUser useHs uid -> do
+    Command.SelectUser useHs uid short -> do
       output <- runAppMSafe runtime . liftIO . STM.atomically $ selectUserById
         _rDb
         uid
@@ -268,7 +268,14 @@ handleCommand runtime@Runtime {..} display user command = do
               let value' = if useHs
                     then show value
                     else LT.toStrict (Aeson.encodeToLazyText value)
-              display value'
+              if short
+                then
+                  display
+                  $  User.unUserId (User._userProfileId value)
+                  <> " "
+                  <> User.unUserName
+                       (User._userCredsName $ User._userProfileCreds value)
+                else display value'
               pure ExitSuccess
             Nothing -> display "No such user." >> pure (ExitFailure 1)
         Left err -> display (show err) >> pure (ExitFailure 1)

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -213,7 +213,7 @@ appMHandlerNatTrans rt appM =
       unwrapReaderT          = (`runReaderT` rt) . runAppM $ appM
       -- Map our errors to `ServantError`
       runtimeErrToServantErr = withExceptT Errs.asServantError
-  in 
+  in
       -- Re-wrap as servant `Handler`
       Servant.Handler $ runtimeErrToServantErr unwrapReaderT
 
@@ -292,7 +292,7 @@ handleCommand runtime@Runtime {..} display user command = do
           let f User.UserProfile {..} =
                 let User.UserId   i = _userProfileId
                     User.UserName n = User._userCredsName _userProfileCreds
-                in  putStrLn $ "  " <> i <> " " <> n
+                in  putStrLn $ i <> " " <> n
           mapM_ f profiles
           pure ExitSuccess
     Command.UpdateUser update -> do
@@ -472,7 +472,7 @@ createUserFull db newProfile = if username `elem` User.usernameBlocklist
     case mprofile of
       Just profile -> existsErr
       Nothing      -> do
-        modifyUsers db (newProfile :)
+        modifyUsers db (++ [newProfile])
         pure $ Right newProfileId
   existsErr = pure . Left $ User.UserExists
 


### PR DESCRIPTION
- `cty run` accepts comments, starting with "#"
- The output of `cty run` now shows the input line numbers and the commands being run
- `cty user get` accepts a `--short` option to make its output less verbose
- `cty run` understands a `reset` command, to make the state empty
- Internally, new users are appended at the end of the list of users. This makes for a nicer default when displaying the state.
- A new `cty users` command is added to filter users
- `cty run` understands a `as` command, to change the default user for the next commands in the script
- Enable some completion: for the filenames for `cty run`, and for user IDs (the later is really just a helper, and it not dependant on an actual state)