### PR TITLE
Web page to run `cty run` commands

### DIFF
--- a/content/documentation/clis.md
+++ b/content/documentation/clis.md
@@ -14,6 +14,9 @@ rendered as HTML pages:
 - [`curiosity(7)`](/documentation/clis/curiosity.7)
 - [`cty(1)`](/documentation/clis/cty.1)
 
+It is also possible to submit individual commands through a [web
+interface](/run).
+
 # Quick start
 
 This quick start section assumes you have SSH access to the Linux user `alice`

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -111,6 +111,7 @@ library
     Curiosity.Html.Misc
     Curiosity.Html.Navbar
     Curiosity.Html.Profile
+    Curiosity.Interpret
     Curiosity.Parse
     Curiosity.Process
     Curiosity.Run

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -26,9 +26,12 @@ module Curiosity.Data
   , genRandomText
   , readStdGen
   , writeStdGen
+  -- * Re-exports
+  , Command.Command(..)
   ) where
 
 import qualified Curiosity.Data.Counter        as C
+import qualified Curiosity.Data.Command        as Command ( Command(..) )
 import qualified Commence.Runtime.Errors       as E
 import qualified Control.Concurrent.STM        as STM
 import qualified Curiosity.Data.Business       as Business

--- a/src/Curiosity/Data/Command.hs
+++ b/src/Curiosity/Data/Command.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+{- |
+Module: Curiosity.Data.Command
+Description: A command received from the web interface.
+-}
+module Curiosity.Data.Command
+  ( Command(..)
+  ) where
+
+import qualified Commence.Runtime.Errors       as Errs
+import qualified Commence.Runtime.Storage      as Storage
+import qualified Commence.Types.Secret         as Secret
+import qualified Commence.Types.Wrapped        as W
+import           Control.Lens
+import qualified Curiosity.Html.Errors         as Pages
+import           Data.Aeson
+import qualified Data.Text                     as T
+import qualified Data.Text.Lazy                as LT
+import qualified Network.HTTP.Types            as HTTP
+import qualified Servant.Auth.Server           as SAuth
+import qualified Smart.Server.Page.Navbar      as Nav
+import qualified Text.Blaze.Html5              as H
+import           Text.Blaze.Html5               ( (!) )
+import qualified Text.Blaze.Html5.Attributes   as A
+import           Text.Blaze.Renderer.Text       ( renderMarkup )
+import           Web.FormUrlEncoded             ( FromForm(..)
+                                                , parseMaybe
+                                                , parseUnique
+                                                )
+import           Web.HttpApiData                ( FromHttpApiData(..) )
+
+
+--------------------------------------------------------------------------------
+-- | Represent a command received through a web page.
+-- the operation to create a user.
+data Command = Command { command :: Text }
+  deriving (Generic, Eq, Show)
+
+instance FromForm Command where
+  fromForm f = Command <$> parseUnique "command" f

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -34,6 +34,7 @@ module Curiosity.Html.Misc
   , renderView
   , renderView'
   , renderForm
+  , renderForm'
   , renderFormLarge
   , autoReload
   ) where
@@ -119,6 +120,17 @@ header mprofile = H.header $ case mprofile of
       . User._userCredsName
       $ User._userProfileCreds profile
   Nothing -> H.toMarkup navbarWebsite
+
+renderForm' :: Maybe User.UserProfile -> Html -> Html
+renderForm' mprofile content =
+  Render.renderCanvasFullScroll
+    . Dsl.SingletonCanvas
+    $ H.div
+    ! A.class_ "c-app-layout u-scroll-vertical"
+    $ do
+        header mprofile
+        H.main ! A.class_ "u-maximize-width" $ containerMedium $ do
+          H.form $ content
 
 renderForm :: User.UserProfile -> Html -> Html
 renderForm profile content =

