### PR TITLE
Add a simple websocket-based auto-reload mechanism

### DIFF
--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -49,6 +49,7 @@ common common-dependencies
     , lens
     , exceptions
     , random
+    , splitmix
 
     , megaparsec
 
@@ -71,6 +72,7 @@ common common-dependencies
     , jose
     , wai
     , warp
+    , websockets
 
     , aeson
     , blaze

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -65,6 +65,7 @@ common common-dependencies
     , servant
     , servant-blaze
     , servant-server
+    , servant-websockets
     -- Authentication: use Jose based JWK settings as well.
     , servant-auth-server
     , jose

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,7 +14,7 @@
     "design-hs": {
         "branch": "main",
         "repo": "git@github.com:hypered/smart-design-hs.git",
-	"rev": "d972f6c11ed3b8534a7e91659979c5c8ab854b0c",
+        "rev": "68c9eb3fa14397fb4d861f33f1dd8f3689ad2266",
         "type": "git"
     },
     "gitignore": {

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -22,6 +22,8 @@ module Curiosity.Html.Misc
   -- Keep here:
   , renderView
   , renderForm
+
+  , autoReload
   ) where
 
 import qualified Curiosity.Data.User           as User
@@ -166,3 +168,48 @@ editButton lnk =
     $ do
         H.div ! A.class_ "o-svg-icon o-svg-icon-edit" $ H.toHtml svgIconEdit
         H.span ! A.class_ "c-button__label" $ "Edit"
+
+
+--------------------------------------------------------------------------------
+-- | This is a script to connect to the backend using websocket, and reload the
+-- page when the connection is lost (and then successfully re-created). You can
+-- thus add this element temporarily to a page when you're hacking at it using
+-- something like ghcid.
+{-# DEPRECATED autoReload "Use this only during interactive development" #-}
+autoReload = H.preEscapedText
+  "<script>\n\
+  \function connect(isInitialConnection) {\n\
+  \  // Create WebSocket connection.\n\
+  \  var ws = new WebSocket('ws://' + location.host + '/ws');\n\
+  \\n\
+  \  // Connection opened\n\
+  \  ws.onopen = function() {\n\
+  \    ws.send('Hello server.');\n\
+  \    if (isInitialConnection) {\n\
+  \      console.log('autoreload: Initial connection.');\n\
+  \    } else {\n\
+  \      console.log('autoreload: Reconnected.');\n\
+  \      location.reload();\n\
+  \    };\n\
+  \  };\n\
+  \\n\
+  \  // Listen for messages.\n\
+  \  ws.onmessage = function(ev) {\n\
+  \    console.log('autoreload: Message from server: ', ev.data);\n\
+  \  };\n\
+  \\n\
+  \  // Trying to reconnect when the socket is closed.\n\
+  \  ws.onclose = function(ev) {\n\
+  \    console.log('autoreload: Socket closed. Trying to reconnect in 0.5 second.');\n\
+  \    setTimeout(function() { connect(false); }, 500);\n\
+  \  };\n\
+  \\n\
+  \  // Close the socker upon error.\n\
+  \  ws.onerror = function(err) {\n\
+  \    console.log('autoreload: Socket errored. Closing socket.');\n\
+  \    ws.close();\n\
+  \  };\n\
+  \}\n\
+  \\n\
+  \connect(true);\n\
+  \</script>\n"


### PR DESCRIPTION
This add a simple websocket-based mechanism to auto-reload a page when the server is restarted (typically used with `ghcid`). See first commit message.