### PR TITLE
Begin a form to create a contract

### DIFF
--- a/content/documentation/forms.md
+++ b/content/documentation/forms.md
@@ -22,6 +22,10 @@ title: Curiosity
     profile form is part of the settings and is available from the user menu at
     [`/settings/profile/edit`](/settings/profile/edit).
 
+[New contract](/forms/new-contract)
+
+:   The new contract form allows a user to ...
+
 # See also
 
 - [Sitemap](/documentation/sitemap)

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -68,7 +68,7 @@ data Db (datastore :: Type -> Type) (runtime :: Type) = Db
   , _dbRandomGenState     :: datastore (Word64, Word64)
     -- ^ The internal representation of a StdGen.
   , _dbFormCreateContract ::
-      datastore (Map (Text, User.UserName) Employment.CreateContract)
+      datastore (Map (User.UserName, Text) Employment.CreateContract)
   }
 
 -- | Hask database type: used for starting the system, values reside in @Hask@

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -36,7 +36,6 @@ import qualified Curiosity.Data.Legal          as Legal
 import qualified Curiosity.Data.User           as User
 import           Data.Aeson
 import qualified Data.List                     as L
-import           Data.Map                       ( Map )
 import qualified Data.Text                     as T
 import qualified Network.HTTP.Types.Status     as S
 import qualified System.Random                 as Rand

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -20,6 +20,10 @@ module Curiosity.Data
   -- * Serialising and deseralising DB to bytes.
   , serialiseDb
   , deserialiseDb
+  -- * Pseudo-random number generation.
+  , genRandomText
+  , readStdGen
+  , writeStdGen
   ) where
 
 import Curiosity.Data.Counter as C
@@ -31,9 +35,16 @@ import qualified Curiosity.Data.Invoice        as Invoice
 import qualified Curiosity.Data.Legal          as Legal
 import qualified Curiosity.Data.User           as User
 import           Data.Aeson
+import qualified Data.List                     as L
+import           Data.Map                       ( Map )
 import qualified Data.Text                     as T
 import qualified Network.HTTP.Types.Status     as S
+import qualified System.Random                 as Rand
+import qualified System.Random.Internal        as Rand
+import qualified System.Random.SplitMix        as SM
 
+
+--------------------------------------------------------------------------------
 {- | The central database. The product type contains all values and is
 parameterised by @datastore@. The @datastore@ can be the layer dealing with
 storage. When it is @Identity@, it just means the data is stored as is. It can,
@@ -53,6 +64,11 @@ data Db (datastore :: Type -> Type) (runtime :: Type) = Db
   , _dbInvoices         :: datastore [Invoice.Invoice]
   , _dbNextEmploymentId :: C.CounterValue datastore Int
   , _dbEmployments      :: datastore [Employment.Contract]
+
+  , _dbRandomGenState     :: datastore (Word64, Word64)
+    -- ^ The internal representation of a StdGen.
+  , _dbFormCreateContract ::
+      datastore (Map (Text, User.UserName) Employment.CreateContract)
   }
 
 -- | Hask database type: used for starting the system, values reside in @Hask@
@@ -77,6 +93,9 @@ emptyHask = Db
   (pure 1) (pure mempty)
   (pure 1) (pure mempty)
 
+  (pure $ randomGenState 42) -- Deterministic initial seed.
+  (pure mempty)
+
 instantiateStmDb
   :: forall runtime m . MonadIO m => HaskDb runtime -> m (StmDb runtime)
 instantiateStmDb Db
@@ -90,6 +109,9 @@ instantiateStmDb Db
   , _dbInvoices         = Identity seedInvoices
   , _dbNextEmploymentId = CounterValue (Identity seedNextEmploymentId)
   , _dbEmployments      = Identity seedEmployments
+
+  , _dbRandomGenState     = Identity seedRandomGenState
+  , _dbFormCreateContract = Identity seedFormCreateContract
   }
   =
   -- We don't use `newTVarIO` repeatedly under here and instead wrap the whole
@@ -105,6 +127,9 @@ instantiateStmDb Db
     _dbInvoices         <- STM.newTVar seedInvoices
     _dbNextEmploymentId <- C.newCounter seedNextEmploymentId
     _dbEmployments      <- STM.newTVar seedEmployments
+
+    _dbRandomGenState     <- STM.newTVar seedRandomGenState
+    _dbFormCreateContract <- STM.newTVar seedFormCreateContract
     pure Db { .. }
 
 instantiateEmptyStmDb :: forall runtime m . MonadIO m => m (StmDb runtime)
@@ -125,6 +150,8 @@ resetStmDb stmDb = liftIO . STM.atomically $ do
   STM.writeTVar (_dbInvoices stmDb) seedInvoices
   C.writeCounter (_dbNextEmploymentId stmDb) seedNextEmploymentId
   STM.writeTVar (_dbEmployments stmDb) seedEmployments
+
+  STM.writeTVar (_dbFormCreateContract stmDb) seedFormCreateContract
  where
   Db
     { _dbNextBusinessId   = CounterValue (Identity seedNextBusinessId)
@@ -137,6 +164,8 @@ resetStmDb stmDb = liftIO . STM.atomically $ do
     , _dbInvoices         = Identity seedInvoices
     , _dbNextEmploymentId = CounterValue (Identity seedNextEmploymentId)
     , _dbEmployments      = Identity seedEmployments
+
+    , _dbFormCreateContract = Identity seedFormCreateContract
     } = emptyHask
 
 -- | Reads all values of the `Db` product type from `STM.STM` to @Hask@.
@@ -164,6 +193,9 @@ readFullStmDbInHask' stmDb = do
   _dbInvoices         <- pure <$> STM.readTVar (_dbInvoices stmDb)
   _dbNextEmploymentId <- pure <$> C.readCounter (_dbNextEmploymentId stmDb)
   _dbEmployments      <- pure <$> STM.readTVar (_dbEmployments stmDb)