--- a/src/Curiosity/Html/Run.hs
+++ b/src/Curiosity/Html/Run.hs
@@ -1,0 +1,44 @@
+{- |
+Module: Curiosity.Html.Run
+Description: A page to run a `cty run` command.
+-}
+module Curiosity.Html.Run
+  ( RunPage(..)
+  ) where
+
+import qualified Curiosity.Data.User           as User
+import           Curiosity.Html.Misc
+import           Curiosity.Html.Navbar          ( navbar )
+import qualified Smart.Html.Dsl                as Dsl
+import           Smart.Html.Layout
+import qualified Smart.Html.Misc               as Misc
+import qualified Smart.Html.Render             as Render
+import           Smart.Html.Shared.Html.Icons   ( svgIconAdd
+                                                , svgIconArrowRight
+                                                )
+import           Smart.Html.SideMenu            ( SideMenu(..)
+                                                , SideMenuItem(..)
+                                                )
+import           Text.Blaze                     ( customAttribute )
+import qualified Text.Blaze.Html5              as H
+import           Text.Blaze.Html5               ( (!) )
+import qualified Text.Blaze.Html5.Attributes   as A
+
+
+--------------------------------------------------------------------------------
+data RunPage = RunPage
+  { _runPageUserProfile :: Maybe User.UserProfile
+  , _runPageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup RunPage where
+  toMarkup (RunPage mprofile submitUrl) =
+    renderForm' mprofile $ groupLayout $ do
+      title "Run a command"
+      inputText
+          "Command"
+          "command"
+          Nothing
+        $ Just
+            "A command similar to what `cty run` can accept."
+      submitButton submitUrl "Run"

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE TupleSections #-}
+module Curiosity.Interpret
+  ( interpretFile
+  , interpret'
+  , formatOutput
+  , wordsq
+  ) where
+
+import qualified Curiosity.Command             as Command
+import qualified Curiosity.Data.User           as User
+import qualified Curiosity.Runtime             as Rt
+import           Data.List                      ( last )
+import qualified Data.Text                     as T
+import qualified Options.Applicative           as A
+import           System.FilePath                ( (</>)
+                                                , takeDirectory
+                                                )
+
+
+--------------------------------------------------------------------------------
+interpretFile
+  :: Rt.Runtime
+  -> User.UserName
+  -> FilePath
+  -> Int
+  -> IO [(Int, ExitCode, Text)]
+interpretFile runtime user path nesting = do
+  let dir = takeDirectory path
+  content <- T.lines <$> readFile path
+  interpret' runtime user dir content nesting
+
+interpret'
+  :: Rt.Runtime
+  -> User.UserName
+  -> FilePath
+  -> [Text]
+  -> Int
+  -> IO [(Int, ExitCode, Text)]
+interpret' runtime user dir content nesting = do
+  (_, output) <- foldlM loop (user, []) $ zip [1 :: Int ..] content
+  pure output
+ where
+  loop (user', acc) (ln, line) = do
+    let (prefix, comment) = T.breakOn "#" line
+        separated         = map T.pack . wordsq $ T.unpack prefix
+        grouped           = T.unwords separated
+    case separated of
+      []               -> pure (user', acc)
+      ["as", username] -> do
+        let output = [show ln <> ": " <> grouped, "Modifiying default user."]
+        pure
+          (User.UserName username, acc ++ map (nesting, ExitSuccess, ) output)
+      ["quit"] -> do
+        let output = [show ln <> ": " <> grouped, "Exiting."]
+        pure (user', acc ++ map (nesting, ExitSuccess, ) output)
+      input -> do
+        let output_ = [show ln <> ": " <> grouped]
+            result =
+              A.execParserPure A.defaultPrefs Command.parserInfo
+                $   T.unpack
+                <$> input
+        case result of
+          A.Success command -> do
+            case command of
+              Command.Reset _ -> do
+                let output = output_ ++ ["Resetting to the empty state."]
+                Rt.reset runtime
+                pure (user', acc ++ map (nesting, ExitSuccess, ) output)
+              Command.Run _ scriptPath -> do
+                output' <- liftIO $ interpretFile runtime
+                                                       user
+                                                       (dir </> scriptPath)
+                                                       (succ nesting)
+                pure
+                  ( user'
+                  , acc ++ map (nesting, ExitSuccess, ) output_ ++ output'
+                  )
+              _ -> do
+                (_, output) <- Rt.handleCommand runtime user' command
+                pure
+                  ( user'
+                  , acc ++ map (nesting, ExitSuccess, ) (output_ ++ output)
+                  )
+          A.Failure err ->
+            pure (user', acc ++ [(nesting, ExitFailure 1, show err)])
+          A.CompletionInvoked _ ->
+            pure (user', acc ++ [(nesting, ExitFailure 1, "Shouldn't happen")])
+
+
+--------------------------------------------------------------------------------
+formatOutput :: [(Int, ExitCode, Text)] -> (ExitCode, [Text])
+formatOutput output =
+  let len     = length $ takeWhile ((== ExitSuccess) . snd3) output
+      output' = take (len + 1) output
+      pad 0 = ""
+      pad 1 = "> "
+      pad n = T.concat (replicate ((n - 1) * 2) ">") <> "> "
+      ls =  map (\(a, _, c) -> pad a <> c) output'
+  in (snd3 . last $ (0, ExitSuccess, "") : output', ls)
+
+snd3 (_, b, _) = b
+thd3 (_, _, c) = c
+
+
+--------------------------------------------------------------------------------
+-- From https://stackoverflow.com/questions/4334897/functionally-split-a-string-by-whitespace-group-by-quotes
+wordsq = outside [] . (' ' :)
+
+add c res = if null res then [[c]] else map (++ [c]) res
+
+outside res xs = case xs of
+  ' ' : ' '  : ys -> outside res $ ' ' : ys
+  ' ' : '\"' : ys -> res ++ inside [] ys
+  ' '        : ys -> res ++ outside [] ys
+  c          : ys -> outside (add c res) ys
+  _               -> res
+
+inside res xs = case xs of
+  ' '  : ' ' : ys -> inside res $ ' ' : ys
+  '\"' : ' ' : ys -> res ++ outside [] (' ' : ys)
+  '\"'       : [] -> res
+  c          : ys -> inside (add c res) ys
+  _               -> res
+

--- a/tests/run-scenarios.hs
+++ b/tests/run-scenarios.hs
@@ -38,7 +38,7 @@ mkGoldenTest path = do
 -- Similar to Run.handleRun, but capturing the output.
 run :: FilePath -> IO [Text]
 run scriptPath = do
-  runtime     <- Rt.boot P.defaultConf >>= either throwIO pure
-  (_, output) <- Run.interpret' runtime "system" scriptPath 0
+  runtime <- Rt.boot P.defaultConf >>= either throwIO pure
+  output  <- Run.interpretFile runtime "system" scriptPath 0
   Rt.powerdown runtime
   pure $ map (\(_ ,_ , c) -> c)  output


### PR DESCRIPTION
This adds a web page with a single field to run a command, similar to what `cty run` supports, and the corresponding POST handler. If the user is logged, their username is used. Otherwise, the command is run as `--user nobody`. This currently doesn't mean anything but could be useful/improved in the future to support some anonymous commands.