### PR TITLE
Add Brotli compression to Nginx

### DIFF
--- a/modules/brotlify.nix
+++ b/modules/brotlify.nix
@@ -1,0 +1,36 @@
+# This is a copy of the file presented in the blog post
+# https://dee.underscore.world/blog/brotlifying-nginx/
+# Differences:
+#   - Added "svg".
+#   - Commented out version and pname.
+{ stdenvNoCC
+, lib
+, brotli
+, element-web }:
+{ src
+, fileExtensions ? [
+  "html" "js" "css" "json" "txt" "ttf" "ico" "svg" "wasm"
+]}:
+let
+  findQuery = lib.flatten (lib.intersperse "-o"
+    (map (ext: [ "-iname" (lib.escapeShellArg "*.${ext}") ]) fileExtensions));
+in stdenvNoCC.mkDerivation {
+  inherit src;
+  name = "brotlified";
+  # inherit (src) version;
+  # pname = "${src.pname}-brotlified";
+
+  nativeBuildInputs = [
+    brotli
+  ];
+
+  buildPhase = ''
+    find . -type f \( \
+      ${lib.concatStringsSep " " findQuery} \
+      \) -print0 | xargs -0 -P $NIX_BUILD_CORES -I{} brotli -vZ {}
+  '';
+
+  installPhase = ''
+    find . -type f -iname '*.br' -exec install -m444 -D {} $out/{} \;
+  '';
+}

--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -1,7 +1,20 @@
 { config, lib, pkgs, ... }:
+let
+  brotlify = pkgs.callPackage ./brotlify.nix { };
+  static = (import ../.).static;
+  static-layered = pkgs.buildEnv {
+    name = "static-layered";
+    paths = [
+      static
+      (brotlify { src = static; })
+    ];
+  };
+in
 {
   services.nginx = {
     enable = true;
+    package = pkgs.nginxMainline;
+    additionalModules = [ pkgs.nginxModules.brotli ];
     recommendedGzipSettings = true;
     virtualHosts."smartcoop.sh" = {
       locations = {
@@ -11,11 +24,15 @@
           extraConfig = "ssi on;";
         };
         "/static/" = {
-          alias = (import ../.).static + "/";
+          alias = static-layered + "/";
         };
         # TODO How to avoid hard-coding this 0.1.0.0 path ?
         "/haddock/".alias = (import ../.).haddock + "/share/doc/curiosity-0.1.0.0/html/";
       };
+
+      extraConfig = ''
+        brotli_static on;
+      '';
     };
   };
 }


### PR DESCRIPTION
This is done following the blog post
https://dee.underscore.world/blog/brotlifying-nginx/

- Use mainline Nginx
- Add Brotly extension
- Add a Nix function to apply Brotli compression
- Use it on the static assets, that were already served by Nginx