### PR TITLE
Complete the contract flow

### DIFF
--- a/data/alice.json
+++ b/data/alice.json
@@ -8,5 +8,5 @@
   "_userProfileTosConsent": true,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
-  "_userProfileRights": ["CanVerifyEmailAddr"]
+  "_userProfileRights": ["CanCreateContracts", "CanVerifyEmailAddr"]
 }

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -448,13 +448,17 @@ parserUsers :: A.Parser Command
 parserUsers = do
   predicate <-
     (  A.flag' User.PredicateEmailAddrToVerify
-      $  A.long "email-addr-to-verify"
-      <> A.help "Show users with an email address to verify."
-      )
-      <|> (  A.flag' (User.PredicateHas User.CanVerifyEmailAddr)
-          $  A.long "can-verify-email-addr"
-          <> A.help "Show users with the right to verify email addresses."
-          )
+    $  A.long "email-addr-to-verify"
+    <> A.help "Show users with an email address to verify."
+    )
+    <|> (  A.flag' (User.PredicateHas User.CanCreateContracts)
+        $  A.long "can-create-contracts"
+        <> A.help "Show users with the right to create contracts."
+        )
+    <|> (  A.flag' (User.PredicateHas User.CanVerifyEmailAddr)
+        $  A.long "can-verify-email-addr"
+        <> A.help "Show users with the right to verify email addresses."
+        )
   pure $ FilterUsers predicate
 
 parserCreateUser :: A.Parser Command

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -15,6 +15,7 @@ module Curiosity.Command
 
 import qualified Commence.Runtime.Storage      as S
 import qualified Curiosity.Data.Business       as Business
+import qualified Curiosity.Data.Employment     as Employment
 import qualified Curiosity.Data.Legal          as Legal
 import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Parse               as P
@@ -54,7 +55,7 @@ data Command =
   | UpdateUser (S.DBUpdate User.UserProfile)
   | SetUserEmailAddrAsVerified User.UserName
     -- ^ High-level operations on users.
-  | CreateEmployment
+  | CreateEmployment Employment.CreateContractAll
   | CreateInvoice
   | ViewQueue QueueName
     -- ^ View queue. The queues can be filters applied to objects, not
@@ -517,7 +518,8 @@ parserEmployment = A.subparser $ A.command
   )
 
 parserCreateEmployment :: A.Parser Command
-parserCreateEmployment = pure CreateEmployment
+parserCreateEmployment =
+  pure $ CreateEmployment Employment.emptyCreateContractAll
 
 parserInvoice :: A.Parser Command
 parserInvoice = A.subparser $ A.command

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -3,9 +3,18 @@
 {- |
 Module: Curiosity.Data.Employment
 Description: Employment related datatypes
+
+This module contains data types used to represent contracts, both as used when
+filling a form, and used as proper validated data.
+
+See also the [related documentation page](/documentation/objects/invoices).
+
 -}
 module Curiosity.Data.Employment
