### PR TITLE
Start golden tests

### DIFF
--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -165,3 +165,18 @@ test-suite curiosity-tests
   main-is: Spec.hs
   hs-source-dirs:
       tests
+
+test-suite curiosity-scenarios
+  import: common-dependencies, lang-settings, common-extensions
+  build-depends:
+      bytestring
+    , curiosity
+    , filepath
+    , Glob
+    , lens
+    , tasty
+    , tasty-silver
+  type: exitcode-stdio-1.0
+  main-is: run-scenarios.hs
+  hs-source-dirs:
+      tests

--- a/scenarios/0.golden
+++ b/scenarios/0.golden
@@ -1,0 +1,8 @@
+1: reset
+Resetting to the empty state.
+3: user create alice secret alice@example.com --accept-tos
+User created: USER-1
+4: user get USER-1 --short
+USER-1 alice
+5: quit
+Exiting.

--- a/scenarios/1.golden
+++ b/scenarios/1.golden
@@ -1,0 +1,22 @@
+4: reset
+Resetting to the empty state.
+5: as alice
+Modifiying default user.
+6: user create alice secret alice@example.com --accept-tos
+User created: USER-1
+7: user create bob secret bob@example.com --accept-tos
+User created: USER-2
+8: user do set-email-addr-as-verified USER-2
+User successfully updated.
+9: user do set-email-addr-as-verified USER-2
+EmailAddrAlreadyVerified
+11: reset
+Resetting to the empty state.
+12: as bob
+Modifiying default user.
+13: user create alice secret alice@example.com --accept-tos
+User created: USER-1
+14: user create bob secret bob@example.com --accept-tos
+User created: USER-2
+15: user do set-email-addr-as-verified USER-2
+MissingRight CanVerifyEmailAddr

--- a/scenarios/example.golden
+++ b/scenarios/example.golden
@@ -1,0 +1,8 @@
+1: state
+{"_dbNextUserId":1,"_dbTodos":[],"_dbUserProfiles":[]}
+2: user get USER-1 --short
+No such user.
+3: user create alice secret alice@example.com
+User created: USER-1
+4: user get USER-1 --short
+USER-1 alice

--- a/scenarios/example.txt
+++ b/scenarios/example.txt
@@ -1,5 +1,4 @@
 state
-user get USER-1
+user get USER-1 --short
 user create alice secret alice@example.com
-user get USER-1
-state
+user get USER-1 --short

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash ../shell.nix
 
-# This script runs the Haskell library test suite.
+# This script runs the Haskell library test suite and the scenarios.
 
-cabal test --test-show-details=direct --test-option=--format=checks
+cabal test --test-show-details=direct

--- a/tests/run-scenarios.hs
+++ b/tests/run-scenarios.hs
@@ -1,0 +1,44 @@
+-- | Run scripts similarly to `cty run`, ensuring their outputs are identical
+-- to "golden" (expected) results.
+import qualified Curiosity.Parse               as P
+import qualified Curiosity.Run                 as Run
+import qualified Curiosity.Runtime             as Rt
+import qualified Data.Text                     as T
+import           System.FilePath
+import qualified System.FilePath.Glob          as Glob
+
+import           Test.Tasty
+import qualified Test.Tasty.Silver             as Silver
+
+--------------------------------------------------------------------------------
+main :: IO ()
+main = do
+  goldens <- listScenarios >>= mapM mkGoldenTest
+  defaultMain $ testGroup "Tests" goldens
+
+
+--------------------------------------------------------------------------------
+listScenarios :: IO [FilePath]
+listScenarios = sort <$> Glob.globDir1 pat "scenarios/"
+  where pat = Glob.compile "*.txt"
+
+mkGoldenTest :: FilePath -> IO TestTree
+mkGoldenTest path = do
+  let testName   = takeBaseName path
+  let goldenPath = replaceExtension path ".golden"
+  pure $ Silver.goldenVsAction testName goldenPath action convert
+ where
+  action :: IO [Text]
+  action = do
+    actual <- run path
+    return actual
+
+  convert = T.unlines
+
+-- Similar to Run.handleRun, but capturing the output.
+run :: FilePath -> IO [Text]
+run scriptPath = do
+  runtime     <- Rt.boot P.defaultConf >>= either throwIO pure
+  (_, output) <- Run.interpret' runtime "system" scriptPath
+  Rt.powerdown runtime
+  pure $ map snd output


### PR DESCRIPTION
- The `interpret` function underlying `cty run` has been modified to
  make it possible to easily capture its output
- A `run-scenarios.hs` test script now gather all scripts under
  `scenarios/`, run them, and ensure their output match "golden" files.