### PR TITLE
Trying to serve namespaces

### DIFF
--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -65,6 +65,7 @@ common common-dependencies
     -- Servant
     , servant
     , servant-blaze
+    , servant-rawm-server
     , servant-server
     , servant-websockets
     -- Authentication: use Jose based JWK settings as well.


### PR DESCRIPTION
Currently, a single "alice" is handled, instead of a captured namespace.

@asheshambasta I can't manage to make it work. I tried initially with `Tagged m Application` (which matches `Raw` I think), then I tried with https://hackage.haskell.org/package/servant-rawm-1.0.0.0/docs/Servant-RawM.html. The problem is to be able to use `withMaybeUserFromUsername` to lookup a user, together with `serveDocumentation` (as a fallback when there is no such user). Could you have a try at this ?

Previously I wanted to simply have `serveNamespace` fail "softly" so that Servant would try the next handler, but I didn't find how to make that work either.