### PR TITLE
Complete profile pages (for users, entities, and units)

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -6,7 +6,7 @@ title: Curiosity
 # About
 
 Curiosity is an ever-evolving prototype system to think, discuss, and
-communicate the future of Smart Belgium's developments. The complete system is
+communicate the future of Smart Coop's developments. The complete system is
 packaged as a [virtual machine image](/documentation/machine). It is exposed to
 end-users as a web application and a running instance of Curiosity is made
 available at [`smartcoop.sh`](//smartcoop.sh) for demonstration purpose.
@@ -16,7 +16,7 @@ available at [`smartcoop.sh`](//smartcoop.sh) for demonstration purpose.
 Curiosity is being developed to inform further developments, and is not
 intended to be a production system. It will evolve during the next few months
 as we try to nail down as precisely as possible what the best solutions for
-Smart Belgium are.
+Smart Coop are.
 
 ## Open source
 

--- a/content/about.md
+++ b/content/about.md
@@ -6,10 +6,11 @@ title: Curiosity
 # About
 
 Curiosity is an ever-evolving prototype system to think, discuss, and
-communicate the future of Smart Coop's developments. The complete system is
-packaged as a [virtual machine image](/documentation/machine). It is exposed to
+communicate the future of Smart Coop's developments. It is exposed to
 end-users as a web application and a running instance of Curiosity is made
-available at [`smartcoop.sh`](//smartcoop.sh) for demonstration purpose.
+available at [`smartcoop.sh`](//smartcoop.sh) for demonstration purpose. For
+tech savvy users, the complete system is packaged as a [virtual machine
+image](/documentation/machine), made to be easily run and explored.
 
 ## Experimental
 

--- a/content/default.nix
+++ b/content/default.nix
@@ -31,4 +31,14 @@ in
       cp -r data $out
     '';
   };
+
+  # Define this here, instead of creating a .nix file in scenarios/.
+  scenarios = pkgs.stdenv.mkDerivation {
+    name = "scenarios";
+    # TODO We only need scenarios/
+    src = ../.;
+    installPhase = ''
+      cp -r scenarios $out
+    '';
+  };
 }

--- a/content/documentation.md
+++ b/content/documentation.md
@@ -16,6 +16,7 @@ title: Curiosity
 - [Man pages](/documentation/man-pages)
 - [Messages](/documentation/messages)
 - [Objects](/documentation/objects)
+- [Scenarios](/documentation/scenarios)
 - [Sitemap](/documentation/sitemap)
 - [Source code](/documentation/source)
 - [UBL](/documentation/ubl)

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -44,3 +44,7 @@ system was initialized.
 ## Legal entities
 
 - [One S.A.](/entity/one)
+
+## Business units
+
+- [Alpha](/alpha)

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -1,0 +1,5 @@
+---
+title: Curiosity
+---
+
+# Test scenarios

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -3,3 +3,44 @@ title: Curiosity
 ---
 
 # Test scenarios
+
+One the main goal of Curiosity is to precisely describe its behavior in terms
+of test scenarios. To do so, Curiosity supports running scripts: they are
+textual sequences of commands that mimic closly what can be done through the
+web interface.
+
+As part of its test suite, a collection of scenarios are run and their results
+are compared to known sources of truth, called "golden files". This makes sure
+that, as scenarios are created, and as Curiosity evolves, the system continues
+to work as expected, and few bugs can be introduced inadvertantly.
+
+# Example data
+
+Entering enough data into the system to allow to execute (possibly manually,
+through the web interface) a specific test scenario can be tedious if the
+system is initially empty. Fortunately, scripts can also be used to generate
+the necessary data and set the system state as desired.
+
+A specific set of example data is available with Curiosity, called `state-0`.
+(We envision that additional set of data could be created in the future.)
+
+Note: if you are operating Curiosity yourself, you can initialize Curiosity's
+state by running `cty run scenarios/state-0.txt`.
+
+# `state-0`
+
+We intend `state-0` to serve as common knowledge among the team working with
+Curiosity. Here, we detail what it is comprised of.
+
+Note: sometimes, we provide links to specific pages of the web application.
+When those pages are displaying the live application state, it is possible that
+the underlying data have changed and are no longer how they were when the
+system was initialized.
+
+## Users
+
+- [Alice](/alice)
+
+## Legal entities
+
+- [One S.A.](/entity/one)

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -6,13 +6,13 @@ title: Curiosity
 
 One the main goal of Curiosity is to precisely describe its behavior in terms
 of test scenarios. To do so, Curiosity supports running scripts: they are
-textual sequences of commands that mimic closly what can be done through the
+textual sequences of commands that mimic closely what can be done through the
 web interface.
 
-As part of its test suite, a collection of scenarios are run and their results
-are compared to known sources of truth, called "golden files". This makes sure
-that, as scenarios are created, and as Curiosity evolves, the system continues
-to work as expected, and few bugs can be introduced inadvertantly.
+As part of Curiosity's test suite, a collection of scenarios are run and their
+results are compared to known sources of truth, called "golden files". This
+makes sure that, as scenarios are created, and as Curiosity evolves, the system
+continues to work as expected, and few bugs can be introduced inadvertantly.
 
 # Example data
 
@@ -25,7 +25,10 @@ A specific set of example data is available with Curiosity, called `state-0`.
 (We envision that additional set of data could be created in the future.)
 
 Note: if you are operating Curiosity yourself, you can initialize Curiosity's
-state by running `cty run scenarios/state-0.txt`.
+state by running `cty run scenarios/state-0.txt`. Here is [an example
+scenario](https://github.com/hypered/curiosity/blob/main/scenarios/0.txt), and
+its [corresponding golden
+file](https://github.com/hypered/curiosity/blob/main/scenarios/0.golden).
 
 # `state-0`
 
@@ -40,6 +43,7 @@ system was initialized.
 ## Users
 
 - [Alice](/alice)
+- [Mila](/mila)
 
 ## Legal entities
 

--- a/content/documentation/state.md
+++ b/content/documentation/state.md
@@ -7,45 +7,53 @@ title: Curiosity
 In a traditional [three-tier
 architecture](https://en.wikipedia.org/wiki/Multitier_architecture)
 application, the data tier, which stores the complete state of the system, is a
-relational database, such as PostgreSQL.
+relational database such as PostgreSQL.
 
 In Curiosity, the complete state of the application is maintained in-memory
 using [Software transactional
 memory](https://en.wikipedia.org/wiki/Software_transactional_memory).
 
 From the web interface, the complete application state can be browsed at
-[`/state`](/state) (displayed using the internal state representation) and
-[`/state.json`](/state.json) (displayed as JSON).
+[`/state`](/state) and [`/state.json`](/state.json). The first link uses the
+internal state representation to format the data and the second link uses JSON.
 
-From the command-line, it is available with the `cty state` command, and from
-the REPL, it is available with `state`.
+From the command-line, the complete state can be viewed with the `cty state`
+command, and from the REPL, it is available with `state`. Further drilling down
+the returned data can be done on the command-line for instance with
+[`jq`](https://stedolan.github.io/jq/).
 
 Such complete representations are currently only practical for little data.
+We'll probably have to revisit the means to query it when we have to deal with
+bigger volumes.
 
 # Application state management
 
-While Curiosity maintains only the state in-memory during nomal operations, it
-is possible to write the state to disk or read the state from disk.
+While Curiosity maintains the state only in-memory during nomal operations, it
+is possible to write the state to disk, or read it from disk. Many `cty`
+commands accept the `--state <file.json>`, `--socket <file.sock>`, and
+`--memory` options to decide how the state is managed.
 
-By default, the initial state of `cty repl` and `cty serve` are empty, and
-their state is simply discarded when they shut down. It is possible to instruct
-them to operate against a file: the initial state is read from the file, and
-the final state is written back to the file upon exit. It is also possible for
-`cty repl` to instruct it to talk to a running server.
+By default, commands such as `cty repl` and `cty serve` are operating as if
+`--state state.json` was given. This causes the state to be read from the
+`state.json` file upon startup, and written back to end with the program exits.
 
-Other `cty` commands on the other hand either "talk" to a state backed by a
-file, or backed by a running server. By default, they operate against a file
-called "state.json". When those commands are called through SSH, the machine is
-configured so that they operate against the running server.
+With the `--memory` option, the commands are not using a file at all. Their
+initial state is empty, and is simply discarded when they shut down.
 
-Note: the reason for differences in the default behavior of `cty repl` and `cty
-server` vs. the other command, is to simplify calling `cty <some command>`
-repeatedly from a shell, while `cty repl` and `cty serve` are typed less often
-on the keyboard.
+The `--socket` option, can be used to operate against the state of a running
+server. This feature is currently incomplete.
+
+Another currently incomplete feature allows to call `cty` commands across SSH.
+In that case, the machine is configured so that they operate against the
+running server.
 
 For commands that expect a state file, whether it is their default behavior or
 they are instructed to do so, the state file must exit. The command to create a
 state file is `cty init`.
 
-Note: the reason to create explicitely a state file is to avoid modifying a
-state file by mistake, e.g. from a script calling multiple `cty` commands.
+# Virtual machine state
+
+The virtual machine shipped with the prototype (and featured at
+[`smartcoop.sh`](https://smartcoop.sh)) is configured to start with an initial
+state, called `state-0`. You can read more about it in the section about [test
+scenarios](/documentation/scenarios).

--- a/content/documentation/views.md
+++ b/content/documentation/views.md
@@ -11,7 +11,7 @@ User profile
 
     Example data include:
 
-    - [Alice](/views/profile/alice.json)
+    - [Alice](/views/profile/alice.json), [with bio](/views/profile/alice-with-bio.json)
     - [Charlie](/views/profile/charlie.json)
 
 

--- a/data/alice-with-bio.json
+++ b/data/alice-with-bio.json
@@ -1,0 +1,14 @@
+{
+  "_userProfileId": "USER-1",
+  "_userProfileCreds": {
+    "_userCredsName": "alice",
+    "_userCredsPassword": "a"
+  },
+  "_userProfileEmailAddr": "alice@example.com",
+  "_userProfileDisplayName": "Alice",
+  "_userProfileBio": "Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !",
+  "_userProfileTosConsent": true,
+  "_userProfileCompletion1": {},
+  "_userProfileCompletion2": {},
+  "_userProfileRights": ["CanVerifyEmailAddr"]
+}

--- a/data/alice.json
+++ b/data/alice.json
@@ -5,7 +5,6 @@
     "_userCredsPassword": "a"
   },
   "_userProfileEmailAddr": "alice@example.com",
-  "_userProfileDisplayName": "TODO",
   "_userProfileTosConsent": true,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},

--- a/data/alpha.json
+++ b/data/alpha.json
@@ -1,3 +1,5 @@
 {
-  "_entityId": "BENT-1"
+  "_entityId": "BENT-1",
+  "_entitySlug": "alpha",
+  "_entityName": "Alpha"
 }

--- a/data/one.json
+++ b/data/one.json
@@ -1,5 +1,6 @@
 {
   "_entityId": "LENT-1",
+  "_entitySlug": "one",
   "_entityName": "One S.A.",
   "_entityCbeNumber": "100200300",
   "_entityVatNumber": "BE0100200300"

--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,7 @@ in rec
     haddock = nixpkgs.haskellPackages.curiosity.doc;
     content = (import ./content {}).html.all;
     data = (import ./content {}).data;
+    scenarios = (import ./content {}).scenarios;
     static = (import "${sources.design-hs}").static;
     man-pages = (import ./man {}).man-pages;
     toplevel = os.config.system.build.toplevel;

--- a/modules/curiosity.nix
+++ b/modules/curiosity.nix
@@ -3,9 +3,20 @@
   systemd.services.curiosity = {
     wantedBy = [ "multi-user.target" ];
     script = ''
+      # Run from a state file, reset to a known state.
       # TODO system is meaningless for now.
+      rm -f /tmp/state.json
       ${(import ../.).binaries}/bin/cty \
-        --memory \
+        --state /tmp/state.json \
+        --user system \
+        init
+      ${(import ../.).binaries}/bin/cty \
+        --state /tmp/state.json \
+        --user system \
+        run ${(import ../.).scenarios}/state-0.txt
+
+      ${(import ../.).binaries}/bin/cty \
+        --state /tmp/state.json \
         --user system \
         serve \
         --server-port 9100 \

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,7 +14,7 @@
     "design-hs": {
         "branch": "main",
         "repo": "git@github.com:hypered/smart-design-hs.git",
-        "rev": "68c9eb3fa14397fb4d861f33f1dd8f3689ad2266",
+        "rev": "4480c4a2d491616dec05bf6cc15a2ed2ab9826b7",
         "type": "git"
     },
     "gitignore": {

--- a/scenarios/init-entities.golden
+++ b/scenarios/init-entities.golden
@@ -1,2 +1,4 @@
-1: legal create one One,S.A. 100200300 BE0100200300
+1: legal create one One S.A. 100200300 BE0100200300
 Legal entity created: LENT-1
+2: legal update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
+Legal entity updated: one

--- a/scenarios/init-entities.golden
+++ b/scenarios/init-entities.golden
@@ -1,0 +1,2 @@
+1: legal create one One,S.A. 100200300 BE0100200300
+Legal entity created: LENT-1

--- a/scenarios/init-entities.txt
+++ b/scenarios/init-entities.txt
@@ -1,1 +1,2 @@
-legal create one One,S.A. 100200300 BE0100200300
+legal create one "One S.A." 100200300 BE0100200300
+legal update one "One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One."

--- a/scenarios/init-entities.txt
+++ b/scenarios/init-entities.txt
@@ -1,0 +1,1 @@
+legal create one One,S.A. 100200300 BE0100200300

--- a/scenarios/init-units.golden
+++ b/scenarios/init-units.golden
@@ -1,2 +1,4 @@
 1: business create alpha Alpha
 Business entity created: BENT-1
+2: business update alpha The first business unit of the prototype, Alpha is run by @mila.
+Business unit updated: alpha

--- a/scenarios/init-units.golden
+++ b/scenarios/init-units.golden
@@ -1,0 +1,2 @@
+1: business create alpha Alpha
+Business entity created: BENT-1

--- a/scenarios/init-units.txt
+++ b/scenarios/init-units.txt
@@ -1,1 +1,2 @@
 business create alpha Alpha
+business update alpha "The first business unit of the prototype, Alpha is run by @mila."

--- a/scenarios/init-units.txt
+++ b/scenarios/init-units.txt
@@ -1,0 +1,1 @@
+business create alpha Alpha

--- a/scenarios/init-users.golden
+++ b/scenarios/init-users.golden
@@ -2,7 +2,11 @@
 User created: USER-1
 3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
 Right (Right (Right [UserId {unUserId = "USER-1"}]))
-4: user create bob b bob@example.com --accept-tos
+5: user create bob b bob@example.com --accept-tos
 User created: USER-2
-5: user create charlie c charlie@example.com --accept-tos
+6: user create charlie c charlie@example.com --accept-tos
 User created: USER-3
+8: user create mila m mila@example.com --accept-tos
+User created: USER-4
+9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
+Right (Right (Right [UserId {unUserId = "USER-4"}]))

--- a/scenarios/init-users.golden
+++ b/scenarios/init-users.golden
@@ -1,6 +1,8 @@
 2: user create alice a alice@example.com --accept-tos
 User created: USER-1
-3: user create bob b bob@example.com --accept-tos
+3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
+Right (Right (Right [UserId {unUserId = "USER-1"}]))
+4: user create bob b bob@example.com --accept-tos
 User created: USER-2
-4: user create charlie c charlie@example.com --accept-tos
+5: user create charlie c charlie@example.com --accept-tos
 User created: USER-3

--- a/scenarios/init-users.golden
+++ b/scenarios/init-users.golden
@@ -1,0 +1,6 @@
+2: user create alice a alice@example.com --accept-tos
+User created: USER-1
+3: user create bob b bob@example.com --accept-tos
+User created: USER-2
+4: user create charlie c charlie@example.com --accept-tos
+User created: USER-3

--- a/scenarios/init-users.txt
+++ b/scenarios/init-users.txt
@@ -1,0 +1,4 @@
+# Initialize a state with three users.
+user create alice a alice@example.com --accept-tos
+user create bob b bob@example.com --accept-tos
+user create charlie c charlie@example.com --accept-tos

--- a/scenarios/init-users.txt
+++ b/scenarios/init-users.txt
@@ -1,4 +1,5 @@
 # Initialize a state with three users.
 user create alice a alice@example.com --accept-tos
+user update USER-1 Alice "Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !"
 user create bob b bob@example.com --accept-tos
 user create charlie c charlie@example.com --accept-tos

--- a/scenarios/init-users.txt
+++ b/scenarios/init-users.txt
@@ -1,5 +1,9 @@
-# Initialize a state with three users.
+# Initialize a state with four users.
 user create alice a alice@example.com --accept-tos
 user update USER-1 Alice "Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !"
+
 user create bob b bob@example.com --accept-tos
 user create charlie c charlie@example.com --accept-tos
+
+user create mila m mila@example.com --accept-tos
+user update USER-4 Mila "I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha."

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -1,0 +1,12 @@
+1: reset
+Resetting to the empty state.
+2: run scenarios/init-users.txt
+2: user create alice a alice@example.com --accept-tos
+User created: USER-1
+3: user create bob b bob@example.com --accept-tos
+User created: USER-2
+4: user create charlie c charlie@example.com --accept-tos
+User created: USER-3
+3: run scenarios/init-entities.txt
+1: legal create one One,S.A. 100200300 BE0100200300
+Legal entity created: LENT-1

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -18,3 +18,6 @@ Right (Right (Right [UserId {unUserId = "USER-4"}]))
 Legal entity created: LENT-1
 2: legal update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
 Legal entity updated: one
+4: run init-units.txt
+1: business create alpha Alpha
+Business entity created: BENT-1

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -21,3 +21,5 @@ Legal entity updated: one
 4: run init-units.txt
 1: business create alpha Alpha
 Business entity created: BENT-1
+2: business update alpha The first business unit of the prototype, Alpha is run by @mila.
+Business unit updated: alpha

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -3,9 +3,11 @@ Resetting to the empty state.
 2: run init-users.txt
 2: user create alice a alice@example.com --accept-tos
 User created: USER-1
-3: user create bob b bob@example.com --accept-tos
+3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
+Right (Right (Right [UserId {unUserId = "USER-1"}]))
+4: user create bob b bob@example.com --accept-tos
 User created: USER-2
-4: user create charlie c charlie@example.com --accept-tos
+5: user create charlie c charlie@example.com --accept-tos
 User created: USER-3
 3: run init-entities.txt
 1: legal create one One,S.A. 100200300 BE0100200300

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -10,5 +10,7 @@ User created: USER-2
 5: user create charlie c charlie@example.com --accept-tos
 User created: USER-3
 3: run init-entities.txt
-1: legal create one One,S.A. 100200300 BE0100200300
+1: legal create one One S.A. 100200300 BE0100200300
 Legal entity created: LENT-1
+2: legal update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
+Legal entity updated: one

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -5,10 +5,14 @@ Resetting to the empty state.
 User created: USER-1
 3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
 Right (Right (Right [UserId {unUserId = "USER-1"}]))
-4: user create bob b bob@example.com --accept-tos
+5: user create bob b bob@example.com --accept-tos
 User created: USER-2
-5: user create charlie c charlie@example.com --accept-tos
+6: user create charlie c charlie@example.com --accept-tos
 User created: USER-3
+8: user create mila m mila@example.com --accept-tos
+User created: USER-4
+9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
+Right (Right (Right [UserId {unUserId = "USER-4"}]))
 3: run init-entities.txt
 1: legal create one One S.A. 100200300 BE0100200300
 Legal entity created: LENT-1

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -1,12 +1,12 @@
 1: reset
 Resetting to the empty state.
-2: run scenarios/init-users.txt
+2: run init-users.txt
 2: user create alice a alice@example.com --accept-tos
 User created: USER-1
 3: user create bob b bob@example.com --accept-tos
 User created: USER-2
 4: user create charlie c charlie@example.com --accept-tos
 User created: USER-3
-3: run scenarios/init-entities.txt
+3: run init-entities.txt
 1: legal create one One,S.A. 100200300 BE0100200300
 Legal entity created: LENT-1

--- a/scenarios/state-0.txt
+++ b/scenarios/state-0.txt
@@ -1,3 +1,4 @@
 reset
 run init-users.txt
 run init-entities.txt
+run init-units.txt

--- a/scenarios/state-0.txt
+++ b/scenarios/state-0.txt
@@ -1,0 +1,3 @@
+reset
+run scenarios/init-users.txt
+run scenarios/init-entities.txt

--- a/scenarios/state-0.txt
+++ b/scenarios/state-0.txt
@@ -1,3 +1,3 @@
 reset
-run scenarios/init-users.txt
-run scenarios/init-entities.txt
+run init-users.txt
+run init-entities.txt

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,4 +3,5 @@
 
 # This script runs the Haskell library test suite and the scenarios.
 
+rm -f /tmp/curiosity-test-*
 cabal test --test-show-details=direct

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -14,6 +14,7 @@ module Curiosity.Command
   ) where
 
 import qualified Commence.Runtime.Storage      as S
+import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Legal          as Legal
 import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Parse               as P
@@ -41,7 +42,7 @@ data Command =
     -- ^ Parse a single command.
   | State Bool
     -- ^ Show the full state. If True, use Haskell format instead of JSON.
-  | CreateBusinessEntity
+  | CreateBusinessEntity Business.Create
   | CreateLegalEntity Legal.Create
   | UpdateLegalEntity Legal.Update
   | CreateUser User.Signup
@@ -332,7 +333,12 @@ parserBusiness = A.subparser $ A.command
   )
 
 parserCreateBusinessEntity :: A.Parser Command
-parserCreateBusinessEntity = pure CreateBusinessEntity
+parserCreateBusinessEntity = do
+  slug <- A.argument
+    A.str
+    (A.metavar "SLUG" <> A.help "An identifier suitable for URLs")
+  name <- A.argument A.str (A.metavar "NAME" <> A.help "A name")
+  pure $ CreateBusinessEntity $ Business.Create slug name
 
 parserLegal :: A.Parser Command
 parserLegal =

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -365,6 +365,9 @@ parserUser = A.subparser
        "delete"
        (A.info (parserDeleteUser <**> A.helper) $ A.progDesc "Delete a user")
   <> A.command
+       "update"
+       (A.info (parserUpdateUser <**> A.helper) $ A.progDesc "Update a user")
+  <> A.command
        "get"
        (A.info (parserGetUser <**> A.helper) $ A.progDesc "Select a user")
   <> A.command
@@ -400,6 +403,13 @@ parserCreateUser = do
 
 parserDeleteUser :: A.Parser Command
 parserDeleteUser = UpdateUser . User.UserDelete <$> argumentUserId
+
+parserUpdateUser :: A.Parser Command
+parserUpdateUser = do
+  uid  <- argumentUserId
+  name <- A.argument A.str (A.metavar "NAME" <> A.help "A display name")
+  bio  <- A.argument A.str (A.metavar "TEXT" <> A.help "A bio")
+  pure $ UpdateUser . User.UserUpdate uid $ User.Update (Just name) (Just bio)
 
 parserGetUser :: A.Parser Command
 parserGetUser =

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -342,6 +342,9 @@ parserLegal = A.subparser $ A.command
 
 parserCreateLegalEntity :: A.Parser Command
 parserCreateLegalEntity = do
+  slug <- A.argument
+    A.str
+    (A.metavar "SLUG" <> A.help "An identifier suitable for URLs")
   name <- A.argument A.str (A.metavar "NAME" <> A.help "A registration name")
   cbeNumber <- A.argument
     A.str
@@ -351,7 +354,7 @@ parserCreateLegalEntity = do
   vatNumber <- A.argument
     A.str
     (A.metavar "VAT-NUMER" <> A.help "VAT number (with prefix and leading zero")
-  pure $ CreateLegalEntity $ Legal.Create name cbeNumber vatNumber
+  pure $ CreateLegalEntity $ Legal.Create slug name cbeNumber vatNumber
 
 parserUser :: A.Parser Command
 parserUser = A.subparser

--- a/src/Curiosity/Data/Business.hs
+++ b/src/Curiosity/Data/Business.hs
@@ -6,6 +6,8 @@ Description: Business entities related datatypes
 -}
 module Curiosity.Data.Business
   ( Entity(..)
+  , Create(..)
+  , Update(..)
   , BusinessId(..)
   , Err(..)
   ) where
@@ -13,12 +15,40 @@ module Curiosity.Data.Business
 import qualified Commence.Types.Wrapped        as W
 import           Data.Aeson
 import qualified Text.Blaze.Html5              as H
-import           Web.FormUrlEncoded             ( FromForm(..) )
+import           Web.FormUrlEncoded             ( FromForm(..)
+                                                , parseMaybe
+                                                , parseUnique
+                                                )
+
+
+--------------------------------------------------------------------------------
+data Create = Create
+  { _createSlug :: Text -- Unique
+  , _createName :: Text
+  }
+  deriving (Generic, Eq, Show)
+
+instance FromForm Create where
+  fromForm f = Create <$> parseUnique "slug" f <*> parseUnique "name" f
+
+-- | Represents the input data to update a business unit profile.
+data Update = Update
+  { _updateSlug        :: Text
+  , _updateDescription :: Maybe Text
+  }
+  deriving (Eq, Show, Generic)
+
+instance FromForm Update where
+  fromForm f = Update <$> parseUnique "slug" f <*> parseMaybe "description" f
 
 
 --------------------------------------------------------------------------------
 data Entity = Entity
-  { _entityId :: BusinessId
+  { _entityId          :: BusinessId
+  , _entitySlug        :: Text
+    -- An identifier suitable for URLs
+  , _entityName        :: Text
+  , _entityDescription :: Maybe Text
   }
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)

--- a/src/Curiosity/Data/Legal.hs
+++ b/src/Curiosity/Data/Legal.hs
@@ -26,21 +26,27 @@ import           Web.HttpApiData                ( FromHttpApiData(..) )
 
 --------------------------------------------------------------------------------
 data Create = Create
-  { _createName      :: RegistrationName
+  { _createSlug      :: Text
+  , _createName      :: RegistrationName
   , _createCbeNumber :: CbeNumber
   , _createVatNumber :: VatNumber -- TODO Is it really useful to habe both ?
   }
   deriving (Generic, Eq, Show)
 
 instance FromForm Create where
-  fromForm f = Create <$> parseUnique "name" f
-                      <*> parseUnique "cbe-number" f
-                      <*> parseUnique "vat-number" f
+  fromForm f =
+    Create
+      <$> parseUnique "slug"       f
+      <*> parseUnique "name"       f
+      <*> parseUnique "cbe-number" f
+      <*> parseUnique "vat-number" f
 
 
 --------------------------------------------------------------------------------
 data Entity = Entity
   { _entityId        :: LegalId
+  , _entitySlug      :: Text
+    -- An identifier suitable for URLs
   , _entityName      :: RegistrationName
   , _entityCbeNumber :: CbeNumber
   , _entityVatNumber :: VatNumber -- TODO Is it really useful to habe both ?

--- a/src/Curiosity/Data/Legal.hs
+++ b/src/Curiosity/Data/Legal.hs
@@ -20,9 +20,9 @@ import           Data.Aeson
 import qualified Data.ByteString.Lazy          as LB
 import qualified Text.Blaze.Html5              as H
 import           Web.FormUrlEncoded             ( FromForm(..)
+                                                , parseMaybe
                                                 , parseUnique
                                                 )
-import           Web.FormUrlEncoded             ( parseMaybe )
 import           Web.HttpApiData                ( FromHttpApiData(..) )
 
 

--- a/src/Curiosity/Data/Legal.hs
+++ b/src/Curiosity/Data/Legal.hs
@@ -7,6 +7,7 @@ Description: Legal entities related datatypes
 module Curiosity.Data.Legal
   ( Entity(..)
   , Create(..)
+  , Update(..)
   , LegalId(..)
   , RegistrationName(..)
   , Err(..)
@@ -21,6 +22,7 @@ import qualified Text.Blaze.Html5              as H
 import           Web.FormUrlEncoded             ( FromForm(..)
                                                 , parseUnique
                                                 )
+import           Web.FormUrlEncoded             ( parseMaybe )
 import           Web.HttpApiData                ( FromHttpApiData(..) )
 
 
@@ -41,15 +43,27 @@ instance FromForm Create where
       <*> parseUnique "cbe-number" f
       <*> parseUnique "vat-number" f
 
+-- | Represents the input data to update an entity profile.
+data Update = Update
+  { _updateSlug        :: Text
+  , _updateDescription :: Maybe Text
+  }
+  deriving (Eq, Show, Generic)
+
+instance FromForm Update where
+  fromForm f = Update <$> parseUnique "slug" f <*> parseMaybe "description" f
+
 
 --------------------------------------------------------------------------------
 data Entity = Entity
-  { _entityId        :: LegalId
-  , _entitySlug      :: Text
+  { _entityId          :: LegalId
+  , _entitySlug        :: Text
     -- An identifier suitable for URLs
-  , _entityName      :: RegistrationName
-  , _entityCbeNumber :: CbeNumber
-  , _entityVatNumber :: VatNumber -- TODO Is it really useful to habe both ?
+  , _entityName        :: RegistrationName
+  , _entityCbeNumber   :: CbeNumber
+  , _entityVatNumber   :: VatNumber -- TODO Is it really useful to habe both ?
+  , _entityDescription :: Maybe Text
+    -- Public description. Similar to a user profile bio.
   }
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -119,10 +119,14 @@ type UserProfile = UserProfile' Credentials UserDisplayName UserEmailAddr Bool
 
 data UserProfile' creds userDisplayName userEmailAddr tosConsent = UserProfile
   { _userProfileId                :: UserId
-  , _userProfileCreds             :: creds -- ^ Users credentials
-  , _userProfileDisplayName       :: userDisplayName -- ^ User's human friendly name
-  , _userProfileEmailAddr         :: userEmailAddr -- ^ User's email address
-  , _userProfileEmailAddrVerified :: Maybe Text -- ^ TODO Last date it was checked.
+  , _userProfileCreds             :: creds
+    -- ^ Users credentials
+  , _userProfileDisplayName       :: Maybe userDisplayName
+    -- ^ User's human friendly name
+  , _userProfileEmailAddr         :: userEmailAddr
+    -- ^ User's email address
+  , _userProfileEmailAddrVerified :: Maybe Text
+    -- ^ TODO Last date it was checked
   , _userProfileTosConsent        :: tosConsent
   , _userProfileCompletion1       :: UserCompletion1
   , _userProfileCompletion2       :: UserCompletion2
@@ -231,8 +235,8 @@ instance Nav.IsNavbarContent UserProfile where
     editProfileLink
     H.hr
    where
-    greeting =
-      H.div . H.text $ T.unwords ["Hi", _userProfileDisplayName ^. coerced]
+    greeting = H.div . H.text $ T.unwords
+      ["Hi", _userCredsName _userProfileCreds ^. coerced]
     editProfileLink = H.a ! A.href "/settings/profile" $ "Edit profile"
 
 instance Storage.DBIdentity UserProfile where

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -106,12 +106,12 @@ instance FromForm Login where
 
 -- | Represents the input data to update a user profile.
 newtype Update = Update
-  { _editPassword :: Maybe Password
+  { _updateDisplayName :: Maybe UserDisplayName
   }
   deriving (Eq, Show, Generic)
 
 instance FromForm Update where
-  fromForm f = Update <$> parseMaybe "password" f
+  fromForm f = Update <$> parseMaybe "display-name" f
 
 
 --------------------------------------------------------------------------------
@@ -248,7 +248,7 @@ instance Storage.DBStorageOps UserProfile where
     UserCreate UserProfile
     | UserCreateGeneratingUserId Signup
     | UserDelete UserId
-    | UserPasswordUpdate UserId Password
+    | UserDisplayNameUpdate UserId (Maybe UserDisplayName)
     deriving (Show, Eq)
   
   data DBSelect UserProfile =

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -21,6 +21,7 @@ module Curiosity.Data.User
   , userProfileCreds
   , userProfileId
   , userProfileDisplayName
+  , userProfileBio
   , userProfileEmailAddr
   , userProfileTosConsent
   , userProfileAddrAndTelVerified
@@ -105,13 +106,14 @@ instance FromForm Login where
   fromForm f = Login <$> parseUnique "username" f <*> parseUnique "password" f
 
 -- | Represents the input data to update a user profile.
-newtype Update = Update
+data Update = Update
   { _updateDisplayName :: Maybe UserDisplayName
+  , _updateBio         :: Maybe Text
   }
   deriving (Eq, Show, Generic)
 
 instance FromForm Update where
-  fromForm f = Update <$> parseMaybe "display-name" f
+  fromForm f = Update <$> parseMaybe "display-name" f <*> parseMaybe "bio" f
 
 
 --------------------------------------------------------------------------------
@@ -123,6 +125,8 @@ data UserProfile' creds userDisplayName userEmailAddr tosConsent = UserProfile
     -- ^ Users credentials
   , _userProfileDisplayName       :: Maybe userDisplayName
     -- ^ User's human friendly name
+  , _userProfileBio               :: Maybe Text
+    -- ^ Public bio
   , _userProfileEmailAddr         :: userEmailAddr
     -- ^ User's email address
   , _userProfileEmailAddrVerified :: Maybe Text
@@ -248,7 +252,7 @@ instance Storage.DBStorageOps UserProfile where
     UserCreate UserProfile
     | UserCreateGeneratingUserId Signup
     | UserDelete UserId
-    | UserDisplayNameUpdate UserId (Maybe UserDisplayName)
+    | UserUpdate UserId Update
     deriving (Show, Eq)
   
   data DBSelect UserProfile =

--- a/src/Curiosity/Html/Action.hs
+++ b/src/Curiosity/Html/Action.hs
@@ -56,8 +56,10 @@ setUserEmailAddrAsVerifiedPanel username profile =
     $ H.dl
     ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
     $ do
-        keyValuePair "Username"      username
-        keyValuePair "Display name"  (User._userProfileDisplayName profile)
+        keyValuePair "Username" username
+        maybe mempty
+              (keyValuePair "Display name")
+              (User._userProfileDisplayName profile)
         keyValuePair "Email address" (User._userProfileEmailAddr profile)
 
 setUserEmailAddrAsVerifiedForm username = H.form $ do

--- a/src/Curiosity/Html/Business.hs
+++ b/src/Curiosity/Html/Business.hs
@@ -17,19 +17,22 @@ import qualified Text.Blaze.Html5.Attributes   as A
 
 --------------------------------------------------------------------------------
 data UnitView = UnitView
-  { _unitViewUnit          :: Business.Entity
+  { _unitViewUser          :: Maybe User.UserProfile
+    -- ^ The logged-in user, if any.
+  , _unitViewUnit          :: Business.Entity
   , _unitViewHasEditButton :: Maybe H.AttributeValue
   }
 
 instance H.ToMarkup UnitView where
-  toMarkup (UnitView unit hasEditButton) =
-    renderView $ unitView unit hasEditButton
+  toMarkup (UnitView mprofile unit hasEditButton) =
+    renderView' mprofile $ unitView unit hasEditButton
 
-unitView unit hasEditButton = containerLarge $ do
+unitView unit hasEditButton = containerMedium $ do
   title' "Business unit" hasEditButton
   H.dl ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short" $ do
-    keyValuePair "ID" (Business._entityId unit)
-
+    keyValuePair "ID"   (Business._entityId unit)
+    keyValuePair "Name" (Business._entityName unit)
+    maybe mempty (keyValuePair "Description") (Business._entityDescription unit)
 
 --------------------------------------------------------------------------------
 data CreateUnitPage = CreateUnitPage

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -55,7 +55,7 @@ instance H.ToMarkup CreateContractPage where
       panel "General information" $ do
 
         -- TODO I guess this should be the real name ?
-        formKeyValue "Worker name" displayName
+        formKeyValue "Worker username" username
         Misc.inputSelect_
           "project"
           "Project"
@@ -99,7 +99,8 @@ instance H.ToMarkup CreateContractPage where
 
       autoReload
    where
-    displayName = User.unUserDisplayName $ User._userProfileDisplayName profile
+    username =
+      User.unUserName . User._userCredsName $ User._userProfileCreds profile
 
 groupRisks = H.div ! A.class_ "o-form-group" $ do
   H.label ! A.class_ "o-form-group__label" $ "Work risks"
@@ -278,12 +279,12 @@ instance H.ToMarkup ConfirmContractPage where
         $ H.dl
         ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
         $ do
-            keyValuePair "Worker name"    displayName
-            keyValuePair "Project"        _createContractProject
-            keyValuePair "Purchase order" _createContractPO
-            keyValuePair "Role"           _createContractRole
-            keyValuePair "Work type"      _createContractType
-            keyValuePair "Description"    _createContractDescription
+            keyValuePair "Worker username" username
+            keyValuePair "Project"         _createContractProject
+            keyValuePair "Purchase order"  _createContractPO
+            keyValuePair "Role"            _createContractRole
+            keyValuePair "Work type"       _createContractType
+            keyValuePair "Description"     _createContractDescription
 
       H.div
         ! A.class_ "u-padding-vertical-l"
@@ -304,8 +305,9 @@ instance H.ToMarkup ConfirmContractPage where
 
       autoReload
    where
-    displayName = User.unUserDisplayName $ User._userProfileDisplayName profile
-    titles      = ["Amount"]
+    username =
+      User.unUserName . User._userCredsName $ User._userProfileCreds profile
+    titles = ["Amount"]
     display
       :: Text
       -> Int

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -96,8 +96,6 @@ instance H.ToMarkup CreateContractPage where
 
       groupLayout $ do
         submitButton saveUrl "Save changes"
-
-      autoReload
    where
     username =
       User.unUserName . User._userCredsName $ User._userProfileCreds profile
@@ -302,8 +300,6 @@ instance H.ToMarkup ConfirmContractPage where
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)
       button submitUrl "Submit contract"
-
-      autoReload
    where
     username =
       User.unUserName . User._userCredsName $ User._userProfileCreds profile

--- a/src/Curiosity/Html/Legal.hs
+++ b/src/Curiosity/Html/Legal.hs
@@ -24,8 +24,8 @@ data EntityView = EntityView
   }
 
 instance H.ToMarkup EntityView where
-  toMarkup (EntityView profile entity hasEditButton) =
-    renderView $ entityView entity hasEditButton
+  toMarkup (EntityView mprofile entity hasEditButton) =
+    renderView' mprofile $ entityView entity hasEditButton
 
 entityView entity hasEditButton = containerLarge $ do
   title' "Legal entity" hasEditButton

--- a/src/Curiosity/Html/Legal.hs
+++ b/src/Curiosity/Html/Legal.hs
@@ -17,12 +17,14 @@ import qualified Text.Blaze.Html5.Attributes   as A
 
 --------------------------------------------------------------------------------
 data EntityView = EntityView
-  { _entityViewEntity        :: Legal.Entity
+  { _entityViewUser          :: Maybe User.UserProfile
+    -- ^ The logged-in user, if any.
+  , _entityViewEntity        :: Legal.Entity
   , _entityViewHasEditButton :: Maybe H.AttributeValue
   }
 
 instance H.ToMarkup EntityView where
-  toMarkup (EntityView entity hasEditButton) =
+  toMarkup (EntityView profile entity hasEditButton) =
     renderView $ entityView entity hasEditButton
 
 entityView entity hasEditButton = containerLarge $ do

--- a/src/Curiosity/Html/Legal.hs
+++ b/src/Curiosity/Html/Legal.hs
@@ -27,13 +27,14 @@ instance H.ToMarkup EntityView where
   toMarkup (EntityView mprofile entity hasEditButton) =
     renderView' mprofile $ entityView entity hasEditButton
 
-entityView entity hasEditButton = containerLarge $ do
+entityView entity hasEditButton = containerMedium $ do
   title' "Legal entity" hasEditButton
   H.dl ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short" $ do
     keyValuePair "ID"                (Legal._entityId entity)
     keyValuePair "Registration name" (Legal._entityName entity)
     keyValuePair "CBE number"        (Legal._entityCbeNumber entity)
     keyValuePair "VAT number"        (Legal._entityVatNumber entity)
+    maybe mempty (keyValuePair "Description") (Legal._entityDescription entity)
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -17,6 +17,7 @@ module Curiosity.Html.Misc
   , title
   , title'
   , inputText
+  , disabledText
   , submitButton
   , button
   , buttonLink
@@ -165,19 +166,44 @@ title' s mEditButton =
           $ H.text s
         maybe mempty editButton mEditButton
 
+disabledText
+  :: Text -> H.AttributeValue -> Maybe H.AttributeValue -> Maybe Text -> Html
+disabledText label name mvalue mhelp = inputText' label name mvalue mhelp True
+
 inputText
   :: Text -> H.AttributeValue -> Maybe H.AttributeValue -> Maybe Text -> Html
-inputText label name mvalue mhelp = H.div ! A.class_ "o-form-group" $ do
-  H.label ! A.class_ "o-form-group__label" ! A.for name $ H.toHtml label
+inputText label name mvalue mhelp = inputText' label name mvalue mhelp False
+
+inputText'
+  :: Text
+  -> H.AttributeValue
+  -> Maybe H.AttributeValue
+  -> Maybe Text
+  -> Bool
+  -> Html
+inputText' label name mvalue mhelp disabled =
+  H.div ! A.class_ "o-form-group" $ do
+    H.label ! A.class_ "o-form-group__label" ! A.for name $ H.toHtml label
+    H.div
+      ! A.class_ "o-form-group__controls o-form-group__controls--full-width"
+      $ do
+          (if disabled then (! (A.disabled "disabled")) else identity)
+            $ maybe identity (\value -> (! (A.value value))) mvalue
+            $ H.input
+            ! A.class_ "c-input"
+            ! A.id name
+            ! A.name name
+          maybe mempty ((H.p ! A.class_ "c-form-help-text") . H.text) mhelp
+
+inputPassword = H.div ! A.class_ "o-form-group" $ do
+  H.label ! A.class_ "o-form-group__label" ! A.for "password" $ "Password"
   H.div
     ! A.class_ "o-form-group__controls o-form-group__controls--full-width"
-    $ do
-        maybe identity (\value -> (! (A.value value))) mvalue
-          $ H.input
-          ! A.class_ "c-input"
-          ! A.id name
-          ! A.name name
-        maybe mempty ((H.p ! A.class_ "c-form-help-text") . H.text) mhelp
+    $ H.input
+    ! A.class_ "c-input"
+    ! A.type_ "password"
+    ! A.id "password"
+    ! A.name "password"
 
 submitButton :: H.AttributeValue -> Html -> Html
 submitButton submitUrl label =

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -12,6 +12,7 @@ module Curiosity.Html.Misc
   , groupLayout
   , panel
   , panelStandard
+  , header
 
   -- Form
   , title
@@ -31,13 +32,16 @@ module Curiosity.Html.Misc
 
   -- Keep here:
   , renderView
+  , renderView'
   , renderForm
   , renderFormLarge
   , autoReload
   ) where
 
 import qualified Curiosity.Data.User           as User
-import           Curiosity.Html.Navbar          ( navbar )
+import           Curiosity.Html.Navbar          ( navbar
+                                                , navbarWebsite
+                                                )
 import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Render             as Render
 import           Smart.Html.Shared.Html.Icons   ( divIconAdd
@@ -89,6 +93,15 @@ keyValuePair key value = H.div ! A.class_ "c-key-value-item" $ do
 fullScroll content = H.main ! A.class_ "u-maximize-width" $ do
   content
 
+renderView' mprofile content =
+  Render.renderCanvasFullScroll
+    . Dsl.SingletonCanvas
+    $ H.div
+    ! A.class_ "c-app-layout u-scroll-vertical"
+    $ do
+        header mprofile
+        fullScroll content
+
 renderView content =
   Render.renderCanvasFullScroll
     . Dsl.SingletonCanvas
@@ -97,6 +110,15 @@ renderView content =
     $ do
         H.header $ H.toMarkup . navbar $ "TODO username"
         fullScroll content
+
+header mprofile = H.header $ case mprofile of
+  Just profile ->
+    H.toMarkup
+      . navbar
+      . User.unUserName
+      . User._userCredsName
+      $ User._userProfileCreds profile
+  Nothing -> H.toMarkup navbarWebsite
 
 renderForm :: User.UserProfile -> Html -> Html
 renderForm profile content =

--- a/src/Curiosity/Html/Navbar.hs
+++ b/src/Curiosity/Html/Navbar.hs
@@ -3,15 +3,24 @@ Module: Curiosity.Html.Navbar
 Description: A navigation bar for Curiosity.
 -}
 module Curiosity.Html.Navbar
-  ( navbar
+  ( navbarWebsite
+  , navbar
   ) where
 
 import           Smart.Html.Avatar
 import qualified Smart.Html.Navbar             as Navbar
+import qualified Smart.Html.Pages.LandingPage  as Pages
 import           Smart.Html.Shared.Html.Icons
 
 
 --------------------------------------------------------------------------------
+-- The (not logged-in) website navbar.
+navbarWebsite :: Navbar.NavbarWebsite
+navbarWebsite = Pages.navigation
+
+
+--------------------------------------------------------------------------------
+-- The (logged-in) application navbar.
 navbar :: Text -> Navbar.Navbar
 navbar name = Navbar.Navbar [] [helpEntry, plusEntry, userEntry name]
 

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -276,10 +276,7 @@ publicProfileView profile =
             ! A.class_ "c-toolbar__left"
             $ H.h3
             ! A.class_ "c-h3 u-m-b-0"
-            $ do
-                "Public profile "
-                H.toHtml
-                  (User._userCredsName . User._userProfileCreds $ profile)
+            $ "Public profile"
     H.dl
       ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
       $ do

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -15,6 +15,7 @@ import           Curiosity.Html.Navbar          ( navbar
                                                 )
 import qualified Smart.Html.Dsl                as Dsl
 import           Smart.Html.Layout
+import qualified Smart.Html.Misc               as Misc
 import qualified Smart.Html.Render             as Render
 import           Smart.Html.Shared.Html.Icons   ( svgIconAdd
                                                 , svgIconArrowRight
@@ -60,6 +61,12 @@ instance H.ToMarkup ProfilePage where
           )
         $ Just
             "This is the name that appears in e.g. your public profile and can be left empty if you prefer."
+      Misc.inputTextarea "bio"
+                         "Bio"
+                         6
+                         "The bio appears on your public profile"
+                         (maybe "" identity . User._userProfileBio $ profile)
+                         True
       disabledText "Email address"
                    "email-addr"
                    (Just . H.toValue . User._userProfileEmailAddr $ profile)
@@ -195,6 +202,7 @@ profileView profile hasEditButton =
           keyValuePair @Text "Password" ""
           keyValuePair "Display name"
             $ maybe "" identity (User._userProfileDisplayName profile)
+          keyValuePair "Bio" $ maybe "" identity (User._userProfileBio profile)
           keyValuePair "Email address" (User._userProfileEmailAddr profile)
           keyValuePair
             "Email addr. verified"
@@ -291,6 +299,7 @@ publicProfileView profile =
           maybe mempty
                 (keyValuePair "Display name")
                 (User._userProfileDisplayName profile)
+          maybe mempty (keyValuePair "Bio") (User._userProfileBio profile)
 
 -- TODO Move to smart-design-hs and refactor.
 contractCreate1Confirm =

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -10,9 +10,7 @@ module Curiosity.Html.Profile
 
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
-import           Curiosity.Html.Navbar          ( navbar
-                                                , navbarWebsite
-                                                )
+import           Curiosity.Html.Navbar          ( navbar )
 import qualified Smart.Html.Dsl                as Dsl
 import           Smart.Html.Layout
 import qualified Smart.Html.Misc               as Misc
@@ -262,15 +260,7 @@ instance H.ToMarkup PublicProfileView where
       $ H.div
       ! A.class_ "c-app-layout u-scroll-vertical"
       $ do
-          case mprofile of
-            Just profile ->
-              H.header
-                $ H.toMarkup
-                . navbar
-                . User.unUserName
-                . User._userCredsName
-                $ User._userProfileCreds profile
-            Nothing -> H.header $ H.toMarkup navbarWebsite
+          header mprofile
           H.main ! A.class_ "u-maximize-width" $ publicProfileView targetProfile
 
 publicProfileView profile =

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -58,9 +58,15 @@ instance H.ToMarkup ProfilePage where
           ! A.type_ "password"
           ! A.id "password"
           ! A.name "password"
-      inputText "Display name"
-                "display-name"
-                (Just . H.toValue . User._userProfileDisplayName $ profile)
+      inputText
+          "Display name"
+          "display-name"
+          ( Just
+          . H.toValue
+          . maybe "" identity
+          . User._userProfileDisplayName
+          $ profile
+          )
         $ Just "This is the name that appears in e.g. your public profile"
       inputText "Email address"
                 "email-addr"
@@ -195,7 +201,9 @@ profileView profile hasEditButton =
             "Username"
             (User._userCredsName . User._userProfileCreds $ profile)
           keyValuePair @Text "Password" ""
-          keyValuePair "Display name"  (User._userProfileDisplayName profile)
+          maybe mempty
+                (keyValuePair "Display name")
+                (User._userProfileDisplayName profile)
           keyValuePair "Email address" (User._userProfileEmailAddr profile)
           keyValuePair
             "Email addr. verified"
@@ -289,7 +297,9 @@ publicProfileView profile =
           keyValuePair
             "Username"
             (User._userCredsName . User._userProfileCreds $ profile)
-          keyValuePair "Display name" (User._userProfileDisplayName profile)
+          maybe mempty
+                (keyValuePair "Display name")
+                (User._userProfileDisplayName profile)
 
 -- TODO Move to smart-design-hs and refactor.
 contractCreate1Confirm =

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -6,7 +6,6 @@ module Curiosity.Html.Profile
   ( ProfilePage(..)
   , ProfileView(..)
   , PublicProfileView(..)
-  , ProfileSaveConfirmPage(..)
   ) where
 
 import qualified Curiosity.Data.User           as User
@@ -319,15 +318,3 @@ contractCreate1Confirm =
           keyValuePair @Text "Compensation budget" "1000.00 EUR"
           keyValuePair @Text "Project" "Unspecified"
           keyValuePair @Text "Description" "Some description."
-
-
-data ProfileSaveConfirmPage = ProfileSaveSuccess
-                            | ProfileSaveFailure (Maybe Text)
-                            deriving Show
-
-instance H.ToMarkup ProfileSaveConfirmPage where
-  toMarkup = \case
-    ProfileSaveSuccess      -> "All done, you can now go back."
-    ProfileSaveFailure mmsg -> do
-      H.text "We had a problem saving your data."
-      maybe mempty (H.text . mappend "Reason: ") mmsg

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -11,7 +11,9 @@ module Curiosity.Html.Profile
 
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
-import           Curiosity.Html.Navbar          ( navbar )
+import           Curiosity.Html.Navbar          ( navbar
+                                                , navbarWebsite
+                                                )
 import qualified Smart.Html.Dsl                as Dsl
 import           Smart.Html.Layout
 import qualified Smart.Html.Render             as Render
@@ -240,23 +242,29 @@ profileView profile hasEditButton =
                        (show . User._userProfileRights $ profile :: Text)
 
 data PublicProfileView = PublicProfileView
-  { _publicProfileViewUserProfile :: User.UserProfile
+  { _publicProfileViewUserProfile   :: (Maybe User.UserProfile)
+    -- ^ The logged in user, if any
+  , _publicProfileViewTargetProfile :: User.UserProfile
+    -- ^ The profile being displayed
   }
 
 instance H.ToMarkup PublicProfileView where
-  toMarkup (PublicProfileView profile) =
+  toMarkup (PublicProfileView mprofile targetProfile) =
     Render.renderCanvasFullScroll
       . Dsl.SingletonCanvas
       $ H.div
       ! A.class_ "c-app-layout u-scroll-vertical"
       $ do
-          H.header
-            $ H.toMarkup
-            . navbar
-            . User.unUserName
-            . User._userCredsName
-            $ User._userProfileCreds profile
-          H.main ! A.class_ "u-maximize-width" $ publicProfileView profile
+          case mprofile of
+            Just profile ->
+              H.header
+                $ H.toMarkup
+                . navbar
+                . User.unUserName
+                . User._userCredsName
+                $ User._userProfileCreds profile
+            Nothing -> H.header $ H.toMarkup navbarWebsite
+          H.main ! A.class_ "u-maximize-width" $ publicProfileView targetProfile
 
 publicProfileView profile =
   containerMedium $ H.div ! A.class_ "u-spacer-bottom-xl" $ do

--- a/src/Curiosity/Html/Profile.hs
+++ b/src/Curiosity/Html/Profile.hs
@@ -39,7 +39,7 @@ instance H.ToMarkup ProfilePage where
   toMarkup (ProfilePage profile submitUrl) =
     renderForm profile $ groupLayout $ do
       title "User profile"
-      inputText
+      disabledText
           "Username"
           "username"
           ( Just
@@ -48,16 +48,8 @@ instance H.ToMarkup ProfilePage where
           . User._userProfileCreds
           $ profile
           )
-        $ Just "This is your public username"
-      H.div ! A.class_ "o-form-group" $ do
-        H.label ! A.class_ "o-form-group__label" ! A.for "password" $ "Password"
-        H.div
-          ! A.class_ "o-form-group__controls o-form-group__controls--full-width"
-          $ H.input
-          ! A.class_ "c-input"
-          ! A.type_ "password"
-          ! A.id "password"
-          ! A.name "password"
+        $ Just "This is your username. It can not be changed."
+      disabledText "Password" "password" (Just "") Nothing
       inputText
           "Display name"
           "display-name"
@@ -67,11 +59,12 @@ instance H.ToMarkup ProfilePage where
           . User._userProfileDisplayName
           $ profile
           )
-        $ Just "This is the name that appears in e.g. your public profile"
-      inputText "Email address"
-                "email-addr"
-                (Just . H.toValue . User._userProfileEmailAddr $ profile)
-        $ Just "Your email address is private"
+        $ Just
+            "This is the name that appears in e.g. your public profile and can be left empty if you prefer."
+      disabledText "Email address"
+                   "email-addr"
+                   (Just . H.toValue . User._userProfileEmailAddr $ profile)
+        $ Just "Your email address is private."
       submitButton submitUrl "Update profile"
 
 -- Partial re-creation of
@@ -201,9 +194,8 @@ profileView profile hasEditButton =
             "Username"
             (User._userCredsName . User._userProfileCreds $ profile)
           keyValuePair @Text "Password" ""
-          maybe mempty
-                (keyValuePair "Display name")
-                (User._userProfileDisplayName profile)
+          keyValuePair "Display name"
+            $ maybe "" identity (User._userProfileDisplayName profile)
           keyValuePair "Email address" (User._userProfileEmailAddr profile)
           keyValuePair
             "Email addr. verified"

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -743,7 +743,7 @@ createUser db User.Signup {..} = do
     let newProfile = User.UserProfile
           newId
           (User.Credentials username password)
-          "TODO"
+          Nothing
           email
           Nothing
           tosConsent

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -31,6 +31,8 @@ module Curiosity.Runtime
   , checkCredentials
   -- * High-level entity operations
   , selectEntityBySlug
+  -- * High-level unit operations
+  , selectUnitBySlug
   -- * Form edition
   , newCreateContractForm
   , readCreateContractForm
@@ -875,6 +877,13 @@ selectEntityBySlug db name = do
   let tvar = Data._dbLegalEntities db
   records <- STM.readTVar tvar
   pure $ find ((== name) . Legal._entitySlug) records
+
+selectUnitBySlug
+  :: forall runtime . Data.StmDb runtime -> Text -> STM (Maybe Business.Entity)
+selectUnitBySlug db name = do
+  let tvar = Data._dbBusinessEntities db
+  records <- STM.readTVar tvar
+  pure $ find ((== name) . Business._entitySlug) records
 
 withRuntimeAtomically f a = ask >>= \rt -> liftIO . STM.atomically $ f rt a
 

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -601,13 +601,10 @@ handleUserProfileUpdate
   => User.Update
   -> User.UserProfile
   -> m (Headers '[Header "Location" Text] NoContent)
-handleUserProfileUpdate User.Update {..} profile = do
+handleUserProfileUpdate update profile = do
   db   <- asks Rt._rDb
   eIds <- S.liftTxn
-    (S.dbUpdate @m @STM
-      db
-      (User.UserDisplayNameUpdate (S.dbId profile) _updateDisplayName)
-    )
+    (S.dbUpdate @m @STM db (User.UserUpdate (S.dbId profile) update))
 
   case eIds of
     Right (Right [_]) ->

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -988,7 +988,7 @@ withMaybeEntityFromName
   -> (Legal.Entity -> m a)
   -> m a
 withMaybeEntityFromName name a f = do
-  mentity <- Rt.withRuntimeAtomically (Rt.selectEntityByName . Rt._rDb) name
+  mentity <- Rt.withRuntimeAtomically (Rt.selectEntityBySlug . Rt._rDb) name
   maybe (a name) f mentity
 
 

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1081,7 +1081,7 @@ serveEntity
 serveEntity authResult name = withEntityFromName name $ \targetEntity ->
   withMaybeUser
     authResult
-    (const . pure $ Pages.EntityView Nothing targetEntity (Just "#"))
+    (const . pure $ Pages.EntityView Nothing targetEntity Nothing)
     (\profile -> pure $ Pages.EntityView (Just profile) targetEntity (Just "#"))
 
 

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -203,6 +203,7 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
              :<|> "errors" :> "500" :> Get '[B.HTML, JSON] Text
              -- TODO Make a single handler for any namespace:
              :<|> "alice" :> H.UserAuthentication :> Get '[B.HTML] Pages.PublicProfileView
+             :<|> "mila"  :> H.UserAuthentication :> Get '[B.HTML] Pages.PublicProfileView
              :<|> "alice+" :> Get '[B.HTML] Pages.ProfileView
              :<|> "entity" :> H.UserAuthentication
                   :> Capture "name" Text
@@ -263,6 +264,7 @@ serverT conf jwtS root dataDir =
     :<|> serveUBL dataDir
     :<|> serveErrors
     :<|> serveNamespace "alice"
+    :<|> serveNamespace "mila"
     :<|> serveNamespaceDocumentation "alice"
     :<|> serveEntity
     :<|> websocket
@@ -1056,7 +1058,7 @@ errorFormatters = defaultErrorFormatters
 
 --------------------------------------------------------------------------------
 -- | Serve the pages under a namespace. TODO Currently the namespace is
--- hard-coded to "alice"
+-- hard-coded to "alice" and "mila"
 serveNamespace
   :: ServerC m
   => User.UserName

--- a/tests/Curiosity/RunSpec.hs
+++ b/tests/Curiosity/RunSpec.hs
@@ -1,0 +1,24 @@
+module Curiosity.RunSpec
+  ( spec
+  ) where
+
+import           Curiosity.Run
+import           Test.Hspec
+
+
+--------------------------------------------------------------------------------
+spec :: Spec
+spec = do
+  describe "wordsq" $ do
+    let examples =
+          [ ("Hello world."            , ["Hello", "world."])
+          , ("\"Hello world.\""        , ["Hello world."])
+          , ("\"Hello\" world."        , ["Hello", "world."])
+          , ("Hello \"world.\""        , ["Hello", "world."])
+          , ("Hello \"the world.\""    , ["Hello", "the world."])
+          , ("Hello \"the the\" world.", ["Hello", "the the", "world."])
+          , ("Hel\"lo world."          , ["Hel\"lo", "world."])
+          ]
+        f (input, expected) =
+          it ("Split " <> input) $ wordsq input `shouldBe` expected
+    mapM_ f examples

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -5,6 +5,7 @@ module CuriositySpec
 import qualified Curiosity.Command             as Command
 import qualified Curiosity.Data                as Data
 import qualified Curiosity.Data.Counter        as C
+import qualified Curiosity.Data.Legal          as Legal
 import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Run                 as Run
 import qualified Data.Aeson                    as Aeson
@@ -19,6 +20,8 @@ import           Test.Hspec
 --------------------------------------------------------------------------------
 spec :: Spec
 spec = do
+  -- This makes sure we can parse the example data files. Otherwise we can
+  -- forget to update them as we change their corresponding data types.
   describe "UserProfile JSON parser" $ do
     let go (filename, username) = it ("Parses " <> filename) $ do
           Right (result :: User.UserProfile) <- parseFile $ "data/" </> filename
@@ -27,11 +30,25 @@ spec = do
     mapM_
       go
       [ ("alice.json"  , "alice")
+      , ("alice-with-bio.json"  , "alice")
       , ("bob-0.json"  , "bob")
       , ("bob-1.json"  , "bob")
       , ("bob-2.json"  , "bob")
       , ("charlie.json", "charlie")
       ]
+
+  -- Same here.
+  describe "Legal entity JSON parser" $ do
+    let go (filename, slug) = it ("Parses " <> filename) $ do
+          Right (result :: Legal.Entity) <- parseFile $ "data/" </> filename
+          Legal._entitySlug result
+            `shouldBe` slug
+    mapM_
+      go
+      [ ("one.json"  , "one")
+      ]
+
+  -- TODO Check that all the files in data/ are in one of the above lists.
 
   describe "Command-line interface parser" $ do
     let go (arguments, command) =

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -22,14 +22,15 @@ spec = do
   describe "UserProfile JSON parser" $ do
     let go (filename, username) = it ("Parses " <> filename) $ do
           Right (result :: User.UserProfile) <- parseFile $ "data/" </> filename
-          User._userProfileDisplayName result `shouldBe` username
+          User._userCredsName (User._userProfileCreds result)
+            `shouldBe` username
     mapM_
       go
-      [ ("alice.json"  , "TODO")
-      , ("bob-0.json"  , "Bob")
-      , ("bob-1.json"  , "Bob")
-      , ("bob-2.json"  , "Bob")
-      , ("charlie.json", "Charlie")
+      [ ("alice.json"  , "alice")
+      , ("bob-0.json"  , "bob")
+      , ("bob-1.json"  , "bob")
+      , ("bob-2.json"  , "bob")
+      , ("charlie.json", "charlie")
       ]
 
   describe "Command-line interface parser" $ do
@@ -75,7 +76,7 @@ spec = do
               }
         mapM_
           go
-          [ ("init", Data.emptyHask)
+          [ ("init" , Data.emptyHask)
           , ("user create alice a alice@example.com --accept-tos", aliceState)
           , ("reset", Data.emptyHask)
           ]

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -4,6 +4,7 @@ module CuriositySpec
 
 import qualified Curiosity.Command             as Command
 import qualified Curiosity.Data                as Data
+import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Counter        as C
 import qualified Curiosity.Data.Legal          as Legal
 import qualified Curiosity.Data.User           as User
@@ -46,6 +47,17 @@ spec = do
     mapM_
       go
       [ ("one.json"  , "one")
+      ]
+
+  -- Same here.
+  describe "Business unit JSON parser" $ do
+    let go (filename, slug) = it ("Parses " <> filename) $ do
+          Right (result :: Business.Entity) <- parseFile $ "data/" </> filename
+          Business._entitySlug result
+            `shouldBe` slug
+    mapM_
+      go
+      [ ("alpha.json", "alpha")
       ]
 
   -- TODO Check that all the files in data/ are in one of the above lists.


### PR DESCRIPTION
The general idea of this PR is to start having nice web page to present example data in a realistic fashion (i.e. similarly to a real application would), and to describe those example data to have a common, known set of objects to manipulate in test scenarios.

A first set of would-be well-known objects called `state-0` is thus included. To set the state of the system in that known state, scripts intended for `cty run` are used (`cty run` was improved in the previous merge commit for that purpose).

To make things a bit more interesting and pave the road to richer objects, some fields were added: basically, names and bio or description. The bio and description are used to give some "personality" to the example objects, so that they are more relatable.