### PR TITLE
POC: Generalised ID counters.

### DIFF
--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -89,6 +89,7 @@ library
     Curiosity.Command
     Curiosity.Data
     Curiosity.Data.Business
+    Curiosity.Data.Counter
     Curiosity.Data.Employment
     Curiosity.Data.Invoice
     Curiosity.Data.Legal

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -80,7 +80,7 @@ emptyHask = Db
 instantiateStmDb
   :: forall runtime m . MonadIO m => HaskDb runtime -> m (StmDb runtime)
 instantiateStmDb Db
-  { _dbNextBusinessId   = CounterValue (Identity seedNextBusinessId) 
+  { _dbNextBusinessId   = CounterValue (Identity seedNextBusinessId)
   , _dbBusinessEntities = Identity seedBusinessEntities
   , _dbNextLegalId      = Identity seedNextLegalId
   , _dbLegalEntities    = Identity seedLegalEntities
@@ -95,7 +95,7 @@ instantiateStmDb Db
   -- We don't use `newTVarIO` repeatedly under here and instead wrap the whole
   -- instantiation under a single STM transaction (@atomically@).
     liftIO . STM.atomically $ do
-    _dbNextBusinessId   <- C.initialCounter seedNextBusinessId  
+    _dbNextBusinessId   <- C.newCounter seedNextBusinessId
     _dbBusinessEntities <- STM.newTVar seedBusinessEntities
     _dbNextLegalId      <- STM.newTVar seedNextLegalId
     _dbLegalEntities    <- STM.newTVar seedLegalEntities
@@ -135,7 +135,7 @@ readFullStmDbInHask
 readFullStmDbInHask = liftIO . STM.atomically . readFullStmDbInHask'
 
 readFullStmDbInHask' stmDb = do
-  _dbNextBusinessId   <- pure <$> C.currentCounter (_dbNextBusinessId stmDb)
+  _dbNextBusinessId   <- pure <$> C.readCounter (_dbNextBusinessId stmDb)
   _dbBusinessEntities <- pure <$> STM.readTVar (_dbBusinessEntities stmDb)
   _dbNextLegalId      <- pure <$> STM.readTVar (_dbNextLegalId stmDb)
   _dbLegalEntities    <- pure <$> STM.readTVar (_dbLegalEntities stmDb)

--- a/src/Curiosity/Data/Counter.hs
+++ b/src/Curiosity/Data/Counter.hs
@@ -36,6 +36,9 @@ class Counter count datastore m where
   -- | Generate the next value of a counter.
   readCounter :: CounterValue datastore count -> m count
 
+  -- | Set the value of a counter.
+  writeCounter :: CounterValue datastore count -> count -> m ()
+
   -- | Bump the counter value, returning the value before and after the bump.
   bumpCounter :: CounterValue datastore count -> m (CounterStep count)
 
@@ -44,6 +47,8 @@ instance Enum count => Counter count STM.TVar STM.STM  where
   newCounter initCount = CounterValue <$> STM.newTVar initCount
 
   readCounter (CounterValue countTvar) = STM.readTVar countTvar
+
+  writeCounter (CounterValue countTvar) count = STM.writeTVar countTvar count
 
   bumpCounter ctr@(CounterValue countTvar) = do
     was <- readCounter ctr
@@ -57,6 +62,8 @@ instance Enum count => Counter count Identity Identity where
   newCounter initCount = pure $ CounterValue . Identity $ initCount
 
   readCounter (CounterValue (Identity curValue)) = pure curValue
+
+  writeCounter (CounterValue countTvar) count = pure ()
 
   bumpCounter (CounterValue (Identity curValue)) =
     pure CounterStep { was = curValue, is = succ curValue }

--- a/src/Curiosity/Data/Counter.hs
+++ b/src/Curiosity/Data/Counter.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE KindSignatures #-}
+module Curiosity.Data.Counter
+  ( CounterValue(..)
+  , Counter(..)
+  , currentCounterBumping
+  ) where
+
+import qualified Control.Concurrent.STM        as STM
+import           Data.Aeson
+
+newtype CounterValue (datastore :: Type -> Type) count = CounterValue { counterValue :: datastore count }
+                                                       deriving (Eq, Show)
+                                                       deriving (ToJSON, FromJSON) via datastore count
+
+instance Functor datastore => Functor (CounterValue datastore) where
+  fmap f (CounterValue dcount) = CounterValue $ fmap f dcount
+instance Applicative datastore => Applicative (CounterValue datastore) where
+  pure = CounterValue . pure
+  liftA2 f (CounterValue dcount0) (CounterValue dcount1) =
+    CounterValue $ liftA2 f dcount0 dcount1
+
+class Counter count datastore m where
+
+  -- | Generate the initial value of a counter.
+  initialCounter :: count ->  m (CounterValue datastore count)
+
+  -- | Generate the next value of a counter.
+  currentCounter :: CounterValue datastore count -> m count
+
+  -- | Store the new counter value. 
+  bumpCounter :: CounterValue datastore count -> m ()
+
+instance Enum count => Counter count STM.TVar STM.STM  where
+
+  initialCounter initCount = CounterValue <$> STM.newTVar initCount
+
+  currentCounter (CounterValue countTvar) = STM.readTVar countTvar
+
+  bumpCounter (CounterValue countTvar) = STM.modifyTVar countTvar succ
+
+-- | Since we're dealing with pure values, bumpCounter has no effect. 
+instance Enum count => Counter count Identity Identity where
+  initialCounter initCount = pure $ CounterValue . Identity $ initCount
+  currentCounter (CounterValue (Identity curValue)) = pure curValue
+  bumpCounter (CounterValue (Identity curValue)) =
+    pure (CounterValue (Identity $ succ curValue)) $> ()
+
+-- | Get the current value of a counter bumping the value as we go.
+currentCounterBumping
+  :: forall count m datastore
+   . (Counter count datastore m, Applicative m)
+  => CounterValue datastore count
+  -> m count
+currentCounterBumping ctr = currentCounter ctr <* bumpCounter ctr
+

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -482,9 +482,8 @@ createLegalFull db new = do
   pure . Right $ Legal._entityId new
 
 generateLegalId :: forall runtime . Data.StmDb runtime -> STM Legal.LegalId
-generateLegalId db = do
-  let tvar = Data._dbNextLegalId db
-  STM.stateTVar tvar (\i -> (Legal.LegalId $ "LENT-" <> show i, succ i))
+generateLegalId Data.Db {..} =
+  Legal.LegalId <$> C.bumpCounterPrefix "LENT-" _dbNextLegalId
 
 modifyLegalEntities
   :: forall runtime
@@ -519,9 +518,8 @@ createEmploymentFull db new = do
 
 generateEmploymentId
   :: forall runtime . Data.StmDb runtime -> STM Employment.ContractId
-generateEmploymentId db = do
-  let tvar = Data._dbNextEmploymentId db
-  STM.stateTVar tvar (\i -> (Employment.ContractId $ "EMP-" <> show i, succ i))
+generateEmploymentId Data.Db {..} =
+  Employment.ContractId <$> C.bumpCounterPrefix "EMP-" _dbNextEmploymentId
 
 modifyEmployments
   :: forall runtime
@@ -556,9 +554,8 @@ createInvoiceFull db new = do
 
 generateInvoiceId
   :: forall runtime . Data.StmDb runtime -> STM Invoice.InvoiceId
-generateInvoiceId db = do
-  let tvar = Data._dbNextInvoiceId db
-  STM.stateTVar tvar (\i -> (Invoice.InvoiceId $ "INV-" <> show i, succ i))
+generateInvoiceId Data.Db {..} =
+  Invoice.InvoiceId <$> C.bumpCounterPrefix "INV-" _dbNextInvoiceId
 
 modifyInvoices
   :: forall runtime
@@ -684,9 +681,8 @@ createUserFull db newProfile = if username `elem` User.usernameBlocklist
   existsErr = pure . Left $ User.UserExists
 
 generateUserId :: forall runtime . Data.StmDb runtime -> STM User.UserId
-generateUserId db = do
-  let nextUserIdTVar = Data._dbNextUserId db
-  STM.stateTVar nextUserIdTVar (\i -> (User.UserId $ "USER-" <> show i, succ i))
+generateUserId Data.Db {..} =
+  User.UserId <$> C.bumpCounterPrefix "USER-" _dbNextUserId
 
 modifyUsers
   :: forall runtime

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -45,6 +45,7 @@ import "exceptions" Control.Monad.Catch         ( MonadCatch
 import qualified Curiosity.Command             as Command
 import qualified Curiosity.Data                as Data
 import qualified Curiosity.Data.Business       as Business
+import qualified Curiosity.Data.Counter        as C
 import qualified Curiosity.Data.Employment     as Employment
 import qualified Curiosity.Data.Invoice        as Invoice
 import qualified Curiosity.Data.Legal          as Legal
@@ -445,9 +446,11 @@ createBusinessFull db new = do
 
 generateBusinessId
   :: forall runtime . Data.StmDb runtime -> STM Business.BusinessId
-generateBusinessId db = do
-  let tvar = Data._dbNextBusinessId db
-  STM.stateTVar tvar (\i -> (Business.BusinessId $ "BENT-" <> show i, succ i))
+generateBusinessId Data.Db {..} =
+  Business.BusinessId
+    .   mappend "BENT-"
+    .   show
+    <$> C.currentCounterBumping _dbNextBusinessId
 
 modifyBusinessEntities
   :: forall runtime

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -447,10 +447,7 @@ createBusinessFull db new = do
 generateBusinessId
   :: forall runtime . Data.StmDb runtime -> STM Business.BusinessId
 generateBusinessId Data.Db {..} =
-  Business.BusinessId
-    .   mappend "BENT-"
-    .   show
-    <$> C.currentCounterBumping _dbNextBusinessId
+  Business.BusinessId <$> C.bumpCounterPrefix "BENT-" _dbNextBusinessId
 
 modifyBusinessEntities
   :: forall runtime


### PR DESCRIPTION
@noteed we use a generalised class for all the ID types. In this proof
of concept, I've only replaced the business-ids.

--

The core idea is to have a newtype that wraps around a counter value.
Then we have some notion of `m` that wraps around counter values. And
we provide one generalised way to be able to generate new counter
values, bump values, and instantiate them to a desired value.

This can be a drop-in replacement of the repetition you mentioned; and
can provide significant code size reduction, especially as we add more
entities operating with IDs.

This is just a proof of concept, so I'd be curious to know what you
think.
