### PR TITLE
Improve HTML bits

### DIFF
--- a/content/default.nix
+++ b/content/default.nix
@@ -17,6 +17,8 @@ in
 
       make -f scripts/doc.Makefile
       mv _site $out
+
+      cp -r ${(import ../.).static} $out/static
     '';
   };
 

--- a/content/robots.txt
+++ b/content/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
+Allow: /$
 Disallow: /

--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,7 @@ in rec
     haddock = nixpkgs.haskellPackages.curiosity.doc;
     content = (import ./content {}).html.all;
     data = (import ./content {}).data;
+    static = (import "${sources.design-hs}").static;
     man-pages = (import ./man {}).man-pages;
     toplevel = os.config.system.build.toplevel;
     image = os.config.system.build.digitalOceanImage;

--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -2,6 +2,7 @@
 {
   services.nginx = {
     enable = true;
+    recommendedGzipSettings = true;
     virtualHosts."smartcoop.sh" = {
       locations = {
         "/".proxyPass = "http://127.0.0.1:9100";

--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -9,6 +9,9 @@
           proxyPass = "http://127.0.0.1:9100";
           extraConfig = "ssi on;";
         };
+        "/static/" = {
+          alias = (import ../.).static + "/";
+        };
         # TODO How to avoid hard-coding this 0.1.0.0 path ?
         "/haddock/".alias = (import ../.).haddock + "/share/doc/curiosity-0.1.0.0/html/";
       };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,7 +14,7 @@
     "design-hs": {
         "branch": "main",
         "repo": "git@github.com:hypered/smart-design-hs.git",
-        "rev": "05f64ebf84e651dd598471c50a035adddd11d630",
+        "rev": "644c114447909435f6a08caf37334f8e94273a25",
         "type": "git"
     },
     "gitignore": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,7 +14,7 @@
     "design-hs": {
         "branch": "main",
         "repo": "git@github.com:hypered/smart-design-hs.git",
-        "rev": "3bacc8a1dfc43389e17b431c8af618d6b0a5efe0",
+        "rev": "56299d766f63b1dde68b1c5d0bf865d93d55ec27",
         "type": "git"
     },
     "gitignore": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,7 +14,7 @@
     "design-hs": {
         "branch": "main",
         "repo": "git@github.com:hypered/smart-design-hs.git",
-        "rev": "644c114447909435f6a08caf37334f8e94273a25",
+        "rev": "ba1650b5a2678226b4db8bf98eccb54178831cc3",
         "type": "git"
     },
     "gitignore": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,7 +14,7 @@
     "design-hs": {
         "branch": "main",
         "repo": "git@github.com:hypered/smart-design-hs.git",
-        "rev": "e689e8492c1d385587550cd6decc3fde83170190",
+        "rev": "3bacc8a1dfc43389e17b431c8af618d6b0a5efe0",
         "type": "git"
     },
     "gitignore": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,7 +14,7 @@
     "design-hs": {
         "branch": "main",
         "repo": "git@github.com:hypered/smart-design-hs.git",
-        "rev": "56299d766f63b1dde68b1c5d0bf865d93d55ec27",
+        "rev": "bfb98ce209c11c4daec6cd8f26a55bf3a7ab9108",
         "type": "git"
     },
     "gitignore": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,7 +14,7 @@
     "design-hs": {
         "branch": "main",
         "repo": "git@github.com:hypered/smart-design-hs.git",
-        "rev": "bfb98ce209c11c4daec6cd8f26a55bf3a7ab9108",
+        "rev": "05f64ebf84e651dd598471c50a035adddd11d630",
         "type": "git"
     },
     "gitignore": {

--- a/scripts/ghci-serve.conf
+++ b/scripts/ghci-serve.conf
@@ -2,4 +2,4 @@
 import Prelude
 :set -XImplicitPrelude
 :load bin/cty.hs
-:main serve
+:main --memory serve

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -7,7 +7,7 @@
     <meta name="robots" content="noindex">
     <title>$title$
     </title>
-    <link rel="stylesheet" href="https://design.smart.coop/css/main.css">
+    <link rel="stylesheet" href="/static/css/main.css">
 </head>
 
 <body class="u-maximize-height">
@@ -19,7 +19,7 @@
                         <div class="c-toolbar__item">
                             <div class="c-brand c-brand--small">
                                 <a href="/">
-                                    <img src="https://design.smart.coop/images/logo.svg" alt="Smart" />
+                                    <img src="/static/images/logo.svg" alt="Smart" />
                                 </a>
                             </div>
                         </div>
@@ -90,6 +90,6 @@ $body$
             </div>
         </div>
     </div>
-    <script src="https://design.smart.coop/js/bundle-client.js"></script>
+    <script src="/static/js/bundle-client.js"></script>
 </body>
 </html>

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -90,5 +90,6 @@ $body$
             </div>
         </div>
     </div>
+    <script src="https://design.smart.coop/js/bundle-client.js"></script>
 </body>
 </html>

--- a/src/Curiosity/Form/Login.hs
+++ b/src/Curiosity/Form/Login.hs
@@ -33,7 +33,7 @@ loginPage Page {..} = Dsl.SingletonCanvas $ do
     $ H.a
     ! A.href "/"
     $ H.img
-    ! A.src "https://design.smart.coop/images/logo.svg"
+    ! A.src "/static/images/logo.svg"
     ! A.alt "Smart"
   H.main
     ! A.class_ "o-container-vertical"

--- a/src/Curiosity/Form/Signup.hs
+++ b/src/Curiosity/Form/Signup.hs
@@ -35,7 +35,7 @@ signupPage Page {..} = Dsl.SingletonCanvas $ do
     $ H.a
     ! A.href "/"
     $ H.img
-    ! A.src "https://design.smart.coop/images/logo.svg"
+    ! A.src "/static/images/logo.svg"
     ! A.alt "Smart"
   H.main
     ! A.class_ "o-container-vertical"
@@ -178,7 +178,7 @@ withMessage title msg = do
                 $ H.a
                 ! A.href "/"
                 $ H.img
-                ! A.src "https://design.smart.coop/images/logo.svg"
+                ! A.src "/static/images/logo.svg"
                 ! A.alt "Smart"
               H.div
                 ! A.class_ "c-toolbar__right"

--- a/src/Curiosity/Html/Homepage.hs
+++ b/src/Curiosity/Html/Homepage.hs
@@ -7,7 +7,7 @@ module Curiosity.Html.Homepage
   ) where
 
 import           Curiosity.Data.User           as User
-import           Curiosity.Html.Navbar          ( exampleNavbarAlt )
+import           Curiosity.Html.Navbar          ( navbar )
 import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Render             as Render
 import qualified Text.Blaze.Html5              as H
@@ -32,7 +32,12 @@ instance H.ToMarkup WelcomePage where
       $ H.div
       ! A.class_ "c-app-layout"
       $ do
-          H.header $ H.toMarkup exampleNavbarAlt
+          H.header
+            $ H.toMarkup
+            . navbar
+            . User.unUserName
+            . User._userCredsName
+            $ User._userProfileCreds welcomePageUser
           H.body $ do
             case welcomePageEmailAddrToVerify of
               Just profiles -> do

--- a/src/Curiosity/Html/Navbar.hs
+++ b/src/Curiosity/Html/Navbar.hs
@@ -3,22 +3,26 @@ Module: Curiosity.Html.Navbar
 Description: A navigation bar for Curiosity.
 -}
 module Curiosity.Html.Navbar
-  ( exampleNavbarAlt
+  ( navbar
   ) where
 
 import           Smart.Html.Avatar
-import           Smart.Html.Navbar
+import qualified Smart.Html.Navbar             as Navbar
 
 
 --------------------------------------------------------------------------------
-exampleNavbarAlt :: Navbar
-exampleNavbarAlt = Navbar [] [userEntry]
+navbar :: Text -> Navbar.Navbar
+navbar name = Navbar.Navbar [] [userEntry name]
 
-userEntry = UserEntry userEntries NoAvatarImage
+userEntry :: Text -> Navbar.RightEntry
+userEntry name = Navbar.UserEntry (userEntries name) NoAvatarImage
 
-userEntries =
-  [ SubEntry "Settings" "/settings/profile" False
-  , Divider
+userEntries :: Text -> [Navbar.SubEntry]
+userEntries name =
+  [ Navbar.SignedInAs name
+  , Navbar.Divider
+  , Navbar.SubEntry "Settings" "/settings/profile" False
+  , Navbar.Divider
   -- TODO: change to `POST` in the future. 
-  , SubEntry "Sign out"   "/a/logout"       False
+  , Navbar.SubEntry "Sign out" "/a/logout" False
   ]

--- a/src/Curiosity/Html/Navbar.hs
+++ b/src/Curiosity/Html/Navbar.hs
@@ -18,6 +18,7 @@ userEntry = UserEntry userEntries NoAvatarImage
 
 userEntries =
   [ SubEntry "Settings" "/settings/profile" False
+  , Divider
   -- TODO: change to `POST` in the future. 
-  , SubEntry "Logout"   "/a/logout"         False
+  , SubEntry "Sign out"   "/a/logout"       False
   ]

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -31,10 +31,10 @@ data ProfilePage = ProfilePage
 
 instance H.ToMarkup ProfilePage where
   toMarkup (ProfilePage profile submitUrl) =
-    Render.renderCanvas
+    Render.renderCanvasFullScroll
       . Dsl.SingletonCanvas
       $ H.div
-      ! A.class_ "c-app-layout"
+      ! A.class_ "c-app-layout u-scroll-vertical"
       $ do
           H.header
             $ H.toMarkup
@@ -42,7 +42,7 @@ instance H.ToMarkup ProfilePage where
             . User.unUserName
             . User._userCredsName
             $ User._userProfileCreds profile
-          H.main ! A.class_ "u-maximize-width u-scroll-wrapper" $ profileForm
+          H.main ! A.class_ "u-maximize-width" $ profileForm
             profile
             submitUrl
 
@@ -244,10 +244,10 @@ data ProfileView = ProfileView
 
 instance H.ToMarkup ProfileView where
   toMarkup (ProfileView profile hasEditButton) =
-    Render.renderCanvas
+    Render.renderCanvasFullScroll
       . Dsl.SingletonCanvas
       $ H.div
-      ! A.class_ "c-app-layout"
+      ! A.class_ "c-app-layout u-scroll-vertical"
       $ do
           H.header
             $ H.toMarkup
@@ -255,7 +255,7 @@ instance H.ToMarkup ProfileView where
             . User.unUserName
             . User._userCredsName
             $ User._userProfileCreds profile
-          H.main ! A.class_ "u-maximize-width u-scroll-wrapper" $ profileView
+          H.main ! A.class_ "u-maximize-width" $ profileView
             profile
             hasEditButton
 
@@ -344,10 +344,10 @@ data PublicProfileView = PublicProfileView
 
 instance H.ToMarkup PublicProfileView where
   toMarkup (PublicProfileView profile) =
-    Render.renderCanvas
+    Render.renderCanvasFullScroll
       . Dsl.SingletonCanvas
       $ H.div
-      ! A.class_ "c-app-layout"
+      ! A.class_ "c-app-layout u-scroll-vertical"
       $ do
           H.header
             $ H.toMarkup
@@ -356,7 +356,7 @@ instance H.ToMarkup PublicProfileView where
             . User._userCredsName
             $ User._userProfileCreds profile
           H.main
-            ! A.class_ "u-maximize-width u-scroll-wrapper"
+            ! A.class_ "u-maximize-width"
             $ publicProfileView profile
 
 publicProfileView profile =

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -12,7 +12,9 @@ module Curiosity.Html.Profile
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Navbar          ( navbar )
 import qualified Smart.Html.Dsl                as Dsl
+import           Smart.Html.Layout
 import qualified Smart.Html.Render             as Render
+import           Smart.Html.SideMenu            ( SideMenu(..), SideMenuItem(..) )
 import           Smart.Html.Shared.Html.Icons   ( svgIconAdd
                                                 , svgIconArrowRight
                                                 , svgIconEdit
@@ -255,9 +257,15 @@ instance H.ToMarkup ProfileView where
             . User.unUserName
             . User._userCredsName
             $ User._userProfileCreds profile
-          H.main ! A.class_ "u-maximize-width" $ profileView
-            profile
-            hasEditButton
+          withSideMenuFullScroll menu $ profileView profile hasEditButton
+
+menu :: SideMenu
+menu =
+  SideMenuWithActive
+    []
+    ( SideMenuItem "User profile" "/settings/profile" )
+    [ SideMenuItem "Dummy" "/settings/dummy"
+    ]
 
 profileView profile hasEditButton =
   container $ H.div ! A.class_ "u-spacer-bottom-xl" $ do

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -10,7 +10,7 @@ module Curiosity.Html.Profile
   ) where
 
 import qualified Curiosity.Data.User           as User
-import           Curiosity.Html.Navbar          ( exampleNavbarAlt )
+import           Curiosity.Html.Navbar          ( navbar )
 import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Render             as Render
 import           Smart.Html.Shared.Html.Icons   ( svgIconAdd
@@ -36,7 +36,12 @@ instance H.ToMarkup ProfilePage where
       $ H.div
       ! A.class_ "c-app-layout"
       $ do
-          H.header $ H.toMarkup exampleNavbarAlt
+          H.header
+            $ H.toMarkup
+            . navbar
+            . User.unUserName
+            . User._userCredsName
+            $ User._userProfileCreds profile
           H.main ! A.class_ "u-maximize-width u-scroll-wrapper" $ profileForm
             profile
             submitUrl
@@ -244,7 +249,12 @@ instance H.ToMarkup ProfileView where
       $ H.div
       ! A.class_ "c-app-layout"
       $ do
-          H.header $ H.toMarkup exampleNavbarAlt
+          H.header
+            $ H.toMarkup
+            . navbar
+            . User.unUserName
+            . User._userCredsName
+            $ User._userProfileCreds profile
           H.main ! A.class_ "u-maximize-width u-scroll-wrapper" $ profileView
             profile
             hasEditButton
@@ -339,7 +349,12 @@ instance H.ToMarkup PublicProfileView where
       $ H.div
       ! A.class_ "c-app-layout"
       $ do
-          H.header $ H.toMarkup exampleNavbarAlt
+          H.header
+            $ H.toMarkup
+            . navbar
+            . User.unUserName
+            . User._userCredsName
+            $ User._userProfileCreds profile
           H.main
             ! A.class_ "u-maximize-width u-scroll-wrapper"
             $ publicProfileView profile

--- a/src/WaiAppStatic/Storage/Filesystem/Extended.hs
+++ b/src/WaiAppStatic/Storage/Filesystem/Extended.hs
@@ -32,15 +32,16 @@ import           Data.List                      ( init
 import qualified Data.Text                     as T
 import qualified Network.Wai                   as Wai
 import           Prelude                 hiding ( hash )
-import           System.FilePath                ( (</>) )
+import           System.FilePath                ( (</>)
+                                                , takeExtension
+                                                )
 import           System.PosixCompat.Files       ( fileSize
                                                 , getFileStatus
                                                 , isRegularFile
                                                 , modificationTime
                                                 )
 import           WaiAppStatic.Storage.Filesystem
-                                                ( ETagLookup
-                                                )
+                                                ( ETagLookup )
 import           WaiAppStatic.Types             ( File(..)
                                                 , LookupResult(..)
                                                 , Piece(..)
@@ -89,10 +90,22 @@ webAppLookup hashFunc prefix pieces = fileHelperLR hashFunc fp lastPiece
     = (init pieces, unsafeToPiece "index.html")
     | otherwise
     = let lastP = case fromPiece (last pieces) of
-            s | T.isSuffixOf ".ico" s -> last pieces
-            s | T.isSuffixOf ".txt" s -> last pieces
-            s                         -> unsafeToPiece $ s <> ".html"
+            s | takeExtension (T.unpack s) `elem` extensions -> last pieces
+            s -> unsafeToPiece $ s <> ".html"
       in  (init pieces, lastP)
+  extensions =
+    [ ".css"
+    , ".ico"
+    , ".jpg"
+    , ".js"
+    , ".otf"
+    , ".png"
+    , ".ttf"
+    , ".svg"
+    , ".txt"
+    , ".woff"
+    , ".woff2"
+    ]
 
 -- | Convenience wrapper for @fileHelper@.
 fileHelperLR


### PR DESCRIPTION
- Add a dividing line in the user menu
- Show the logged in username in the user menu
- Fix the hamburger menu on the Markdown-based pages
- The whole settings pages (including the main navigation header) are scrollable
- Rename "logout" to "sign out"
- Add a side menu to the settings page
- Serve the static assets directly (instead of design.smart.coop)
- The `smart-design-hs` depency is bumped:
   - making the webpage main navigation header mobile friendly
   - removing unused css and js files
- Some Accessibility (and other metrics) score are improved (measured on web.dev)
   - e.g. gzip compression is enabled