### PR TITLE
Improve the cty command-line

### DIFF
--- a/data/alice.json
+++ b/data/alice.json
@@ -2,12 +2,12 @@
   "_userProfileId": "USER-1",
   "_userProfileCreds": {
     "_userCredsName": "alice",
-    "_userCredsPassword": "secret"
+    "_userCredsPassword": "a"
   },
   "_userProfileEmailAddr": "alice@example.com",
-  "_userProfileDisplayName": "Alice",
-  "_userProfileTosConsent": false,
+  "_userProfileDisplayName": "TODO",
+  "_userProfileTosConsent": true,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
-  "_userProfileRights": []
+  "_userProfileRights": ["CanVerifyEmailAddr"]
 }

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -61,6 +61,8 @@ data Command =
     -- ^ Execute the next automated action when using stepped (non-wallclock)
     -- mode, or mixed-mode, or the next automated action when the automation is
     -- "disabled".
+  | Log Text P.Conf
+    -- Log a line of text to the logs.
   | ShowId Text
     -- ^ If not a command per se, assume it's an ID to be looked up.
   deriving (Eq, Show)
@@ -257,6 +259,12 @@ parser =
            "step"
            ( A.info (pure Step <**> A.helper)
            $ A.progDesc "Run the next automated action"
+           )
+
+      <> A.command
+           "log"
+           ( A.info (parserLog <**> A.helper)
+           $ A.progDesc "Log a message to the logs"
            )
       )
     <|> parserShowId
@@ -490,6 +498,12 @@ parserQueues =
             <> A.metavar "USERNAME"
             )
         )
+
+parserLog :: A.Parser Command
+parserLog =
+  Log
+    <$> A.argument A.str (A.metavar "MESSAGE" <> A.help "A line of text")
+    <*> P.confParser
 
 parserShowId :: A.Parser Command
 parserShowId =

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -29,6 +29,8 @@ data Command =
     -- ^ Display the routing layout of the web server.
   | Init
     -- ^ Initialise a new, empty state file.
+  | Reset P.Conf
+    -- ^ Set the state file to the empty state.
   | Repl P.Conf
     -- ^ Run a REPL.
   | Serve P.Conf P.ServerConf
@@ -171,6 +173,12 @@ parser =
            )
 
       <> A.command
+           "reset"
+           ( A.info (parserReset <**> A.helper)
+           $ A.progDesc "Reset a state file to the empty state"
+           )
+
+      <> A.command
            "repl"
            (A.info (parserRepl <**> A.helper) $ A.progDesc "Start a REPL")
 
@@ -258,6 +266,9 @@ parserLayout = pure Layout
 
 parserInit :: A.Parser Command
 parserInit = pure Init
+
+parserReset :: A.Parser Command
+parserReset = Reset <$> P.confParser
 
 parserRepl :: A.Parser Command
 parserRepl = Repl <$> P.confParser

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -27,7 +27,7 @@ module Curiosity.Data
   , writeStdGen
   ) where
 
-import Curiosity.Data.Counter as C
+import qualified Curiosity.Data.Counter        as C
 import qualified Commence.Runtime.Errors       as E
 import qualified Control.Concurrent.STM        as STM
 import qualified Curiosity.Data.Business       as Business
@@ -99,15 +99,15 @@ emptyHask = Db
 instantiateStmDb
   :: forall runtime m . MonadIO m => HaskDb runtime -> m (StmDb runtime)
 instantiateStmDb Db