-  ( CreateContractAll(..)
+  ( -- * Form data representation
+    --
+    -- $formDataTypes
+    CreateContractAll(..)
   , CreateContractAll'(..)
   , CreateContractType(..)
   , CreateContractGenInfo(..)
@@ -13,10 +22,19 @@ module Curiosity.Data.Employment
   , CreateContractRisks(..)
   , CreateContractInvoice(..)
   , AddExpense(..)
+    -- * Empty values
+    --
+    -- $emptyValues
   , emptyCreateContractAll
   , emptyCreateContractGenInfo
+  , emptyCreateContractType
+  , emptyCreateContractLocDates
+  , emptyCreateContractRisks
+  , emptyCreateContractInvoice
   , emptyAddExpense
+    -- * Form submittal
   , SubmitContract(..)
+    -- * Main data representation
   , Contract(..)
   , ContractId(..)
   , Err(..)
@@ -30,10 +48,16 @@ import           Web.FormUrlEncoded             ( FromForm(..)
                                                 )
 
 --------------------------------------------------------------------------------
--- | This represent a form being filled in. In particular, it can represent
--- invalid inputs. As it is filled, it is kept in a Map, where it is identified
--- by a key. The form data are validated when they are "submitted", using the
--- SubmitContract data type below, and the key.
+-- $formDataTypes
+--
+-- A contract form, as displayed on a web page, is made of multiple input
+-- groups (or panels, or even of separate pages). Different data types are
+-- provided to represent those sets of input fields.
+
+-- | This represents a form being filled in. In particular, it can represent
+-- invalid inputs. As it is filled, it is kept in a Map in "Curiosity.Data",
+-- where it is identified by a key. The form data are validated when they are
+-- "submitted", using the `SubmitContract` data type below, and the key.
 data CreateContractAll = CreateContractAll CreateContractGenInfo
                                            CreateContractType
                                            CreateContractLocDates
@@ -118,6 +142,15 @@ data AddExpense = AddExpense
 
 instance FromForm AddExpense where
   fromForm f = AddExpense <$> parseUnique "amount" f
+
+
+--------------------------------------------------------------------------------
+-- $emptyValues
+--
+-- Since forms are designed to be submitted after a confirmation page, it
+-- should be possible to re-display a form with pre-filled values. The initial
+-- form, when no value has been provided by a user, is actually rendering
+-- \"empty" values, defined here.
 
 emptyCreateContractAll :: CreateContractAll
 emptyCreateContractAll = CreateContractAll emptyCreateContractGenInfo

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -10,6 +10,7 @@ module Curiosity.Data.Employment
   , CreateContractGenInfo(..)
   , CreateContractLocDates(..)
   , CreateContractRisks(..)
+  , CreateContractInvoice(..)
   , AddExpense(..)
   , emptyCreateContractAll
   , emptyCreateContractGenInfo
@@ -35,6 +36,7 @@ import           Web.FormUrlEncoded             ( FromForm(..)
 data CreateContractAll = CreateContractAll CreateContractGenInfo
                                            CreateContractLocDates
                                            CreateContractRisks
+                                           CreateContractInvoice
                                            [AddExpense]
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
@@ -45,11 +47,17 @@ data CreateContractAll = CreateContractAll CreateContractGenInfo
 data CreateContractAll' = CreateContractAll' CreateContractGenInfo
                                              CreateContractLocDates
                                              CreateContractRisks
+                                             CreateContractInvoice
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
 instance FromForm CreateContractAll' where
-  fromForm f = CreateContractAll' <$> fromForm f <*> fromForm f <*> fromForm f
+  fromForm f =
+    CreateContractAll'
+      <$> fromForm f
+      <*> fromForm f
+      <*> fromForm f
+      <*> fromForm f
 
 data CreateContractGenInfo = CreateContractGenInfo
   { _createContractProject     :: Text
@@ -84,6 +92,13 @@ data CreateContractRisks = CreateContractRisks
 instance FromForm CreateContractRisks where
   fromForm f = pure CreateContractRisks
 
+data CreateContractInvoice = CreateContractInvoice
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm CreateContractInvoice where
+  fromForm f = pure CreateContractInvoice
+
 data AddExpense = AddExpense
   { _addExpenseAmount :: Int
   }
@@ -94,8 +109,11 @@ instance FromForm AddExpense where
   fromForm f = AddExpense <$> parseUnique "amount" f
 
 emptyCreateContractAll :: CreateContractAll
-emptyCreateContractAll =
-  CreateContractAll emptyCreateContractGenInfo emptyCreateContractLocDates emptyCreateContractRisks []
+emptyCreateContractAll = CreateContractAll emptyCreateContractGenInfo
+                                           emptyCreateContractLocDates
+                                           emptyCreateContractRisks
+                                           emptyCreateContractInvoice
+                                           []
 
 emptyCreateContractGenInfo :: CreateContractGenInfo
 emptyCreateContractGenInfo = CreateContractGenInfo
@@ -111,6 +129,9 @@ emptyCreateContractLocDates = CreateContractLocDates
 
 emptyCreateContractRisks :: CreateContractRisks
 emptyCreateContractRisks = CreateContractRisks
+
+emptyCreateContractInvoice :: CreateContractInvoice
+emptyCreateContractInvoice = CreateContractInvoice
 
 emptyAddExpense :: AddExpense
 emptyAddExpense = AddExpense { _addExpenseAmount = 0 }

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -34,6 +34,7 @@ module Curiosity.Data.Employment
   , emptyAddExpense
     -- * Form submittal
   , SubmitContract(..)
+  , validateCreateContract
     -- * Main data representation
   , Contract(..)
   , ContractId(..)
@@ -184,6 +185,8 @@ emptyCreateContractInvoice = CreateContractInvoice
 emptyAddExpense :: AddExpense
 emptyAddExpense = AddExpense { _addExpenseAmount = 0 }
 
+
+--------------------------------------------------------------------------------
 -- | This represents the submittal of a CreateContractAll, identified by its
 -- key.
 data SubmitContract = SubmitContract
@@ -195,8 +198,17 @@ data SubmitContract = SubmitContract
 instance FromForm SubmitContract where
   fromForm f = SubmitContract <$> parseUnique "key" f
 
+-- | Given a contract form, tries to return a proper `Contract` value, although
+-- the ID is dummy. Maybe we should have separate data types (with or without
+-- the ID).
+validateCreateContract :: CreateContractAll -> Either Err Contract
+validateCreateContract = do
+  pure $ Right Contract { _contractId = ContractId "TODO-DUMMY" }
 
 --------------------------------------------------------------------------------
+-- | This represents a contract in database. TODO The notion of contract
+-- includes more than amployment contract and all should share most of their
+-- structure.
 data Contract = Contract
   { _contractId :: ContractId
   }

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -9,6 +9,7 @@ module Curiosity.Data.Employment
   , CreateContractAll'(..)
   , CreateContractGenInfo(..)
   , CreateContractLocDates(..)
+  , CreateContractRisks(..)
   , AddExpense(..)
   , emptyCreateContractAll
   , emptyCreateContractGenInfo
@@ -33,6 +34,7 @@ import           Web.FormUrlEncoded             ( FromForm(..)
 -- SubmitContract data type below, and the key.
 data CreateContractAll = CreateContractAll CreateContractGenInfo
                                            CreateContractLocDates
+                                           CreateContractRisks
                                            [AddExpense]
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
@@ -42,11 +44,12 @@ data CreateContractAll = CreateContractAll CreateContractGenInfo
 -- would also work but be less explicit.
 data CreateContractAll' = CreateContractAll' CreateContractGenInfo
                                              CreateContractLocDates
+                                             CreateContractRisks
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
 instance FromForm CreateContractAll' where
-  fromForm f = CreateContractAll' <$> fromForm f <*> fromForm f
+  fromForm f = CreateContractAll' <$> fromForm f <*> fromForm f <*> fromForm f
 
 data CreateContractGenInfo = CreateContractGenInfo
   { _createContractProject     :: Text
@@ -74,6 +77,13 @@ data CreateContractLocDates = CreateContractLocDates
 instance FromForm CreateContractLocDates where
   fromForm f = pure CreateContractLocDates
 
+data CreateContractRisks = CreateContractRisks
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm CreateContractRisks where
+  fromForm f = pure CreateContractRisks
+
 data AddExpense = AddExpense
   { _addExpenseAmount :: Int
   }
@@ -85,7 +95,7 @@ instance FromForm AddExpense where
 
 emptyCreateContractAll :: CreateContractAll
 emptyCreateContractAll =
-  CreateContractAll emptyCreateContractGenInfo emptyCreateContractLocDates []
+  CreateContractAll emptyCreateContractGenInfo emptyCreateContractLocDates emptyCreateContractRisks []
 
 emptyCreateContractGenInfo :: CreateContractGenInfo
 emptyCreateContractGenInfo = CreateContractGenInfo
@@ -98,6 +108,9 @@ emptyCreateContractGenInfo = CreateContractGenInfo
 
 emptyCreateContractLocDates :: CreateContractLocDates
 emptyCreateContractLocDates = CreateContractLocDates
+
+emptyCreateContractRisks :: CreateContractRisks
+emptyCreateContractRisks = CreateContractRisks
 
 emptyAddExpense :: AddExpense
 emptyAddExpense = AddExpense { _addExpenseAmount = 0 }

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -7,6 +7,7 @@ Description: Employment related datatypes
 module Curiosity.Data.Employment
   ( CreateContractAll(..)
   , CreateContractAll'(..)
+  , CreateContractType(..)
   , CreateContractGenInfo(..)
   , CreateContractLocDates(..)
   , CreateContractRisks(..)
@@ -34,6 +35,7 @@ import           Web.FormUrlEncoded             ( FromForm(..)
 -- by a key. The form data are validated when they are "submitted", using the
 -- SubmitContract data type below, and the key.
 data CreateContractAll = CreateContractAll CreateContractGenInfo
+                                           CreateContractType
                                            CreateContractLocDates
                                            CreateContractRisks
                                            CreateContractInvoice
@@ -45,6 +47,7 @@ data CreateContractAll = CreateContractAll CreateContractGenInfo
 -- the main panels into a `FromForm` instance. Simply leaving out the expenses
 -- would also work but be less explicit.
 data CreateContractAll' = CreateContractAll' CreateContractGenInfo
+                                             CreateContractType
                                              CreateContractLocDates
                                              CreateContractRisks
                                              CreateContractInvoice
@@ -55,6 +58,7 @@ instance FromForm CreateContractAll' where
   fromForm f =
     CreateContractAll'
       <$> fromForm f
+      <*> fromForm f
       <*> fromForm f
       <*> fromForm f
       <*> fromForm f
@@ -77,6 +81,13 @@ instance FromForm CreateContractGenInfo where
       <*> parseUnique "role"        f
       <*> parseUnique "type"        f
       <*> parseUnique "description" f
+
+data CreateContractType = CreateContractType
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm CreateContractType where
+  fromForm f = pure CreateContractType
 
 data CreateContractLocDates = CreateContractLocDates
   deriving (Generic, Eq, Show)
@@ -110,6 +121,7 @@ instance FromForm AddExpense where
 
 emptyCreateContractAll :: CreateContractAll
 emptyCreateContractAll = CreateContractAll emptyCreateContractGenInfo
+                                           emptyCreateContractType
                                            emptyCreateContractLocDates
                                            emptyCreateContractRisks
                                            emptyCreateContractInvoice
@@ -123,6 +135,9 @@ emptyCreateContractGenInfo = CreateContractGenInfo
   , _createContractType        = ""
   , _createContractDescription = ""
   }
+
+emptyCreateContractType :: CreateContractType
+emptyCreateContractType = CreateContractType
 
 emptyCreateContractLocDates :: CreateContractLocDates
 emptyCreateContractLocDates = CreateContractLocDates

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -6,9 +6,9 @@ Description: Employment related datatypes
 -}
 module Curiosity.Data.Employment
   ( CreateContractAll(..)
-  , CreateContract(..)
+  , CreateContractGenInfo(..)
   , emptyCreateContractAll
-  , emptyCreateContract
+  , emptyCreateContractGenInfo
   , AddExpense(..)
   , emptyAddExpense
   , SubmitContract(..)
@@ -29,11 +29,11 @@ import           Web.FormUrlEncoded             ( FromForm(..)
 -- invalid inputs. As it is filled, it is kept in a Map, where it is identified
 -- by a key. The form data are validated when they are "submitted", using the
 -- SubmitContract data type below, and the key.
-data CreateContractAll = CreateContractAll CreateContract [AddExpense]
+data CreateContractAll = CreateContractAll CreateContractGenInfo [AddExpense]
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
-data CreateContract = CreateContract
+data CreateContractGenInfo = CreateContractGenInfo
   { _createContractProject     :: Text
   , _createContractPO          :: Text
   , _createContractRole        :: Text
@@ -43,9 +43,9 @@ data CreateContract = CreateContract
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
-instance FromForm CreateContract where
+instance FromForm CreateContractGenInfo where
   fromForm f =
-    CreateContract
+    CreateContractGenInfo
       <$> parseUnique "project"     f
       <*> parseUnique "po"          f
       <*> parseUnique "role"        f
@@ -53,10 +53,10 @@ instance FromForm CreateContract where
       <*> parseUnique "description" f
 
 emptyCreateContractAll :: CreateContractAll
-emptyCreateContractAll = CreateContractAll emptyCreateContract []
+emptyCreateContractAll = CreateContractAll emptyCreateContractGenInfo []
 
-emptyCreateContract :: CreateContract
-emptyCreateContract = CreateContract { _createContractProject     = ""
+emptyCreateContractGenInfo :: CreateContractGenInfo
+emptyCreateContractGenInfo = CreateContractGenInfo { _createContractProject     = ""
                                      , _createContractPO          = ""
                                      , _createContractRole        = ""
                                      , _createContractType        = ""
@@ -74,6 +74,8 @@ instance FromForm AddExpense where
 
 emptyAddExpense = AddExpense { _addExpenseAmount = 0 }
 
+-- | This represents the submittal of a CreateContractAll, identified by its
+-- key.
 data SubmitContract = SubmitContract
   { _submitContractKey :: Text
   }

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -165,7 +165,7 @@ data UserCompletion2 = UserCompletion2
   deriving anyclass (ToJSON, FromJSON)
 
 -- Enable/disable some accesses.
-data AccessRight = CanVerifyEmailAddr | CanDummy
+data AccessRight = CanCreateContracts | CanVerifyEmailAddr
   deriving (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -49,7 +49,7 @@ data CreateContractPage = CreateContractPage
   }
 
 instance H.ToMarkup CreateContractPage where
-  toMarkup (CreateContractPage profile mkey (Employment.CreateContractAll Employment.CreateContract {..} expenses) saveUrl addExpenseUrl)
+  toMarkup (CreateContractPage profile mkey (Employment.CreateContractAll Employment.CreateContractGenInfo {..} expenses) saveUrl addExpenseUrl)
     = renderFormLarge profile $ do
       title "New employment contract"
       panel "General information" $ do
@@ -262,7 +262,7 @@ data ConfirmContractPage = ConfirmContractPage
   }
 
 instance H.ToMarkup ConfirmContractPage where
-  toMarkup (ConfirmContractPage profile key (Employment.CreateContractAll Employment.CreateContract {..} expenses) submitUrl)
+  toMarkup (ConfirmContractPage profile key (Employment.CreateContractAll Employment.CreateContractGenInfo {..} expenses) submitUrl)
     = renderFormLarge profile $ do
       title' "New employment contract"
         .  Just

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -49,7 +49,7 @@ data CreateContractPage = CreateContractPage
   }
 
 instance H.ToMarkup CreateContractPage where
-  toMarkup (CreateContractPage profile mkey (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates{} expenses) saveUrl addExpenseUrl)
+  toMarkup (CreateContractPage profile mkey (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates{} Employment.CreateContractRisks {} expenses) saveUrl addExpenseUrl)
     = renderFormLarge profile $ do
       title "New employment contract"
       panel "General information" $ do
@@ -262,7 +262,7 @@ data ConfirmContractPage = ConfirmContractPage
   }
 
 instance H.ToMarkup ConfirmContractPage where
-  toMarkup (ConfirmContractPage profile key (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates{} expenses) submitUrl)
+  toMarkup (ConfirmContractPage profile key (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates {} Employment.CreateContractRisks {} expenses) submitUrl)
     = renderFormLarge profile $ do
       title' "New employment contract"
         .  Just

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -49,7 +49,7 @@ data CreateContractPage = CreateContractPage
   }
 
 instance H.ToMarkup CreateContractPage where
-  toMarkup (CreateContractPage profile mkey (Employment.CreateContractAll Employment.CreateContractGenInfo {..} expenses) saveUrl addExpenseUrl)
+  toMarkup (CreateContractPage profile mkey (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates{} expenses) saveUrl addExpenseUrl)
     = renderFormLarge profile $ do
       title "New employment contract"
       panel "General information" $ do
@@ -262,7 +262,7 @@ data ConfirmContractPage = ConfirmContractPage
   }
 
 instance H.ToMarkup ConfirmContractPage where
-  toMarkup (ConfirmContractPage profile key (Employment.CreateContractAll Employment.CreateContractGenInfo {..} expenses) submitUrl)
+  toMarkup (ConfirmContractPage profile key (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates{} expenses) submitUrl)
     = renderFormLarge profile $ do
       title' "New employment contract"
         .  Just

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -49,7 +49,7 @@ data CreateContractPage = CreateContractPage
   }
 
 instance H.ToMarkup CreateContractPage where
-  toMarkup (CreateContractPage profile mkey (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates{} Employment.CreateContractRisks{} Employment.CreateContractInvoice{} expenses) saveUrl addExpenseUrl)
+  toMarkup (CreateContractPage profile mkey (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractType {} Employment.CreateContractLocDates{} Employment.CreateContractRisks{} Employment.CreateContractInvoice{} expenses) saveUrl addExpenseUrl)
     = renderFormLarge profile $ do
       title "New employment contract"
       panel "General information" $ do
@@ -81,18 +81,16 @@ instance H.ToMarkup CreateContractPage where
                            "Describe your work (minimum 10 characters)"
                            _createContractDescription
                            True
-
+      panel "Employment type" $ groupEmployment
       panel "Location and dates" $ do
         inputText "Work country" "country" Nothing Nothing
         inputText "Work dates"   "dates"   Nothing Nothing
-
       panel "Risks" $ groupRisks
       panel "Invoicing" $ groupInvoicing
       (! A.id "panel-expenses") $ panelStandard "Expenses" $ groupExpenses
         mkey
         expenses
         addExpenseUrl
-      panel "Employment type" $ groupEmployment
 
       groupLayout $ do
         submitButton saveUrl "Save changes"
@@ -262,7 +260,7 @@ data ConfirmContractPage = ConfirmContractPage
   }
 
 instance H.ToMarkup ConfirmContractPage where
-  toMarkup (ConfirmContractPage profile key (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates{} Employment.CreateContractRisks{} Employment.CreateContractInvoice{} expenses) submitUrl)
+  toMarkup (ConfirmContractPage profile key (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractType {} Employment.CreateContractLocDates{} Employment.CreateContractRisks{} Employment.CreateContractInvoice{} expenses) submitUrl)
     = renderFormLarge profile $ do
       title' "New employment contract"
         .  Just

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -49,7 +49,7 @@ data CreateContractPage = CreateContractPage
   }
 
 instance H.ToMarkup CreateContractPage where
-  toMarkup (CreateContractPage profile mkey (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates{} Employment.CreateContractRisks {} expenses) saveUrl addExpenseUrl)
+  toMarkup (CreateContractPage profile mkey (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates{} Employment.CreateContractRisks{} Employment.CreateContractInvoice{} expenses) saveUrl addExpenseUrl)
     = renderFormLarge profile $ do
       title "New employment contract"
       panel "General information" $ do
@@ -262,7 +262,7 @@ data ConfirmContractPage = ConfirmContractPage
   }
 
 instance H.ToMarkup ConfirmContractPage where
-  toMarkup (ConfirmContractPage profile key (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates {} Employment.CreateContractRisks {} expenses) submitUrl)
+  toMarkup (ConfirmContractPage profile key (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractLocDates{} Employment.CreateContractRisks{} Employment.CreateContractInvoice{} expenses) submitUrl)
     = renderFormLarge profile $ do
       title' "New employment contract"
         .  Just

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -649,12 +649,12 @@ newCreateContractForm
    . Data.StmDb runtime
   -> (User.UserProfile, Employment.CreateContractAll')
   -> STM Text
-newCreateContractForm db (profile, Employment.CreateContractAll' gi ld) = do
+newCreateContractForm db (profile, Employment.CreateContractAll' gi ld rs) = do
   key <- Data.genRandomText db
   STM.modifyTVar (Data._dbFormCreateContractAll db) (add key)
   pure key
  where
-  add key = M.insert (username, key) (Employment.CreateContractAll gi ld [])
+  add key = M.insert (username, key) (Employment.CreateContractAll gi ld rs [])
   username = User._userCredsName $ User._userProfileCreds profile
 
 readCreateContractForm
@@ -673,15 +673,15 @@ writeCreateContractForm
    . Data.StmDb runtime
   -> (User.UserProfile, Text, Employment.CreateContractAll')
   -> STM Text
-writeCreateContractForm db (profile, key, Employment.CreateContractAll' gi ld)
+writeCreateContractForm db (profile, key, Employment.CreateContractAll' gi ld rs)
   = do
     STM.modifyTVar (Data._dbFormCreateContractAll db) save
     pure key
  where
   -- TODO Return an error when the key is not found.
   save = M.adjust
-    (\(Employment.CreateContractAll _ _ es) ->
-      Employment.CreateContractAll gi ld es
+    (\(Employment.CreateContractAll _ _ _ es) ->
+      Employment.CreateContractAll gi ld rs es
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -695,8 +695,8 @@ addExpenseToContractForm db (profile, key, expense) = do
   STM.modifyTVar (Data._dbFormCreateContractAll db) save
  where
   save = M.adjust
-    (\(Employment.CreateContractAll gi ld es) ->
-      Employment.CreateContractAll gi ld $ es ++ [expense]
+    (\(Employment.CreateContractAll gi ld rs es) ->
+      Employment.CreateContractAll gi ld rs $ es ++ [expense]
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -710,10 +710,10 @@ writeExpenseToContractForm db (profile, key, index, expense) = do
   STM.modifyTVar (Data._dbFormCreateContractAll db) save
  where
   save = M.adjust
-    (\(Employment.CreateContractAll gi ld es) ->
+    (\(Employment.CreateContractAll gi ld rs es) ->
       let f i e = if i == index then expense else e
           es' = zipWith f [0 ..] es
-      in  Employment.CreateContractAll gi ld es'
+      in  Employment.CreateContractAll gi ld rs es'
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -727,9 +727,9 @@ removeExpenseFromContractForm db (profile, key, index) = do
   STM.modifyTVar (Data._dbFormCreateContractAll db) save
  where
   save = M.adjust
-    (\(Employment.CreateContractAll gi ld es) ->
+    (\(Employment.CreateContractAll gi ld rs es) ->
       let es' = map snd . filter ((/= index) . fst) $ zip [0 ..] es
-      in  Employment.CreateContractAll gi ld es'
+      in  Employment.CreateContractAll gi ld rs es'
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -649,14 +649,14 @@ newCreateContractForm
    . Data.StmDb runtime
   -> (User.UserProfile, Employment.CreateContractAll')
   -> STM Text
-newCreateContractForm db (profile, Employment.CreateContractAll' gi ld rs inv)
+newCreateContractForm db (profile, Employment.CreateContractAll' gi ty ld rs inv)
   = do
     key <- Data.genRandomText db
     STM.modifyTVar (Data._dbFormCreateContractAll db) (add key)
     pure key
  where
   add key =
-    M.insert (username, key) (Employment.CreateContractAll gi ld rs inv [])
+    M.insert (username, key) (Employment.CreateContractAll gi ty ld rs inv [])
   username = User._userCredsName $ User._userProfileCreds profile
 
 readCreateContractForm
@@ -675,15 +675,15 @@ writeCreateContractForm
    . Data.StmDb runtime
   -> (User.UserProfile, Text, Employment.CreateContractAll')
   -> STM Text
-writeCreateContractForm db (profile, key, Employment.CreateContractAll' gi ld rs inv)
+writeCreateContractForm db (profile, key, Employment.CreateContractAll' gi ty ld rs inv)
   = do
     STM.modifyTVar (Data._dbFormCreateContractAll db) save
     pure key
  where
   -- TODO Return an error when the key is not found.
   save = M.adjust
-    (\(Employment.CreateContractAll _ _ _ _ es) ->
-      Employment.CreateContractAll gi ld rs inv es
+    (\(Employment.CreateContractAll _ _ _ _ _ es) ->
+      Employment.CreateContractAll gi ty ld rs inv es
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -697,8 +697,8 @@ addExpenseToContractForm db (profile, key, expense) = do
   STM.modifyTVar (Data._dbFormCreateContractAll db) save
  where
   save = M.adjust
-    (\(Employment.CreateContractAll gi ld rs inv es) ->
-      Employment.CreateContractAll gi ld rs inv $ es ++ [expense]
+    (\(Employment.CreateContractAll gi ty ld rs inv es) ->
+      Employment.CreateContractAll gi ty ld rs inv $ es ++ [expense]
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -712,10 +712,10 @@ writeExpenseToContractForm db (profile, key, index, expense) = do
   STM.modifyTVar (Data._dbFormCreateContractAll db) save
  where
   save = M.adjust
-    (\(Employment.CreateContractAll gi ld rs inv es) ->
+    (\(Employment.CreateContractAll gi ty ld rs inv es) ->
       let f i e = if i == index then expense else e
           es' = zipWith f [0 ..] es
-      in  Employment.CreateContractAll gi ld rs inv es'
+      in  Employment.CreateContractAll gi ty ld rs inv es'
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -729,9 +729,9 @@ removeExpenseFromContractForm db (profile, key, index) = do
   STM.modifyTVar (Data._dbFormCreateContractAll db) save
  where
   save = M.adjust
-    (\(Employment.CreateContractAll gi ld rs inv es) ->
+    (\(Employment.CreateContractAll gi ty ld rs inv es) ->
       let es' = map snd . filter ((/= index) . fst) $ zip [0 ..] es
-      in  Employment.CreateContractAll gi ld rs inv es'
+      in  Employment.CreateContractAll gi ty ld rs inv es'
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -647,7 +647,7 @@ modifyEmployments db f =
 newCreateContractForm
   :: forall runtime
    . Data.StmDb runtime
-  -> (User.UserProfile, Employment.CreateContract)
+  -> (User.UserProfile, Employment.CreateContractGenInfo)
   -> STM Text
 newCreateContractForm db (profile, c) = do
   key <- Data.genRandomText db
@@ -671,7 +671,7 @@ readCreateContractForm db (profile, key) = do
 writeCreateContractForm
   :: forall runtime
    . Data.StmDb runtime
-  -> (User.UserProfile, Text, Employment.CreateContract)
+  -> (User.UserProfile, Text, Employment.CreateContractGenInfo)
   -> STM Text
 writeCreateContractForm db (profile, key, c) = do
   STM.modifyTVar (Data._dbFormCreateContractAll db) save

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -650,6 +650,11 @@ handleSetUserEmailAddrAsVerified (User.SetUserEmailAddrAsVerified username) prof
       Right ()  -> "Success"
       Left  err -> "Failure: " <> show err
 
+-- $ documentationPages
+--
+-- The \`document` -prefixed functions display the same page as the \`show`
+-- -prefixed one.
+
 documentEditProfilePage :: ServerC m => FilePath -> m Pages.ProfilePage
 documentEditProfilePage dataDir = do
   profile <- readJson $ dataDir </> "alice.json"
@@ -860,7 +865,7 @@ echoSubmitContract dataDir (Employment.SubmitContract key) = do
   output  <- liftIO . atomically $ Rt.readCreateContractForm db (profile, key)
   case output of
     Right contract -> pure . Pages.EchoPage $ show
-      (contract, Employment.validateCreateContract contract)
+      (contract, Employment.validateCreateContract profile contract)
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
 -- TODO Validate the filename (e.g. this can't be a path going up).

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -152,24 +152,24 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                   :> ReqBody '[FormUrlEncoded] User.Signup
                   :> Post '[B.HTML] Pages.EchoPage
              :<|> "echo" :> "new-contract"
-                  :> ReqBody '[FormUrlEncoded] Employment.CreateContract
+                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractGenInfo
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
              :<|> "echo" :> "new-contract-and-add-expense"
-                  :> ReqBody '[FormUrlEncoded] Employment.CreateContract
+                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractGenInfo
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
              :<|> "echo" :> "save-contract"
                   :> Capture "key" Text
-                  :> ReqBody '[FormUrlEncoded] Employment.CreateContract
+                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractGenInfo
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
              :<|> "echo" :> "save-contract-and-add-expense"
                   :> Capture "key" Text
-                  :> ReqBody '[FormUrlEncoded] Employment.CreateContract
+                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractGenInfo
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
@@ -738,7 +738,7 @@ documentRemoveExpensePage dataDir key index = do
 echoNewContract
   :: ServerC m
   => FilePath
-  -> Employment.CreateContract
+  -> Employment.CreateContractGenInfo
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewContract dataDir contract = do
   profile <- readJson $ dataDir </> "alice.json"
@@ -750,7 +750,7 @@ echoNewContract dataDir contract = do
 echoNewContractAndAddExpense
   :: ServerC m
   => FilePath
-  -> Employment.CreateContract
+  -> Employment.CreateContractGenInfo
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewContractAndAddExpense dataDir contract = do
   -- TODO This is the same code, but with a different redirect.
@@ -764,7 +764,7 @@ echoSaveContract
   :: ServerC m
   => FilePath
   -> Text
-  -> Employment.CreateContract
+  -> Employment.CreateContractGenInfo
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveContract dataDir key contract = do
   profile <- readJson $ dataDir </> "alice.json"
@@ -779,7 +779,7 @@ echoSaveContractAndAddExpense
   :: ServerC m
   => FilePath
   -> Text
-  -> Employment.CreateContract
+  -> Employment.CreateContractGenInfo
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveContractAndAddExpense dataDir key contract = do
   -- TODO This is the same code, but with a different redirect.

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -705,7 +705,7 @@ documentEditExpensePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateContractForm db (profile, key)
   case output of
-    Right (Employment.CreateContractAll _ _ expenses) ->
+    Right (Employment.CreateContractAll _ _ _ expenses) ->
       if index > length expenses - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.AddExpensePage
@@ -723,7 +723,7 @@ documentRemoveExpensePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateContractForm db (profile, key)
   case output of
-    Right (Employment.CreateContractAll _ _ expenses) ->
+    Right (Employment.CreateContractAll _ _ _ expenses) ->
       if index > length expenses - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.RemoveExpensePage

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -859,8 +859,9 @@ echoSubmitContract dataDir (Employment.SubmitContract key) = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateContractForm db (profile, key)
   case output of
-    Right contract -> pure . Pages.EchoPage $ show contract
-    Left  _        -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
+    Right contract -> pure . Pages.EchoPage $ show
+      (contract, Employment.validateCreateContract contract)
+    Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
 -- TODO Validate the filename (e.g. this can't be a path going up).
 documentProfilePage :: ServerC m => FilePath -> FilePath -> m Pages.ProfileView

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -705,7 +705,7 @@ documentEditExpensePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateContractForm db (profile, key)
   case output of
-    Right (Employment.CreateContractAll _ _ _ _ expenses) ->
+    Right (Employment.CreateContractAll _ _ _ _ _ expenses) ->
       if index > length expenses - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.AddExpensePage
@@ -723,7 +723,7 @@ documentRemoveExpensePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateContractForm db (profile, key)
   case output of
-    Right (Employment.CreateContractAll _ _ _ _ expenses) ->
+    Right (Employment.CreateContractAll _ _ _ _ _ expenses) ->
       if index > length expenses - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.RemoveExpensePage

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -705,7 +705,7 @@ documentEditExpensePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateContractForm db (profile, key)
   case output of
-    Right (Employment.CreateContractAll _ _ _ expenses) ->
+    Right (Employment.CreateContractAll _ _ _ _ expenses) ->
       if index > length expenses - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.AddExpensePage
@@ -723,7 +723,7 @@ documentRemoveExpensePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateContractForm db (profile, key)
   case output of
-    Right (Employment.CreateContractAll _ _ _ expenses) ->
+    Right (Employment.CreateContractAll _ _ _ _ expenses) ->
       if index > length expenses - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.RemoveExpensePage

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -152,24 +152,24 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                   :> ReqBody '[FormUrlEncoded] User.Signup
                   :> Post '[B.HTML] Pages.EchoPage
              :<|> "echo" :> "new-contract"
-                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractGenInfo
+                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractAll'
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
              :<|> "echo" :> "new-contract-and-add-expense"
-                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractGenInfo
+                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractAll'
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
              :<|> "echo" :> "save-contract"
                   :> Capture "key" Text
-                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractGenInfo
+                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractAll'
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
              :<|> "echo" :> "save-contract-and-add-expense"
                   :> Capture "key" Text
-                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractGenInfo
+                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractAll'
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
@@ -705,7 +705,7 @@ documentEditExpensePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateContractForm db (profile, key)
   case output of
-    Right (Employment.CreateContractAll _ expenses) ->
+    Right (Employment.CreateContractAll _ _ expenses) ->
       if index > length expenses - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.AddExpensePage
@@ -723,7 +723,7 @@ documentRemoveExpensePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateContractForm db (profile, key)
   case output of
-    Right (Employment.CreateContractAll _ expenses) ->
+    Right (Employment.CreateContractAll _ _ expenses) ->
       if index > length expenses - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.RemoveExpensePage
@@ -738,7 +738,7 @@ documentRemoveExpensePage dataDir key index = do
 echoNewContract
   :: ServerC m
   => FilePath
-  -> Employment.CreateContractGenInfo
+  -> Employment.CreateContractAll'
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewContract dataDir contract = do
   profile <- readJson $ dataDir </> "alice.json"
@@ -750,7 +750,7 @@ echoNewContract dataDir contract = do
 echoNewContractAndAddExpense
   :: ServerC m
   => FilePath
-  -> Employment.CreateContractGenInfo
+  -> Employment.CreateContractAll'
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewContractAndAddExpense dataDir contract = do
   -- TODO This is the same code, but with a different redirect.
@@ -764,7 +764,7 @@ echoSaveContract
   :: ServerC m
   => FilePath
   -> Text
-  -> Employment.CreateContractGenInfo
+  -> Employment.CreateContractAll'
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveContract dataDir key contract = do
   profile <- readJson $ dataDir </> "alice.json"
@@ -779,7 +779,7 @@ echoSaveContractAndAddExpense
   :: ServerC m
   => FilePath
   -> Text
-  -> Employment.CreateContractGenInfo
+  -> Employment.CreateContractAll'
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveContractAndAddExpense dataDir key contract = do
   -- TODO This is the same code, but with a different redirect.

--- a/tests/Curiosity/RuntimeSpec.hs
+++ b/tests/Curiosity/RuntimeSpec.hs
@@ -30,6 +30,13 @@ spec = do
 
       muser `shouldBe` Nothing
 
+    it ("The first user ID is " <> show (unUserId firstUserId) <> ".") $ do
+      runtime <- boot' emptyHask "/tmp/curiosity-test-xxx-2-1.log"
+      let db = _rDb runtime
+      id <- atomically $ generateUserId db
+
+      id `shouldBe` firstUserId
+
     it "Adding a user, returns a user." $ do
       runtime <- boot' emptyHask "/tmp/curiosity-test-xxx-3.log"
       let db = _rDb runtime


### PR DESCRIPTION
This is still not yet complete, but now submitting the form triggers a validation function, same for the CLI.

- This adds a simple `CanCreateContracts` right.
- This adds a data type `CreateContractAll` to represent form data. Form data are kept in memory server-side to offer possibly multiple screens to view (and confirm) or edit the data.
- The final screen shows the data ready to be submitted, together with the result of the validation rules. Upon submission, validation rules are applied again before creating the "real" (as opposed to editable form data) contract.