+
+  _dbRandomGenState     <- pure <$> STM.readTVar (_dbRandomGenState stmDb)
+  _dbFormCreateContract <- pure <$> STM.readTVar (_dbFormCreateContract stmDb)
   pure Db { .. }
 
 {- | Provides us with the ability to constrain on a larger product-type (the
@@ -188,6 +220,8 @@ instance E.IsRuntimeErr DbErr where
   userMessage = Just . \case
     DbDecodeFailed msg -> msg
 
+
+--------------------------------------------------------------------------------
 -- | Write an entire db state to bytes.
 serialiseDb :: forall runtime . HaskDb runtime -> LByteString
 serialiseDb = encode
@@ -197,3 +231,32 @@ serialiseDb = encode
 deserialiseDb :: forall runtime . LByteString -> Either DbErr (HaskDb runtime)
 deserialiseDb = first (DbDecodeFailed . T.pack) . eitherDecode
 {-# INLINE deserialiseDb #-}
+
+
+--------------------------------------------------------------------------------
+-- We use System.Random.Internal and Sytem.Random.SplitMix to be able to keep
+-- the random generator internal state (a pair of Word64) in our Data.StmDb
+-- structure.
+randomGenState :: Int -> (Word64, Word64)
+randomGenState = SM.unseedSMGen . Rand.unStdGen . Rand.mkStdGen
+
+readStdGen :: StmDb runtime -> STM Rand.StdGen
+readStdGen db = do
+  (seed, gamma) <- STM.readTVar $ _dbRandomGenState db
+  let g = Rand.StdGen $ SM.seedSMGen' (seed, gamma)
+  pure g
+
+writeStdGen :: StmDb runtime -> Rand.StdGen -> STM ()
+writeStdGen db g = do
+  let (seed, gamma) = SM.unseedSMGen $ Rand.unStdGen g
+  STM.writeTVar (_dbRandomGenState db) (seed, gamma)
+
+genRandomText :: forall runtime . StmDb runtime -> STM Text
+genRandomText db = do
+  g1 <- readStdGen db
+  let ags = take 8 $ unfoldr (\g -> let (a, g') = Rand.uniformR ('A', 'Z') g
+                                     in Just ((a, g'), g')) g1
+      s = T.pack $ fst <$> ags
+      g2 = snd $ L.last ags
+  writeStdGen db g2
+  pure s

--- a/src/Curiosity/Data/Counter.hs
+++ b/src/Curiosity/Data/Counter.hs
@@ -63,7 +63,7 @@ instance Enum count => Counter count Identity Identity where
 
   readCounter (CounterValue (Identity curValue)) = pure curValue
 
-  writeCounter (CounterValue countTvar) count = pure ()
+  writeCounter (CounterValue _) _ = pure ()
 
   bumpCounter (CounterValue (Identity curValue)) =
     pure CounterStep { was = curValue, is = succ curValue }

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -5,7 +5,8 @@ Module: Curiosity.Data.Employment
 Description: Employment related datatypes
 -}
 module Curiosity.Data.Employment
-  ( Contract(..)
+  ( CreateContract(..)
+  , Contract(..)
   , ContractId(..)
   , Err(..)
   ) where
@@ -13,7 +14,18 @@ module Curiosity.Data.Employment
 import qualified Commence.Types.Wrapped        as W
 import           Data.Aeson
 import qualified Text.Blaze.Html5              as H
-import           Web.FormUrlEncoded             ( FromForm(..) )
+import           Web.FormUrlEncoded             ( FromForm(..)
+                                                , parseUnique
+                                                )
+
+--------------------------------------------------------------------------------
+data CreateContract = CreateContract
+  { _createContractDescription :: Text
+  }
+  deriving (Generic, Eq, Show)
+
+instance FromForm CreateContract where
+  fromForm f = CreateContract <$> parseUnique "description" f
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -6,6 +6,7 @@ Description: Employment related datatypes
 -}
 module Curiosity.Data.Employment
   ( CreateContract(..)
+  , emptyCreateContract
   , SubmitContract(..)
   , Contract(..)
   , ContractId(..)
@@ -20,14 +21,36 @@ import           Web.FormUrlEncoded             ( FromForm(..)
                                                 )
 
 --------------------------------------------------------------------------------
+-- | This represent a form being filled in. In particular, it can represent
+-- invalid inputs. As it is filled, it is kept in a Map, where it is identified
+-- by a key. The form data are validated when they are "submitted", using the
+-- SubmitContract data type below, and the key.
 data CreateContract = CreateContract
-  { _createContractDescription :: Text
+  { _createContractProject     :: Text
+  , _createContractPO          :: Text
+  , _createContractRole        :: Text
+  , _createContractType        :: Text
+  , _createContractDescription :: Text
   }
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
 instance FromForm CreateContract where
-  fromForm f = CreateContract <$> parseUnique "description" f
+  fromForm f =
+    CreateContract
+      <$> parseUnique "project"     f
+      <*> parseUnique "po"          f
+      <*> parseUnique "role"        f
+      <*> parseUnique "type"        f
+      <*> parseUnique "description" f
+
+emptyCreateContract :: CreateContract
+emptyCreateContract = CreateContract { _createContractProject     = ""
+                                     , _createContractPO          = ""
+                                     , _createContractRole        = ""
+                                     , _createContractType        = ""
+                                     , _createContractDescription = ""
+                                     }
 
 data SubmitContract = SubmitContract
   { _submitContractKey :: Text

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -5,10 +5,11 @@ Module: Curiosity.Data.Employment
 Description: Employment related datatypes
 -}
 module Curiosity.Data.Employment
-  ( CreateContract(..)
+  ( CreateContractAll(..)
+  , CreateContract(..)
+  , emptyCreateContractAll
   , emptyCreateContract
   , AddExpense(..)
-  , AddExpenseId(..)
   , SubmitContract(..)
   , Contract(..)
   , ContractId(..)
@@ -28,6 +29,10 @@ import           Web.HttpApiData                ( FromHttpApiData(..) )
 -- invalid inputs. As it is filled, it is kept in a Map, where it is identified
 -- by a key. The form data are validated when they are "submitted", using the
 -- SubmitContract data type below, and the key.
+data CreateContractAll = CreateContractAll CreateContract [AddExpense]
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
 data CreateContract = CreateContract
   { _createContractProject     :: Text
   , _createContractPO          :: Text
@@ -47,6 +52,9 @@ instance FromForm CreateContract where
       <*> parseUnique "type"        f
       <*> parseUnique "description" f
 
+emptyCreateContractAll :: CreateContractAll
+emptyCreateContractAll = CreateContractAll emptyCreateContract []
+
 emptyCreateContract :: CreateContract
 emptyCreateContract = CreateContract { _createContractProject     = ""
                                      , _createContractPO          = ""
@@ -65,16 +73,6 @@ data AddExpense = AddExpense
 instance FromForm AddExpense where
   fromForm f =
     AddExpense <$> parseUnique "contract-key" f <*> parseUnique "amount" f
-
-newtype AddExpenseId = AddExpenseId Text
-  deriving (Eq, Ord, Show)
-  deriving ( IsString
-           , FromJSON
-           , ToJSON
-           , H.ToMarkup
-           , H.ToValue
-           ) via Text
-  deriving (FromHttpApiData, FromForm) via W.Wrapped "user-id" Text
 
 data SubmitContract = SubmitContract
   { _submitContractKey :: Text

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -22,7 +22,6 @@ import qualified Text.Blaze.Html5              as H
 import           Web.FormUrlEncoded             ( FromForm(..)
                                                 , parseUnique
                                                 )
-import           Web.HttpApiData                ( FromHttpApiData(..) )
 
 --------------------------------------------------------------------------------
 -- | This represent a form being filled in. In particular, it can represent

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -6,6 +6,7 @@ Description: Employment related datatypes
 -}
 module Curiosity.Data.Employment
   ( CreateContract(..)
+  , SubmitContract(..)
   , Contract(..)
   , ContractId(..)
   , Err(..)
@@ -23,9 +24,19 @@ data CreateContract = CreateContract
   { _createContractDescription :: Text
   }
   deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
 
 instance FromForm CreateContract where
   fromForm f = CreateContract <$> parseUnique "description" f
+
+data SubmitContract = SubmitContract
+  { _submitContractKey :: Text
+  }
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm SubmitContract where
+  fromForm f = SubmitContract <$> parseUnique "key" f
 
 
 --------------------------------------------------------------------------------
@@ -48,4 +59,3 @@ newtype ContractId = ContractId { unContractId :: Text }
 
 data Err = Err
   deriving (Eq, Exception, Show)
-

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -7,6 +7,8 @@ Description: Employment related datatypes
 module Curiosity.Data.Employment
   ( CreateContract(..)
   , emptyCreateContract
+  , AddExpense(..)
+  , AddExpenseId(..)
   , SubmitContract(..)
   , Contract(..)
   , ContractId(..)
@@ -19,6 +21,7 @@ import qualified Text.Blaze.Html5              as H
 import           Web.FormUrlEncoded             ( FromForm(..)
                                                 , parseUnique
                                                 )
+import           Web.HttpApiData                ( FromHttpApiData(..) )
 
 --------------------------------------------------------------------------------
 -- | This represent a form being filled in. In particular, it can represent
@@ -51,6 +54,27 @@ emptyCreateContract = CreateContract { _createContractProject     = ""
                                      , _createContractType        = ""
                                      , _createContractDescription = ""
                                      }
+
+data AddExpense = AddExpense
+  { _addExpenseCreateContract :: Text
+  , _addExpenseAmount         :: Int
+  }
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm AddExpense where
+  fromForm f =
+    AddExpense <$> parseUnique "contract-key" f <*> parseUnique "amount" f
+
+newtype AddExpenseId = AddExpenseId Text
+  deriving (Eq, Ord, Show)
+  deriving ( IsString
+           , FromJSON
+           , ToJSON
+           , H.ToMarkup
+           , H.ToValue
+           ) via Text
+  deriving (FromHttpApiData, FromForm) via W.Wrapped "user-id" Text
 
 data SubmitContract = SubmitContract
   { _submitContractKey :: Text

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -10,6 +10,7 @@ module Curiosity.Data.Employment
   , emptyCreateContractAll
   , emptyCreateContract
   , AddExpense(..)
+  , emptyAddExpense
   , SubmitContract(..)
   , Contract(..)
   , ContractId(..)
@@ -63,15 +64,15 @@ emptyCreateContract = CreateContract { _createContractProject     = ""
                                      }
 
 data AddExpense = AddExpense
-  { _addExpenseCreateContract :: Text
-  , _addExpenseAmount         :: Int
+  { _addExpenseAmount :: Int
   }
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
 instance FromForm AddExpense where
-  fromForm f =
-    AddExpense <$> parseUnique "contract-key" f <*> parseUnique "amount" f
+  fromForm f = AddExpense <$> parseUnique "amount" f
+
+emptyAddExpense = AddExpense { _addExpenseAmount = 0 }
 
 data SubmitContract = SubmitContract
   { _submitContractKey :: Text

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -34,6 +34,7 @@ module Curiosity.Data.User
   , userProfileRights
   , UserId(..)
   , UserName(..)
+  , UserDisplayName(..)
   , UserEmailAddr(..)
   , Password(..)
   , Predicate(..)
@@ -172,7 +173,7 @@ newtype UserName = UserName { unUserName :: Text }
                           ) via Text
                  deriving (FromHttpApiData, FromForm) via W.Wrapped "username" Text
 
-newtype UserDisplayName = UserDisplayName Text
+newtype UserDisplayName = UserDisplayName { unUserDisplayName :: Text }
                  deriving ( Eq
                           , Show
                           , IsString

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -164,6 +164,7 @@ data AccessRight = CanVerifyEmailAddr | CanDummy
 -- | The username is an identifier (i.e. it is unique).
 newtype UserName = UserName { unUserName :: Text }
                  deriving ( Eq
+                          , Ord
                           , Show
                           , IsString
                           , FromJSON

--- a/src/Curiosity/Form/Login.hs
+++ b/src/Curiosity/Form/Login.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 module Curiosity.Form.Login
   ( Page(..)
-  , ResultPage(..)
   ) where
 
 import           Smart.Html.Dsl                 ( HtmlCanvas )
@@ -104,18 +103,3 @@ loginPage Page {..} = Dsl.SingletonCanvas $ do
             ! A.class_ "u-text-muted"
             ! A.href "/password-reset"
             $ "Forgot password"
-
-
---------------------------------------------------------------------------------
-data ResultPage = Success Text
-                | Failure Text
-
-instance H.ToMarkup ResultPage where
-  toMarkup = \case
-    Success msg -> withText msg
-    Failure msg -> withText msg
-   where
-    withText msg =
-      Render.renderCanvas $ Dsl.SingletonCanvas $
-        H.div ! A.class_ "c-display" $
-          H.code $ H.toMarkup msg

--- a/src/Curiosity/Form/Signup.hs
+++ b/src/Curiosity/Form/Signup.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 module Curiosity.Form.Signup
   ( Page(..)
-  , ResultPage(..)
   , SignupResultPage(..)
   ) where
 
@@ -205,14 +204,3 @@ withMessage title msg = do
         H.div ! A.class_ "c-content" $ H.h1 $ H.toHtml title
 
         H.div ! A.class_ "c-panel" $ H.div ! A.class_ "c-panel__body" $ msg
---------------------------------------------------------------------------------
-data ResultPage = Success Text
-                | Failure Text
-
-instance H.ToMarkup ResultPage where
-  toMarkup = \case
-    Success msg -> withText msg
-    Failure msg -> withText msg
-   where
-    withText msg =
-      Render.renderCanvas $ Dsl.SingletonCanvas $ H.code $ H.toMarkup msg

--- a/src/Curiosity/Html/Action.hs
+++ b/src/Curiosity/Html/Action.hs
@@ -6,6 +6,7 @@ under e.g. `cty user do` and the action menu on table views.
 module Curiosity.Html.Action
   ( SetUserEmailAddrAsVerifiedPage(..)
   , ActionResult(..)
+  , EchoPage(..)
   ) where
 
 import           Curiosity.Data.User           as User
@@ -89,3 +90,19 @@ instance H.ToMarkup ActionResult where
 
 actionResultPanel title msg =
   PanelHeaderAndBody (Types.Title title) $ H.code $ H.text msg
+
+
+--------------------------------------------------------------------------------
+data EchoPage = EchoPage Text
+
+instance H.ToMarkup EchoPage where
+  toMarkup = \case
+    EchoPage msg -> withText msg
+   where
+    withText msg =
+      Render.renderCanvas
+        $ Dsl.SingletonCanvas
+        $ H.div
+        ! A.class_ "c-display"
+        $ H.code
+        $ H.toMarkup msg

--- a/src/Curiosity/Html/Action.hs
+++ b/src/Curiosity/Html/Action.hs
@@ -11,9 +11,7 @@ module Curiosity.Html.Action
 
 import           Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
-import           Curiosity.Html.Profile         ( keyValuePair )
 import qualified Smart.Html.Dsl                as Dsl
-import qualified Smart.Html.Misc               as Misc
 import           Smart.Html.Panel               ( Panel(..) )
 import qualified Smart.Html.Render             as Render
 import qualified Smart.Html.Shared.Types       as Types

--- a/src/Curiosity/Html/Action.hs
+++ b/src/Curiosity/Html/Action.hs
@@ -10,6 +10,7 @@ module Curiosity.Html.Action
   ) where
 
 import           Curiosity.Data.User           as User
+import           Curiosity.Html.Misc
 import           Curiosity.Html.Profile         ( keyValuePair )
 import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Misc               as Misc
@@ -64,21 +65,7 @@ setUserEmailAddrAsVerifiedPanel username profile =
 setUserEmailAddrAsVerifiedForm username = H.form $ do
   H.input ! A.type_ "hidden" ! A.id "username" ! A.name "username" ! A.value
     (H.toValue username)
-  H.div
-    ! A.class_ "o-form-group-layout o-form-group-layout--horizontal"
-    $ H.div
-    ! A.class_ "o-form-group"
-    $ H.div
-    ! A.class_ "u-spacer-left-auto u-spacer-top-l"
-    $ H.button
-    ! A.class_ "c-button c-button--primary"
-    ! A.formaction "/a/set-email-addr-as-verified"
-    ! A.formmethod "POST"
-    $ H.span
-    ! A.class_ "c-button__content"
-    $ do
-        H.span ! A.class_ "c-button__label" $ "Set as verified"
-        Misc.divIconCheck
+  button "/a/set-email-addr-as-verified" "Set as verified"
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Business.hs
+++ b/src/Curiosity/Html/Business.hs
@@ -10,10 +10,6 @@ module Curiosity.Html.Business
 import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
-import           Curiosity.Html.Navbar          ( navbar )
-import qualified Smart.Html.Dsl                as Dsl
-import qualified Smart.Html.Render             as Render
-import           Smart.Html.Shared.Html.Icons   ( svgIconEdit )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A

--- a/src/Curiosity/Html/Business.hs
+++ b/src/Curiosity/Html/Business.hs
@@ -44,6 +44,7 @@ data CreateUnitPage = CreateUnitPage
 
 instance H.ToMarkup CreateUnitPage where
   toMarkup (CreateUnitPage profile submitUrl) =
-    renderForm profile "New business unit" $ do
+    renderForm profile $ groupLayout $ do
+      title "New business unit"
       inputText "Unit name" "name" Nothing Nothing
       submitButton submitUrl "Create new business unit"

--- a/src/Curiosity/Html/Business.hs
+++ b/src/Curiosity/Html/Business.hs
@@ -4,9 +4,11 @@ Description: Business unit pages (view and edit).
 -}
 module Curiosity.Html.Business
   ( UnitView(..)
+  , CreateUnitPage(..)
   ) where
 
 import qualified Curiosity.Data.Business       as Business
+import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
 import           Curiosity.Html.Navbar          ( navbar )
 import qualified Smart.Html.Dsl                as Dsl
@@ -31,3 +33,17 @@ unitView unit hasEditButton = containerLarge $ do
   title' "Business unit" hasEditButton
   H.dl ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short" $ do
     keyValuePair "ID" (Business._entityId unit)
+
+
+--------------------------------------------------------------------------------
+data CreateUnitPage = CreateUnitPage
+  { _createUnitPageUserProfile :: User.UserProfile
+    -- ^ The user creating the unit
+  , _createUnitPageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup CreateUnitPage where
+  toMarkup (CreateUnitPage profile submitUrl) =
+    renderForm profile "New business unit" $ do
+      inputText "Unit name" "name" Nothing Nothing
+      submitButton submitUrl "Create new business unit"

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -6,6 +6,7 @@ module Curiosity.Html.Employment
   ( ContractView(..)
   , CreateContractPage(..)
   , AddExpensePage(..)
+  , RemoveExpensePage(..)
   , ConfirmContractPage(..)
   ) where
 
@@ -163,7 +164,7 @@ groupExpenses mkey expenses submitUrl = do
     ( [show _addExpenseAmount]
     , [ ( Misc.divIconDelete
         , "Remove"
-        , "/echo/remove-expense/" <> key <> "/" <> show i
+        , "/forms/remove-expense/" <> key <> "/" <> show i
         )
       ]
     , (Just $ "/forms/edit-expense/" <> key <> "/" <> show i)
@@ -214,6 +215,32 @@ instance H.ToMarkup AddExpensePage where
       button submitUrl "Add expense"
    where
     mamount = if amount /= 0 then Just (H.toValue amount) else Nothing
+    amount  = Employment._addExpenseAmount expense
+
+
+--------------------------------------------------------------------------------
+data RemoveExpensePage = RemoveExpensePage
+  { _removeExpensePageUserProfile :: User.UserProfile
+    -- ^ The user creating the expense within a contract
+  , _removeExpensePageKey         :: Text
+    -- ^ The key of the contract form
+  , _removeExpensePageIndex       :: Int
+    -- ^ The index of the expense within CreateContractAll
+  , _removeExpensePageExpense     :: Employment.AddExpense
+  , _removeExpensePageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup RemoveExpensePage where
+  toMarkup (RemoveExpensePage profile key mindex expense submitUrl) =
+    renderFormLarge profile $ do
+      title' "Remove expense" Nothing
+
+      panel "General information" $ do
+        keyValuePair "Amount" mamount
+
+      button submitUrl "Remove expense"
+   where
+    mamount = if amount /= 0 then show amount else "/" :: Text
     amount  = Employment._addExpenseAmount expense
 
 

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -150,9 +150,9 @@ groupExpenses mkey expenses submitUrl = do
         $ "When using a project, you can choose to add expenses directly or later."
       H.div ! A.class_ "c-button-toolbar" $ buttonAdd submitUrl "Add expense"
     case mkey of
-      Nothing -> pure ()
-      Just key ->
+      Just key | not (null expenses) ->
         Misc.table titles (uncurry $ display key) $ zip [0 ..] expenses
+      _ -> pure ()
  where
   titles = ["Amount"]
   display
@@ -200,7 +200,7 @@ data AddExpensePage = AddExpensePage
 instance H.ToMarkup AddExpensePage where
   toMarkup (AddExpensePage profile key mindex expense submitUrl) =
     renderFormLarge profile $ do
-      title' "Add expense" Nothing
+      title' label Nothing
 
       panel "General information" $ do
         H.input
@@ -212,8 +212,15 @@ instance H.ToMarkup AddExpensePage where
 
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)
-      button submitUrl "Add expense"
+      buttonBar $ do
+        buttonLink
+          (H.toValue $ "/forms/edit-contract/" <> key <> "#panel-expenses")
+          "Cancel"
+        buttonPrimary
+          submitUrl
+          label
    where
+    label = if isJust mindex then "Update expense" else "Add expense"
     mamount = if amount /= 0 then Just (H.toValue amount) else Nothing
     amount  = Employment._addExpenseAmount expense
 

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -5,6 +5,7 @@ Description: Employment contract pages (view and edit).
 module Curiosity.Html.Employment
   ( ContractView(..)
   , CreateContractPage(..)
+  , ConfirmContractPage(..)
   ) where
 
 import qualified Curiosity.Data.Employment     as Employment
@@ -40,43 +41,43 @@ contractView contract hasEditButton = containerLarge $ do
 data CreateContractPage = CreateContractPage
   { _createContractPageUserProfile :: User.UserProfile
     -- ^ The user creating the contract
-  , _createContractPageSubmitURL   :: H.AttributeValue
+  , _createContractPageSaveURL     :: H.AttributeValue
   }
 
 instance H.ToMarkup CreateContractPage where
-  toMarkup (CreateContractPage profile submitUrl) =
-    renderFormLarge profile $ do
-      title "New employment contract"
-      panel "General information" $ do
+  toMarkup (CreateContractPage profile saveUrl) = renderFormLarge profile $ do
+    title "New employment contract"
+    panel "General information" $ do
 
-        -- TODO I guess this should be the real name ?
-        formKeyValue "Worker name" displayName
-        Misc.inputSelect_ "project"
-                          "Project"
-                          ["Select a project"]
-                          (Just "Enter an existing project or create new one")
-                          True
-        inputText "Purchase order" "po"   Nothing Nothing
-        inputText "Role"           "role" Nothing Nothing
-        inputText "Work type"      "type" Nothing Nothing
-        Misc.inputTextarea "description"
-                           "Description"
-                           6
-                           "Describe your work (minimum 10 characters)"
-                           True
+      -- TODO I guess this should be the real name ?
+      formKeyValue "Worker name" displayName
+      Misc.inputSelect_ "project"
+                        "Project"
+                        ["Select a project"]
+                        (Just "Enter an existing project or create new one")
+                        True
+      inputText "Purchase order" "po"   Nothing Nothing
+      inputText "Role"           "role" Nothing Nothing
+      inputText "Work type"      "type" Nothing Nothing
+      Misc.inputTextarea "description"
+                         "Description"
+                         6
+                         "Describe your work (minimum 10 characters)"
+                         True
 
-      panel "Location and dates" $ do
-        inputText "Work country" "country" Nothing Nothing
-        inputText "Work dates"   "dates"   Nothing Nothing
+    panel "Location and dates" $ do
+      inputText "Work country" "country" Nothing Nothing
+      inputText "Work dates"   "dates"   Nothing Nothing
 
-      panel "Risks" $ groupRisks
-      panel "Invoicing" $ groupInvoicing
-      panel "Expenses" $ groupExpenses
-      panel "Employment type" $ groupEmployment
+    panel "Risks" $ groupRisks
+    panel "Invoicing" $ groupInvoicing
+    panel "Expenses" $ groupExpenses
+    panel "Employment type" $ groupEmployment
 
-      groupLayout $ submitButton submitUrl "Save changes"
+    groupLayout $ do
+      submitButton saveUrl "Save changes"
 
-      autoReload
+    autoReload
    where
     displayName = User.unUserDisplayName $ User._userProfileDisplayName profile
 
@@ -136,3 +137,40 @@ formKeyValue label value = H.div ! A.class_ "o-form-group" $ do
     ! A.class_ "o-form-group__controls o-form-group__controls--full-width"
     $ H.label
     $ H.text value
+
+
+--------------------------------------------------------------------------------
+data ConfirmContractPage = ConfirmContractPage
+  { _confirmContractPageUserProfile :: User.UserProfile
+    -- ^ The user creating the contract
+  , _confirmContractPageKey         :: Text
+  , _confirmContractPageContract    :: Employment.CreateContract
+  , _confirmContractPageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup ConfirmContractPage where
+  toMarkup (ConfirmContractPage profile key contract submitUrl) =
+    renderFormLarge profile $ do
+      title "New employment contract"
+
+      H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
+        (H.toValue key)
+      H.div
+        ! A.class_ "o-form-group-layout o-form-group-layout--horizontal"
+        $ H.div
+        ! A.class_ "o-form-group"
+        $ H.div
+        ! A.class_ "u-spacer-left-auto u-spacer-top-l"
+        $ H.button
+        ! A.class_ "c-button c-button--primary"
+        ! A.formaction submitUrl
+        ! A.formmethod "POST"
+        $ H.span
+        ! A.class_ "c-button__content"
+        $ do
+            H.span ! A.class_ "c-button__label" $ "Submit contract"
+            Misc.divIconCheck
+
+      autoReload
+   where
+    displayName = User.unUserDisplayName $ User._userProfileDisplayName profile

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -12,6 +12,7 @@ import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
 import           Curiosity.Html.Navbar          ( navbar )
 import qualified Smart.Html.Dsl                as Dsl
+import qualified Smart.Html.Misc               as Misc
 import qualified Smart.Html.Render             as Render
 import           Smart.Html.Shared.Html.Icons   ( svgIconEdit )
 import qualified Text.Blaze.Html5              as H
@@ -44,6 +45,94 @@ data CreateContractPage = CreateContractPage
 
 instance H.ToMarkup CreateContractPage where
   toMarkup (CreateContractPage profile submitUrl) =
-    renderForm profile "New employment contract" $ do
-      inputText "Contract name" "name" Nothing Nothing
-      submitButton submitUrl "Create new employment contract"
+    renderFormLarge profile $ do
+      title "New employment contract"
+      panel "General information" $ do
+
+        -- TODO I guess this should be the real name ?
+        formKeyValue "Worker name" displayName
+        Misc.inputSelect_ "project"
+                          "Project"
+                          ["Select a project"]
+                          (Just "Enter an existing project or create new one")
+                          True
+        inputText "Purchase order" "po"   Nothing Nothing
+        inputText "Role"           "role" Nothing Nothing
+        inputText "Work type"      "type" Nothing Nothing
+        Misc.inputTextarea "description"
+                           "Description"
+                           6
+                           "Describe your work (minimum 10 characters)"
+                           True
+
+      panel "Location and dates" $ do
+        inputText "Work country" "country" Nothing Nothing
+        inputText "Work dates"   "dates"   Nothing Nothing
+
+      panel "Risks" $ groupRisks
+      panel "Invoicing" $ groupInvoicing
+      panel "Expenses" $ groupExpenses
+      panel "Employment type" $ groupEmployment
+
+      groupLayout $ submitButton submitUrl "Save changes"
+
+      autoReload
+   where
+    displayName = User.unUserDisplayName $ User._userProfileDisplayName profile
+
+groupRisks = H.div ! A.class_ "o-form-group" $ do
+  H.label ! A.class_ "o-form-group__label" $ "Work risks"
+  H.div
+    ! A.class_ "o-form-group__controls"
+    $ H.div
+    ! A.class_ "c-radio-group c-radio-group--inline"
+    $ do
+        H.div ! A.class_ "c-radio" $ H.label $ do
+          H.input ! A.type_ "radio" ! A.name "radio1"
+          "Without risks"
+        H.div ! A.class_ "c-radio" $ H.label $ do
+          H.input ! A.type_ "radio" ! A.name "radio1"
+          "With risks"
+        H.p ! A.class_ "c-form-help-text" $ do
+          "For your safety and your colleagues safety, if your role "
+          "involves risks, you have to select \"With risks\". "
+          H.a ! A.class_ "c-link" ! A.href "#" $ "Learn more about risks."
+
+groupInvoicing = do
+  inputText "Client" "client" Nothing Nothing
+  inputText "Amount" "amount" Nothing Nothing
+  inputText "VAT"    "vat"    Nothing Nothing
+  H.div ! A.class_ "o-form-group" $ do
+    H.label ! A.class_ "o-form-group__label" $ "Include VAT ?"
+    H.div
+      ! A.class_ "o-form-group__controls"
+      $ H.div
+      ! A.class_ "c-radio-group c-radio-group--inline"
+      $ do
+          H.div ! A.class_ "c-radio" $ H.label $ do
+            H.input ! A.type_ "radio" ! A.name "radio2"
+            "Include"
+          H.div ! A.class_ "c-radio" $ H.label $ do
+            H.input ! A.type_ "radio" ! A.name "radio2"
+            "Exclude"
+          H.p
+            ! A.class_ "c-form-help-text"
+            $ "Usually, business clients prefer to see amounts VAT excluded."
+  inputText "Down payment" "down-payment" Nothing Nothing
+
+groupExpenses = H.p ! A.class_ "c-form-help-text" $ do
+  "When using a project, you can choose to add expenses directly or later. "
+  H.a ! A.class_ "c-link" ! A.href "#" $ "Add an expense now."
+
+groupEmployment = do
+  inputText "Withholding tax"     "withholding-tax" Nothing Nothing
+  inputText "Student / au cachet" "TODO"            Nothing Nothing
+  inputText "Interim"             "interim"         Nothing Nothing
+
+formKeyValue :: Text -> Text -> H.Html
+formKeyValue label value = H.div ! A.class_ "o-form-group" $ do
+  H.label ! A.class_ "o-form-group__label" $ H.text label
+  H.div
+    ! A.class_ "o-form-group__controls o-form-group__controls--full-width"
+    $ H.label
+    $ H.text value

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -143,16 +143,20 @@ groupInvoicing = do
 
 groupExpenses mkey expenses submitUrl = do
   H.div ! A.class_ "o-form-group" $ do
-    H.label ! A.class_ "o-form-group__label" $ "Add expenses (optional)"
-    H.div ! A.class_ "c-blank-slate c-blank-slate--bg-alt" $ do
-      H.p
-        ! A.class_ "u-text-muted c-body-1"
-        $ "When using a project, you can choose to add expenses directly or later."
-      H.div ! A.class_ "c-button-toolbar" $ buttonAdd submitUrl "Add expense"
+    when (null expenses)
+      $ H.div
+      ! A.class_ "c-blank-slate c-blank-slate--bg-alt"
+      $ do
+          H.p
+            ! A.class_ "u-text-muted c-body-1"
+            $ "When using a project, you can choose to add expenses directly or later."
+          H.div ! A.class_ "c-button-toolbar" $ buttonAdd submitUrl
+                                                          "Add expense"
     case mkey of
       Just key | not (null expenses) ->
         Misc.table titles (uncurry $ display key) $ zip [0 ..] expenses
       _ -> pure ()
+    when (not $ null expenses) $ buttonGroup $ buttonAdd submitUrl "Add expense"
  where
   titles = ["Amount"]
   display
@@ -216,11 +220,9 @@ instance H.ToMarkup AddExpensePage where
         buttonLink
           (H.toValue $ "/forms/edit-contract/" <> key <> "#panel-expenses")
           "Cancel"
-        buttonPrimary
-          submitUrl
-          label
+        buttonPrimary submitUrl label
    where
-    label = if isJust mindex then "Update expense" else "Add expense"
+    label   = if isJust mindex then "Update expense" else "Add expense"
     mamount = if amount /= 0 then Just (H.toValue amount) else Nothing
     amount  = Employment._addExpenseAmount expense
 

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -271,7 +271,9 @@ instance H.ToMarkup ConfirmContractPage where
         $  "/forms/edit-contract/"
         <> key
 
-      H.toMarkup
+      H.div
+        ! A.class_ "u-padding-vertical-l"
+        $ H.toMarkup
         $ PanelHeaderAndBody "General information"
         $ H.dl
         ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
@@ -283,6 +285,19 @@ instance H.ToMarkup ConfirmContractPage where
             keyValuePair "Work type"      _createContractType
             keyValuePair "Description"    _createContractDescription
 
+      H.div
+        ! A.class_ "u-padding-vertical-l"
+        $ H.toMarkup
+        $ PanelHeaderAndBody "Expenses"
+        $ H.dl
+        ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
+        $ if null expenses
+            then H.div ! A.class_ "c-blank-slate c-blank-slate--bg-alt" $ do
+              H.p
+                ! A.class_ "u-text-muted c-body-1"
+                $ "You have no expenses right now."
+            else Misc.table titles (uncurry $ display key) $ zip [0 ..] expenses
+
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)
       button submitUrl "Submit contract"
@@ -290,3 +305,11 @@ instance H.ToMarkup ConfirmContractPage where
       autoReload
    where
     displayName = User.unUserDisplayName $ User._userProfileDisplayName profile
+    titles      = ["Amount"]
+    display
+      :: Text
+      -> Int
+      -> Employment.AddExpense
+      -> ([Text], [(H.Html, Text, Text)], Maybe Text)
+    display key i Employment.AddExpense {..} =
+      ([show _addExpenseAmount], [], Nothing)

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -12,12 +12,8 @@ module Curiosity.Html.Employment
 import qualified Curiosity.Data.Employment     as Employment
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
-import           Curiosity.Html.Navbar          ( navbar )
-import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Misc               as Misc
 import           Smart.Html.Panel               ( Panel(..) )
-import qualified Smart.Html.Render             as Render
-import           Smart.Html.Shared.Html.Icons   ( svgIconEdit )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
@@ -212,8 +208,6 @@ instance H.ToMarkup AddExpensePage where
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)
       button submitUrl "Add expense"
-   where
-    displayName = User.unUserDisplayName $ User._userProfileDisplayName profile
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -4,9 +4,11 @@ Description: Employment contract pages (view and edit).
 -}
 module Curiosity.Html.Employment
   ( ContractView(..)
+  , CreateContractPage(..)
   ) where
 
 import qualified Curiosity.Data.Employment     as Employment
+import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
 import           Curiosity.Html.Navbar          ( navbar )
 import qualified Smart.Html.Dsl                as Dsl
@@ -31,3 +33,17 @@ contractView contract hasEditButton = containerLarge $ do
   title' "Employment contract" hasEditButton
   H.dl ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short" $ do
     keyValuePair "ID" (Employment._contractId contract)
+
+
+--------------------------------------------------------------------------------
+data CreateContractPage = CreateContractPage
+  { _createContractPageUserProfile :: User.UserProfile
+    -- ^ The user creating the contract
+  , _createContractPageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup CreateContractPage where
+  toMarkup (CreateContractPage profile submitUrl) =
+    renderForm profile "New employment contract" $ do
+      inputText "Contract name" "name" Nothing Nothing
+      submitButton submitUrl "Create new employment contract"

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -166,7 +166,7 @@ groupExpenses mkey expenses submitUrl = do
         , "/echo/remove-expense/" <> key <> "/" <> show i
         )
       ]
-    , (Just $ "/echo/edit-expense/" <> key <> "/" <> show i)
+    , (Just $ "/forms/edit-expense/" <> key <> "/" <> show i)
     )
 
 groupEmployment = do
@@ -189,11 +189,15 @@ data AddExpensePage = AddExpensePage
     -- ^ The user creating the expense within a contract
   , _addExpensePageKey         :: Text
     -- ^ The key of the contract form
+  , _addExpensePageIndex       :: Maybe Int
+    -- ^ The index of the expense within CreateContractAll, if it was already
+    -- added
+  , _addExpensePageExpense     :: Employment.AddExpense
   , _addExpensePageSubmitURL   :: H.AttributeValue
   }
 
 instance H.ToMarkup AddExpensePage where
-  toMarkup (AddExpensePage profile key submitUrl) =
+  toMarkup (AddExpensePage profile key mindex expense submitUrl) =
     renderFormLarge profile $ do
       title' "Add expense" Nothing
 
@@ -203,11 +207,14 @@ instance H.ToMarkup AddExpensePage where
           ! A.id "contract-key"
           ! A.name "contract-key"
           ! A.value (H.toValue key)
-        inputText "Amount" "amount" Nothing Nothing
+        inputText "Amount" "amount" mamount Nothing
 
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)
       button submitUrl "Add expense"
+   where
+    mamount = if amount /= 0 then Just (H.toValue amount) else Nothing
+    amount  = Employment._addExpenseAmount expense
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -43,14 +43,14 @@ contractView contract hasEditButton = containerLarge $ do
 data CreateContractPage = CreateContractPage
   { _createContractPageUserProfile   :: User.UserProfile
     -- ^ The user creating the contract
-  , _createContractContract          :: Employment.CreateContract
+  , _createContractContract          :: Employment.CreateContractAll
     -- ^ The contract being edited
   , _createContractPageSaveURL       :: H.AttributeValue
   , _createContractPageAddExpenseURL :: H.AttributeValue
   }
 
 instance H.ToMarkup CreateContractPage where
-  toMarkup (CreateContractPage profile Employment.CreateContract {..} saveUrl addExpenseUrl)
+  toMarkup (CreateContractPage profile (Employment.CreateContractAll Employment.CreateContract {..} expenses) saveUrl addExpenseUrl)
     = renderFormLarge profile $ do
       title "New employment contract"
       panel "General information" $ do
@@ -197,12 +197,12 @@ data ConfirmContractPage = ConfirmContractPage
   { _confirmContractPageUserProfile :: User.UserProfile
     -- ^ The user creating the contract
   , _confirmContractPageKey         :: Text
-  , _confirmContractPageContract    :: Employment.CreateContract
+  , _confirmContractPageContract    :: Employment.CreateContractAll
   , _confirmContractPageSubmitURL   :: H.AttributeValue
   }
 
 instance H.ToMarkup ConfirmContractPage where
-  toMarkup (ConfirmContractPage profile key Employment.CreateContract {..} submitUrl)
+  toMarkup (ConfirmContractPage profile key (Employment.CreateContractAll Employment.CreateContract {..} expenses) submitUrl)
     = renderFormLarge profile $ do
       title' "New employment contract"
         .  Just

--- a/src/Curiosity/Html/Invoice.hs
+++ b/src/Curiosity/Html/Invoice.hs
@@ -10,10 +10,6 @@ module Curiosity.Html.Invoice
 import qualified Curiosity.Data.Invoice        as Invoice
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
-import           Curiosity.Html.Navbar          ( navbar )
-import qualified Smart.Html.Dsl                as Dsl
-import qualified Smart.Html.Render             as Render
-import           Smart.Html.Shared.Html.Icons   ( svgIconEdit )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A

--- a/src/Curiosity/Html/Invoice.hs
+++ b/src/Curiosity/Html/Invoice.hs
@@ -44,6 +44,7 @@ data CreateInvoicePage = CreateInvoicePage
 
 instance H.ToMarkup CreateInvoicePage where
   toMarkup (CreateInvoicePage profile submitUrl) =
-    renderForm profile "New invoice" $ do
+    renderForm profile $ groupLayout $ do
+      title "New invoice"
       inputText "Invoice name" "name" Nothing Nothing
       submitButton submitUrl "Create new invoice"

--- a/src/Curiosity/Html/Invoice.hs
+++ b/src/Curiosity/Html/Invoice.hs
@@ -4,9 +4,11 @@ Description: Invoice pages (view and edit).
 -}
 module Curiosity.Html.Invoice
   ( InvoiceView(..)
+  , CreateInvoicePage(..)
   ) where
 
 import qualified Curiosity.Data.Invoice        as Invoice
+import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
 import           Curiosity.Html.Navbar          ( navbar )
 import qualified Smart.Html.Dsl                as Dsl
@@ -31,3 +33,17 @@ invoiceView invoice hasEditButton = containerLarge $ do
   title' "Invoice" hasEditButton
   H.dl ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short" $ do
     keyValuePair "ID" (Invoice._entityId invoice)
+
+
+--------------------------------------------------------------------------------
+data CreateInvoicePage = CreateInvoicePage
+  { _createInvoicePageUserProfile :: User.UserProfile
+    -- ^ The user creating the invoice
+  , _createInvoicePageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup CreateInvoicePage where
+  toMarkup (CreateInvoicePage profile submitUrl) =
+    renderForm profile "New invoice" $ do
+      inputText "Invoice name" "name" Nothing Nothing
+      submitButton submitUrl "Create new invoice"

--- a/src/Curiosity/Html/Legal.hs
+++ b/src/Curiosity/Html/Legal.hs
@@ -10,9 +10,6 @@ module Curiosity.Html.Legal
 import qualified Curiosity.Data.Legal          as Legal
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
-import           Curiosity.Html.Navbar          ( navbar )
-import qualified Smart.Html.Dsl                as Dsl
-import qualified Smart.Html.Render             as Render
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A

--- a/src/Curiosity/Html/Legal.hs
+++ b/src/Curiosity/Html/Legal.hs
@@ -46,7 +46,8 @@ data CreateEntityPage = CreateEntityPage
 
 instance H.ToMarkup CreateEntityPage where
   toMarkup (CreateEntityPage profile submitUrl) =
-    renderForm profile "New legal entity" $ do
+    renderForm profile $ groupLayout $ do
+      title "New legal entity"
       inputText "Registration name" "name" Nothing Nothing
       inputText "CBE number" "cbe-number" Nothing $ Just "Example: 100200300"
       inputText "VAT number" "vat-number" Nothing $ Just "Example: BE0100200300"

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -9,6 +9,8 @@ module Curiosity.Html.Misc
   , containerLarge
   , keyValuePair
   , fullScroll
+  , groupLayout
+  , panel
 
   -- Form
   , title
@@ -22,7 +24,7 @@ module Curiosity.Html.Misc
   -- Keep here:
   , renderView
   , renderForm
-
+  , renderFormLarge
   , autoReload
   ) where
 
@@ -85,24 +87,45 @@ renderView content =
         H.header $ H.toMarkup . navbar $ "TODO username"
         fullScroll content
 
-renderForm :: User.UserProfile -> Text -> Html -> Html
-renderForm profile s content =
+renderForm :: User.UserProfile -> Html -> Html
+renderForm profile content =
   Render.renderCanvasFullScroll
     . Dsl.SingletonCanvas
     $ H.div
     ! A.class_ "c-app-layout u-scroll-vertical"
     $ do
-        H.header
-          $ H.toMarkup
-          . navbar
-          . User.unUserName
-          . User._userCredsName
-          $ User._userProfileCreds profile
+        H.header $ navbar' profile
         H.main ! A.class_ "u-maximize-width" $ containerMedium $ do
-          title s
-          H.div
-            ! A.class_ "o-form-group-layout o-form-group-layout--horizontal"
-            $ H.form content
+          H.form $ content
+
+renderFormLarge :: User.UserProfile -> Html -> Html
+renderFormLarge profile content =
+  Render.renderCanvasFullScroll
+    . Dsl.SingletonCanvas
+    $ H.div
+    ! A.class_ "c-app-layout u-scroll-vertical"
+    $ do
+        H.header $ navbar' profile
+        H.main ! A.class_ "u-maximize-width" $ containerLarge $ do
+          H.form $ content
+
+navbar' profile =
+  H.toMarkup
+    . navbar
+    . User.unUserName
+    . User._userCredsName
+    $ User._userProfileCreds profile
+
+panel s content = H.div ! A.class_ "c-panel u-spacer-bottom-l" $ do
+  H.div ! A.class_ "c-panel__header" $ H.h2 ! A.class_ "c-panel__title" $ H.text
+    s
+  H.div ! A.class_ "c-panel__body" $ groupLayout $ do
+    content
+
+groupLayout content =
+  H.div
+    ! A.class_ "o-form-group-layout o-form-group-layout--horizontal"
+    $ content
 
 
 --------------------------------------------------------------------------------
@@ -176,8 +199,9 @@ editButton lnk =
 -- thus add this element temporarily to a page when you're hacking at it using
 -- something like ghcid.
 {-# DEPRECATED autoReload "Use this only during interactive development" #-}
-autoReload = H.preEscapedText
-  "<script>\n\
+autoReload =
+  H.preEscapedText
+    "<script>\n\
   \function connect(isInitialConnection) {\n\
   \  // Create WebSocket connection.\n\
   \  var ws = new WebSocket('ws://' + location.host + '/ws');\n\

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -19,7 +19,11 @@ module Curiosity.Html.Misc
   , inputText
   , submitButton
   , button
+  , buttonLink
   , buttonAdd
+  , buttonGroup
+  , buttonBar
+  , buttonPrimary
 
   -- View
   , editButton
@@ -191,14 +195,40 @@ submitButton submitUrl label =
     ! A.class_ "c-button__label"
     $ label
 
-button submitUrl label =
+buttonGroup content =
   H.div
     ! A.class_ "o-form-group-layout o-form-group-layout--horizontal"
     $ H.div
     ! A.class_ "o-form-group"
     $ H.div
     ! A.class_ "u-spacer-left-auto u-spacer-top-l"
-    $ H.button
+    $ content
+
+buttonBar content =
+  H.div
+    ! A.class_ "c-toolbar"
+    $ H.div
+    ! A.class_ "c-toolbar__right"
+    $ H.div
+    ! A.class_ "c-toolbar__item"
+    $ H.div
+    ! A.class_ "c-button-toolbar"
+    $ content
+
+button submitUrl label = buttonGroup $ buttonPrimary submitUrl label
+
+buttonLink url label =
+  H.a
+    ! A.class_ "c-button c-button--secondary"
+    ! A.href url
+    $ H.div
+    ! A.class_ "c-button__content"
+    $ H.div
+    ! A.class_ "c-button__label"
+    $ H.text label
+
+buttonPrimary submitUrl label =
+  H.button
     ! A.class_ "c-button c-button--primary"
     ! A.formaction submitUrl
     ! A.formmethod "POST"

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -17,6 +17,7 @@ module Curiosity.Html.Misc
   , title'
   , inputText
   , submitButton
+  , button
 
   -- View
   , editButton
@@ -32,7 +33,9 @@ import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Navbar          ( navbar )
 import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Render             as Render
-import           Smart.Html.Shared.Html.Icons   ( svgIconEdit )
+import           Smart.Html.Shared.Html.Icons   ( divIconCheck
+                                                , svgIconEdit
+                                                )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!)
                                                 , Html
@@ -177,6 +180,23 @@ submitButton submitUrl label =
     $ H.span
     ! A.class_ "c-button__label"
     $ label
+
+button submitUrl label =
+  H.div
+    ! A.class_ "o-form-group-layout o-form-group-layout--horizontal"
+    $ H.div
+    ! A.class_ "o-form-group"
+    $ H.div
+    ! A.class_ "u-spacer-left-auto u-spacer-top-l"
+    $ H.button
+    ! A.class_ "c-button c-button--primary"
+    ! A.formaction submitUrl
+    ! A.formmethod "POST"
+    $ H.span
+    ! A.class_ "c-button__content"
+    $ do
+        H.span ! A.class_ "c-button__label" $ H.text label
+        divIconCheck
 
 --------------------------------------------------------------------------------
 editButton :: H.AttributeValue -> Html

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -11,6 +11,7 @@ module Curiosity.Html.Misc
   , fullScroll
   , groupLayout
   , panel
+  , panelStandard
 
   -- Form
   , title
@@ -18,6 +19,7 @@ module Curiosity.Html.Misc
   , inputText
   , submitButton
   , button
+  , buttonAdd
 
   -- View
   , editButton
@@ -33,7 +35,8 @@ import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Navbar          ( navbar )
 import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Render             as Render
-import           Smart.Html.Shared.Html.Icons   ( divIconCheck
+import           Smart.Html.Shared.Html.Icons   ( divIconAdd
+                                                , divIconCheck
                                                 , svgIconEdit
                                                 )
 import qualified Text.Blaze.Html5              as H
@@ -122,13 +125,20 @@ navbar' profile =
 panel s content = H.div ! A.class_ "c-panel u-spacer-bottom-l" $ do
   H.div ! A.class_ "c-panel__header" $ H.h2 ! A.class_ "c-panel__title" $ H.text
     s
-  H.div ! A.class_ "c-panel__body" $ groupLayout $ do
-    content
+  H.div ! A.class_ "c-panel__body" $ groupLayout $ content
+
+panelStandard s content = H.div ! A.class_ "c-panel u-spacer-bottom-l" $ do
+  H.div ! A.class_ "c-panel__header" $ H.h2 ! A.class_ "c-panel__title" $ H.text
+    s
+  H.div ! A.class_ "c-panel__body" $ groupLayoutStandard $ content
 
 groupLayout content =
   H.div
     ! A.class_ "o-form-group-layout o-form-group-layout--horizontal"
     $ content
+
+groupLayoutStandard content =
+  H.div ! A.class_ "o-form-group-layout o-form-group-layout--standard" $ content
 
 
 --------------------------------------------------------------------------------
@@ -197,6 +207,17 @@ button submitUrl label =
     $ do
         H.span ! A.class_ "c-button__label" $ H.text label
         divIconCheck
+
+buttonAdd submitUrl label =
+  H.button
+    ! A.class_ "c-button c-button--secondary"
+    ! A.formaction submitUrl
+    ! A.formmethod "POST"
+    $ H.span
+    ! A.class_ "c-button__content"
+    $ do
+        H.toMarkup divIconAdd
+        H.span ! A.class_ "c-button__label" $ H.text label
 
 --------------------------------------------------------------------------------
 editButton :: H.AttributeValue -> Html

--- a/src/Curiosity/Html/Navbar.hs
+++ b/src/Curiosity/Html/Navbar.hs
@@ -39,9 +39,9 @@ plusEntry = Navbar.IconEntry divIconAdd plusEntries
 
 plusEntries :: [Navbar.SubEntry]
 plusEntries =
-  [ Navbar.SubEntry "New invoice" "#" False
-  , Navbar.SubEntry "New contract" "#" False
+  [ Navbar.SubEntry "New invoice" "/new/invoice" False
+  , Navbar.SubEntry "New contract" "/new/contract" False
   , Navbar.Divider
-  , Navbar.SubEntry "New business entity" "#" False
+  , Navbar.SubEntry "New business entity" "/new/unit" False
   , Navbar.SubEntry "New legal entity" "/new/entity" False
   ]

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -7,7 +7,6 @@ module Curiosity.Html.Profile
   , ProfileView(..)
   , PublicProfileView(..)
   , ProfileSaveConfirmPage(..)
-  , keyValuePair -- TODO Move to Misc.
   ) where
 
 import qualified Curiosity.Data.User           as User

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -36,7 +36,8 @@ data ProfilePage = ProfilePage
 
 instance H.ToMarkup ProfilePage where
   toMarkup (ProfilePage profile submitUrl) =
-    renderForm profile "User profile" $ do
+    renderForm profile $ groupLayout $ do
+      title "User profile"
       inputText
           "Username"
           "username"

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -31,6 +31,7 @@ module Curiosity.Runtime
   -- * Form edition
   , newCreateContractForm
   , readCreateContractForm
+  , writeCreateContractForm
   -- * Servant compat
   , appMHandlerNatTrans
   ) where
@@ -556,6 +557,19 @@ readCreateContractForm db (profile, key) = do
   let mform = M.lookup (username, key) m
   pure $ maybe (Left ()) Right mform
   where username = User._userCredsName $ User._userProfileCreds profile
+
+writeCreateContractForm
+  :: forall runtime
+   . Data.StmDb runtime
+  -> (User.UserProfile, Text, Employment.CreateContract)
+  -> STM Text
+writeCreateContractForm db (profile, key, c) = do
+  STM.modifyTVar (Data._dbFormCreateContract db) save
+  pure key
+ where
+  -- TODO Return an error when the key is not found.
+  save     = M.adjust (const c) (username, key)
+  username = User._userCredsName $ User._userProfileCreds profile
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -93,6 +93,7 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
              :<|> "forms" :> "login" :> Get '[B.HTML] Login.Page
              :<|> "forms" :> "signup" :> Get '[B.HTML] Signup.Page
              :<|> "forms" :> "profile" :> Get '[B.HTML] Pages.ProfilePage
+             :<|> "forms" :> "new-contract" :> Get '[B.HTML] Pages.CreateContractPage
 
              :<|> "views" :> "profile"
                   :> Capture "filename" FilePath
@@ -158,6 +159,8 @@ serverT conf jwtS root dataDir =
     :<|> documentLoginPage
     :<|> documentSignupPage
     :<|> documentEditProfilePage
+    :<|> documentCreateContractPage
+
     :<|> documentProfilePage dataDir
     :<|> documentEntityPage dataDir
     :<|> documentUnitPage dataDir
@@ -558,6 +561,11 @@ documentEditProfilePage :: ServerC m => m Pages.ProfilePage
 documentEditProfilePage = do
   profile <- readJson "data/alice.json"
   pure $ Pages.ProfilePage profile "/echo/profile"
+
+documentCreateContractPage :: ServerC m => m Pages.CreateContractPage
+documentCreateContractPage = do
+  profile <- readJson "data/alice.json"
+  pure $ Pages.CreateContractPage profile "/echo/new-contract"
 
 -- TODO Validate the filename (e.g. this can't be a path going up).
 documentProfilePage :: ServerC m => FilePath -> FilePath -> m Pages.ProfileView

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -555,6 +555,7 @@ showCreateContractPage
   :: ServerC m => User.UserProfile -> m Pages.CreateContractPage
 showCreateContractPage profile = pure $ Pages.CreateContractPage
   profile
+  Nothing
   Employment.emptyCreateContractAll
   "/a/new-contract"
   "/a/new-contract-and-add-expense"
@@ -622,6 +623,7 @@ documentCreateContractPage = do
   profile <- readJson "data/alice.json"
   let contractAll = Employment.emptyCreateContractAll
   pure $ Pages.CreateContractPage profile
+                                  Nothing
                                   contractAll
                                   "/echo/new-contract"
                                   "/echo/new-contract-and-add-expense"
@@ -635,6 +637,7 @@ documentEditContractPage key = do
   case output of
     Right contractAll -> pure $ Pages.CreateContractPage
       profile
+      (Just key)
       contractAll
       (H.toValue $ "/echo/save-contract/" <> key)
       (H.toValue $ "/echo/save-contract-and-add-expense/" <> key)

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -437,6 +437,9 @@ type Private = H.UserAuthentication :> (
                    :> Get '[B.HTML] Pages.ProfilePage
 
              :<|> "new" :> "entity" :> Get '[B.HTML] Pages.CreateEntityPage
+             :<|> "new" :> "unit" :> Get '[B.HTML] Pages.CreateUnitPage
+             :<|> "new" :> "contract" :> Get '[B.HTML] Pages.CreateContractPage
+             :<|> "new" :> "invoice" :> Get '[B.HTML] Pages.CreateInvoicePage
 
              :<|>  "a" :>"set-user-profile"
                    :> ReqBody '[FormUrlEncoded] User.Update
@@ -457,6 +460,9 @@ privateT conf authResult =
         :<|> (withUser' showProfileAsJson)
         :<|> (withUser' showEditProfilePage)
         :<|> (withUser' showCreateEntityPage)
+        :<|> (withUser' showCreateUnitPage)
+        :<|> (withUser' showCreateContractPage)
+        :<|> (withUser' showCreateInvoicePage)
         :<|> (withUser' . handleUserUpdate)
         :<|> (withUser' $ const (handleLogout conf))
         :<|> (withUser' . handleSetUserEmailAddrAsVerified)
@@ -486,6 +492,19 @@ showCreateEntityPage
   :: ServerC m => User.UserProfile -> m Pages.CreateEntityPage
 showCreateEntityPage profile =
   pure $ Pages.CreateEntityPage profile "/a/new-entity"
+
+showCreateUnitPage :: ServerC m => User.UserProfile -> m Pages.CreateUnitPage
+showCreateUnitPage profile = pure $ Pages.CreateUnitPage profile "/a/new-unit"
+
+showCreateContractPage
+  :: ServerC m => User.UserProfile -> m Pages.CreateContractPage
+showCreateContractPage profile =
+  pure $ Pages.CreateContractPage profile "/a/new-contract"
+
+showCreateInvoicePage
+  :: ServerC m => User.UserProfile -> m Pages.CreateInvoicePage
+showCreateInvoicePage profile =
+  pure $ Pages.CreateInvoicePage profile "/a/new-invoice"
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This is the beginning of a form to create a contract. It is not yet complete and mixes fields from the original 3in1 application ("Tools", where contract, invoice, and expense data are filled in at once) and from the "Activité" forms ("Desk", where the three objects can be filled separately). The goal was mainly to get the general mechanism done (e.g. a confirmation screen, a separate screen for separate objects, ...).

There is now:

- A main page to start an form editing session
- Data associated to that session. The Contract part and the Expense part are separated, so they can be filled on different screens
- A second page to add/edit expenses
- A confirmation page
- Links and buttons to add/edit/remove expenses or cancel the action

All the above is wired in to the documentation routes (i.e. `/forms` and `/echo`), not yet to the application routes.