-  { _dbNextBusinessId   = CounterValue (Identity seedNextBusinessId)
+  { _dbNextBusinessId   = C.CounterValue (Identity seedNextBusinessId)
   , _dbBusinessEntities = Identity seedBusinessEntities
-  , _dbNextLegalId      = CounterValue (Identity seedNextLegalId)
+  , _dbNextLegalId      = C.CounterValue (Identity seedNextLegalId)
   , _dbLegalEntities    = Identity seedLegalEntities
-  , _dbNextUserId       = CounterValue (Identity seedNextUserId)
+  , _dbNextUserId       = C.CounterValue (Identity seedNextUserId)
   , _dbUserProfiles     = Identity seedProfiles
-  , _dbNextInvoiceId    = CounterValue (Identity seedNextInvoiceId)
+  , _dbNextInvoiceId    = C.CounterValue (Identity seedNextInvoiceId)
   , _dbInvoices         = Identity seedInvoices
-  , _dbNextEmploymentId = CounterValue (Identity seedNextEmploymentId)
+  , _dbNextEmploymentId = C.CounterValue (Identity seedNextEmploymentId)
   , _dbEmployments      = Identity seedEmployments
 
   , _dbRandomGenState        = Identity seedRandomGenState
@@ -156,15 +156,15 @@ resetStmDb' stmDb = do
   STM.writeTVar (_dbFormCreateContractAll stmDb) seedFormCreateContractAll
  where
   Db
-    { _dbNextBusinessId   = CounterValue (Identity seedNextBusinessId)
+    { _dbNextBusinessId   = C.CounterValue (Identity seedNextBusinessId)
     , _dbBusinessEntities = Identity seedBusinessEntities
-    , _dbNextLegalId      = CounterValue (Identity seedNextLegalId)
+    , _dbNextLegalId      = C.CounterValue (Identity seedNextLegalId)
     , _dbLegalEntities    = Identity seedLegalEntities
-    , _dbNextUserId       = CounterValue (Identity seedNextUserId)
+    , _dbNextUserId       = C.CounterValue (Identity seedNextUserId)
     , _dbUserProfiles     = Identity seedProfiles
-    , _dbNextInvoiceId    = CounterValue (Identity seedNextInvoiceId)
+    , _dbNextInvoiceId    = C.CounterValue (Identity seedNextInvoiceId)
     , _dbInvoices         = Identity seedInvoices
-    , _dbNextEmploymentId = CounterValue (Identity seedNextEmploymentId)
+    , _dbNextEmploymentId = C.CounterValue (Identity seedNextEmploymentId)
     , _dbEmployments      = Identity seedEmployments
 
     , _dbFormCreateContractAll = Identity seedFormCreateContractAll

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -13,6 +13,7 @@ module Curiosity.Data
   , instantiateStmDb
   , instantiateEmptyStmDb
   , resetStmDb
+  , resetStmDb'
   -- * Reading values from the database.
   , readFullStmDbInHaskFromRuntime
   , readFullStmDbInHask
@@ -138,7 +139,9 @@ instantiateEmptyStmDb = instantiateStmDb emptyHask
 -- state.
 resetStmDb
   :: forall runtime m . MonadIO m => StmDb runtime -> m ()
-resetStmDb stmDb = liftIO . STM.atomically $ do
+resetStmDb = liftIO . STM.atomically . resetStmDb'
+
+resetStmDb' stmDb = do
   C.writeCounter (_dbNextBusinessId stmDb) seedNextBusinessId
   STM.writeTVar (_dbBusinessEntities stmDb) seedBusinessEntities
   C.writeCounter (_dbNextLegalId stmDb) seedNextLegalId

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -5,7 +5,9 @@
 -- operations provided by Curiosity.
 -- In the future this might be useful to try to express complex business rules
 -- clearly, possibly for non-developers.
-module Curiosity.Dsl where
+module Curiosity.Dsl
+  ( reset
+  ) where
 
 import qualified Control.Concurrent.STM        as STM
 import qualified Curiosity.Data                as Data
@@ -41,6 +43,9 @@ db0 = Data.emptyHask
 state :: Run (HaskDb Rt.Runtime)
 state = ask >>= (Run . lift . readFullStmDbInHask')
 
+reset :: Run ()
+reset = ask >>= (Run . lift . Data.resetStmDb')
+
 user :: User.UserName -> Run (Maybe User.UserProfile)
 user username = ask >>= (Run . lift . flip Rt.selectUserByUsername username)
 
@@ -58,6 +63,8 @@ can profile name = ask >>= (Run . lift . flip (Rt.canPerform name) profile)
 
 
 --------------------------------------------------------------------------------
+-- In a GHCi session, e.g. obtained with scripts/ghci-dsl.sh:
+--     ghci> run db0 example
 example :: Run (Bool, Bool)
 example = do
   signup "alice" "a" "alice@example.com"

--- a/src/Curiosity/Process.hs
+++ b/src/Curiosity/Process.hs
@@ -5,6 +5,7 @@ module Curiosity.Process
   , endServer
   , shutdown
   , startupLogInfo
+  , logInfo
   ) where
 
 import qualified Commence.Multilogging         as ML
@@ -38,8 +39,16 @@ The implementation is simple: if there are no loggers, we don't output anything.
 FIXME: check if the logger is not using STDOUT, or, find the first non-STDOUT logger and log on that.
 -}
 startupLogInfo :: MonadIO m => ML.AppNameLoggers -> Text -> m ()
-startupLogInfo (ML.AppNameLoggers loggers) msg = mapM_ logOver loggers
-  where logOver l = L.runLogT' l . L.localEnv (<> "Boot") $ L.info msg
+startupLogInfo loggers = logInfo (<> "Boot") loggers
+
+logInfo
+  :: MonadIO m
+  => (ML.AppName -> ML.AppName)
+  -> ML.AppNameLoggers
+  -> Text
+  -> m ()
+logInfo env (ML.AppNameLoggers loggers) msg = mapM_ logOver loggers
+  where logOver l = L.runLogT' l . L.localEnv env $ L.info msg
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -231,26 +231,31 @@ handleServe conf serverConf = do
 handleRun :: P.Conf -> User.UserName -> FilePath -> IO ExitCode
 handleRun conf user scriptPath = do
   runtime <- Rt.boot conf >>= either throwIO pure
-  let handleExceptions = (`catch` P.shutdown runtime . Just)
-  handleExceptions $ do
-    code <- interpret runtime user scriptPath
-    Rt.powerdown runtime
-    exitWith code
+  code    <- interpret runtime user scriptPath
+  Rt.powerdown runtime
+  exitWith code
 
 interpret :: Rt.Runtime -> User.UserName -> FilePath -> IO ExitCode
 interpret runtime user path = do
-  (_, output) <- interpret' runtime user path
-  let len     = length $ takeWhile ((== ExitSuccess) . fst) output
+  (_, output) <- interpret' runtime user path 0
+  let len     = length $ takeWhile ((== ExitSuccess) . snd3) output
       output' = take (len + 1) output
-  mapM_ (putStrLn . snd) output'
-  pure $ fst . last $ (ExitSuccess, "") : output'
+      pad 0 = ""
+      pad 1 = "> "
+      pad n = T.concat (replicate ((n - 1) * 2) ">") <> "> "
+  mapM_ (\(a, _, c) -> putStrLn $ pad a <> c) output'
+  pure $ snd3 . last $ (0, ExitSuccess, "") : output'
+
+snd3 (_, b, _) = b
+thd3 (_, _, c) = c
 
 interpret'
   :: Rt.Runtime
   -> User.UserName
   -> FilePath
-  -> IO (User.UserName, [(ExitCode, Text)])
-interpret' runtime user path = do
+  -> Int
+  -> IO (User.UserName, [(Int, ExitCode, Text)])
+interpret' runtime user path nesting = do
   content <- readFile path
   foldlM loop (user, []) $ zip [1 :: Int ..] (T.lines content)
  where
@@ -259,18 +264,14 @@ interpret' runtime user path = do
         separated         = T.words prefix
         grouped           = T.unwords separated
     case separated of
-      []        -> pure (user', acc)
-      ["reset"] -> do
-        let output =
-              [show ln <> ": " <> grouped, "Resetting to the empty state."]
-        Rt.reset runtime
-        pure (user', acc ++ map (ExitSuccess, ) output)
+      []               -> pure (user', acc)
       ["as", username] -> do
         let output = [show ln <> ": " <> grouped, "Modifiying default user."]
-        pure (User.UserName username, acc ++ map (ExitSuccess, ) output)
+        pure
+          (User.UserName username, acc ++ map (nesting, ExitSuccess, ) output)
       ["quit"] -> do
         let output = [show ln <> ": " <> grouped, "Exiting."]
-        pure (user', acc ++ map (ExitSuccess, ) output)
+        pure (user', acc ++ map (nesting, ExitSuccess, ) output)
       input -> do
         let output_ = [show ln <> ": " <> grouped]
             result =
@@ -279,11 +280,28 @@ interpret' runtime user path = do
                 <$> input
         case result of
           A.Success command -> do
-            (_, output) <- Rt.handleCommand runtime user' command
-            pure (user', acc ++ map (ExitSuccess, ) (output_ ++ output))
-          A.Failure err -> pure (user', acc ++ [(ExitFailure 1, show err)])
+            case command of
+              Command.Reset _ -> do
+                let output = output_ ++ ["Resetting to the empty state."]
+                Rt.reset runtime
+                pure (user', acc ++ map (nesting, ExitSuccess, ) output)
+              Command.Run _ scriptPath -> do
+                (_, output') <- liftIO
+                  $ interpret' runtime user scriptPath (succ nesting)
+                pure
+                  ( user'
+                  , acc ++ map (nesting, ExitSuccess, ) output_ ++ output'
+                  )
+              _ -> do
+                (_, output) <- Rt.handleCommand runtime user' command
+                pure
+                  ( user'
+                  , acc ++ map (nesting, ExitSuccess, ) (output_ ++ output)
+                  )
+          A.Failure err ->
+            pure (user', acc ++ [(nesting, ExitFailure 1, show err)])
           A.CompletionInvoked _ ->
-            pure (user', acc ++ [(ExitFailure 1, "Shouldn't happen")])
+            pure (user', acc ++ [(nesting, ExitFailure 1, "Shouldn't happen")])
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -365,6 +365,7 @@ repl runtime user = HL.runInputT HL.defaultSettings loop
     -- other possible results (beside mod and viz): comments and blanks
     -- (no-op), instead of this special empty case.
     Just ""     -> loop
+    Just "reset" -> Rt.reset runtime >> loop
     Just "quit" -> pure ()
     Just input  -> do
       let result =

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -58,6 +58,14 @@ run (Command.CommandWithTarget Command.Init (Command.StateFileTarget path) _) =
             exitSuccess
           )
 
+run (Command.CommandWithTarget (Command.Reset conf) (Command.StateFileTarget path) _)
+  = do
+    runtime <-
+      Rt.boot conf { P._confDbFile = Just path } >>= either throwIO pure
+    Rt.reset runtime
+    Rt.powerdown runtime
+    exitSuccess
+
 run (Command.CommandWithTarget (Command.Repl conf) (Command.StateFileTarget path) (Command.User user))
   = do
     runtime <- Rt.boot conf >>= either throwIO pure
@@ -338,7 +346,7 @@ client path command = do
   exitSuccess
 
 commandToString = \case
-  Command.Init        -> do
+  Command.Init -> do
     putStrLn @Text "Can't send `init` to a server."
     exitFailure
   Command.State useHs -> pure $ "state" <> if useHs then " --hs" else ""

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -5,6 +5,7 @@ module Curiosity.Run
   , interpret'
   ) where
 
+import qualified Commence.Multilogging         as ML
 import qualified Commence.Runtime.Errors       as Errs
 import qualified Curiosity.Command             as Command
 import qualified Curiosity.Data                as Data
@@ -187,6 +188,14 @@ run (Command.CommandWithTarget Command.Step target (Command.User user)) = do
     Command.UnixDomainTarget path -> do
       putStrLn @Text "TODO"
       exitFailure
+
+run (Command.CommandWithTarget (Command.Log msg conf) (Command.StateFileTarget path) _)
+  = do
+    runtime <-
+      Rt.boot conf { P._confDbFile = Just path } >>= either throwIO pure
+    P.logInfo (<> "CLI" <> "Log") (Rt._rLoggers runtime) msg
+    Rt.powerdown runtime
+    exitSuccess
 
 run (Command.CommandWithTarget (Command.ShowId i) target (Command.User user)) =
   do

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -382,7 +382,11 @@ handleCommand runtime@Runtime {..} user command = do
         Right x   -> pure (ExitSuccess, map show x)
         Left  err -> pure (ExitFailure 1, [Errs.displayErr err])
     _ -> do
-      pure (ExitFailure 1, ["Unhandled command " <> show command])
+      -- TODO It seems that showing the command causes a stack overflow. For
+      -- instance the error happens by passing the Log or the Reset commands.
+      -- I think this has to do with the fact that they contain a conf.
+      -- pure (ExitFailure 1, ["Unhandled command " <> show command])
+      pure (ExitFailure 1, ["Unhandled command."])
 
 setUserEmailAddrAsVerifiedFull
   :: Data.StmDb runtime

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -77,6 +77,7 @@ spec = do
           go
           [ ("init", Data.emptyHask)
           , ("user create alice a alice@example.com --accept-tos", aliceState)
+          , ("reset", Data.emptyHask)
           ]
 
 

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -4,6 +4,7 @@ module CuriositySpec
 
 import qualified Curiosity.Command             as Command
 import qualified Curiosity.Data                as Data
+import qualified Curiosity.Data.Counter        as C
 import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Run                 as Run
 import qualified Data.Aeson                    as Aeson
@@ -24,7 +25,7 @@ spec = do
           User._userProfileDisplayName result `shouldBe` username
     mapM_
       go
-      [ ("alice.json"  , "Alice")
+      [ ("alice.json"  , "TODO")
       , ("bob-0.json"  , "Bob")
       , ("bob-1.json"  , "Bob")
       , ("bob-2.json"  , "Bob")
@@ -68,13 +69,15 @@ spec = do
     malice <- runIO $ parseFile "data/alice.json"
     case malice of
       Right alice -> do
-        let aliceState =
-              Data.emptyHask { Data._dbUserProfiles = Identity [alice] }
-        mapM_ go
-              [("init", Data.emptyHask)
-          -- TODO:
-          -- , ("user create alice secret alice@example.com", aliceState)
-                                       ]
+        let aliceState = Data.emptyHask
+              { Data._dbNextUserId   = C.CounterValue 2
+              , Data._dbUserProfiles = Identity [alice]
+              }
+        mapM_
+          go
+          [ ("init", Data.emptyHask)
+          , ("user create alice a alice@example.com --accept-tos", aliceState)
+          ]
 
 
 --------------------------------------------------------------------------------

--- a/tests/run-scenarios.hs
+++ b/tests/run-scenarios.hs
@@ -39,6 +39,6 @@ mkGoldenTest path = do
 run :: FilePath -> IO [Text]
 run scriptPath = do
   runtime     <- Rt.boot P.defaultConf >>= either throwIO pure
-  (_, output) <- Run.interpret' runtime "system" scriptPath
+  (_, output) <- Run.interpret' runtime "system" scriptPath 0
   Rt.powerdown runtime
-  pure $ map snd output
+  pure $ map (\(_ ,_ , c) -> c)  output


### PR DESCRIPTION
- Add a `cty reset` command, similar to the one existing already in `cty run`
- Add a similar function to `Curiosity.Dsl`
- Add `reset` to `cty repl`
- `cty reset` has a simple test in `CuriositySpec.hs`
- Add a `cty log` command
- Add `run` to `cty run`
- Add `run` to `cty repl`