### PR TITLE
Alternative contract form: "simple" contract

### DIFF
--- a/content/documentation/forms.md
+++ b/content/documentation/forms.md
@@ -26,6 +26,10 @@ title: Curiosity
 
 :   The new contract form allows a user to ...
 
+[New simple contract](/forms/new-simple-contract)
+
+:   The new contract form allows a user to ...
+
 # See also
 
 - [Sitemap](/documentation/sitemap)

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -52,3 +52,27 @@ system was initialized.
 ## Business units
 
 - [Alpha](/alpha)
+
+## Forms
+
+Forms data are held separately from the rest of the regular objects in what we
+call the _staging area_. This is a place in memory where form data can be
+edited and eventually submitted. When they are submitted, they are validated
+against various rules. Only if they pass such validation, data are recorded in
+the regular state.
+
+In the staging area, invalid data can reside. The user can amend the data as
+much as they desire. Interestingly, this allows us to have example data in the
+staging area that will fail validation, and this can be used to exemplify
+validation rules.
+
+### Simple contract
+
+- [Amount `-100`](/forms/edit/simple-contract/confirm-simple-contract/TBPJLIUG)
+- [Amount `0`](/forms/edit/simple-contract/confirm-simple-contract/HNONWPTG)
+- [Amount `100`](/forms/edit/simple-contract/confirm-simple-contract/RZEMQMNF)
+
+Note: the validation rules are visible in the [source
+code](/haddock/src/Curiosity.Data.SimpleContract.html#validateCreateSimpleContract).
+We should try to expose them more clearly, both in the documentation, and in
+the code.

--- a/content/documentation/validation.md
+++ b/content/documentation/validation.md
@@ -5,8 +5,15 @@ title: Curiosity
 
 # Validation rules
 
+## Users
+
 Usernames from the following list cannot be used:
 
 <!--# include virtual="/partials/username-blocklist" -->
 
 The list [as JSON](/partials/username-blocklist.json).
+
+## Simple contracts
+
+See [state-0](/documentation/scenarios#simple-contract) for example data,
+displayed with validation errors.

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -111,6 +111,8 @@ library
     Curiosity.Html.Misc
     Curiosity.Html.Navbar
     Curiosity.Html.Profile
+    Curiosity.Html.Run
+    Curiosity.Html.SimpleContract
     Curiosity.Interpret
     Curiosity.Parse
     Curiosity.Process

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -96,6 +96,7 @@ library
     Curiosity.Data.Employment
     Curiosity.Data.Invoice
     Curiosity.Data.Legal
+    Curiosity.Data.SimpleContract
     Curiosity.Data.User
     Curiosity.Dsl
     Curiosity.Form.Login

--- a/data/mila.json
+++ b/data/mila.json
@@ -1,0 +1,12 @@
+{
+  "_userProfileId": "USER-4",
+  "_userProfileCreds": {
+    "_userCredsName": "mila",
+    "_userCredsPassword": "m"
+  },
+  "_userProfileEmailAddr": "mila@example.com",
+  "_userProfileTosConsent": true,
+  "_userProfileCompletion1": {},
+  "_userProfileCompletion2": {},
+  "_userProfileRights": []
+}

--- a/scenarios/init-form-simple-contracts.golden
+++ b/scenarios/init-form-simple-contracts.golden
@@ -1,0 +1,8 @@
+1: as mila
+Modifiying default user.
+2: forms simple-contract new --amount -100
+UserNotFound "mila"
+3: forms simple-contract new
+UserNotFound "mila"
+4: forms simple-contract new --amount 100
+UserNotFound "mila"

--- a/scenarios/init-form-simple-contracts.txt
+++ b/scenarios/init-form-simple-contracts.txt
@@ -1,0 +1,4 @@
+as mila
+forms simple-contract new --amount "-100"
+forms simple-contract new
+forms simple-contract new --amount 100

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -23,3 +23,12 @@ Legal entity updated: one
 Business entity created: BENT-1
 2: business update alpha The first business unit of the prototype, Alpha is run by @mila.
 Business unit updated: alpha
+5: run init-form-simple-contracts.txt
+1: as mila
+Modifiying default user.
+2: forms simple-contract new --amount -100
+Simple contract form created: TBPJLIUG
+3: forms simple-contract new
+Simple contract form created: HNONWPTG
+4: forms simple-contract new --amount 100
+Simple contract form created: RZEMQMNF

--- a/scenarios/state-0.txt
+++ b/scenarios/state-0.txt
@@ -2,3 +2,4 @@ reset
 run init-users.txt
 run init-entities.txt
 run init-units.txt
+run init-form-simple-contracts.txt

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -59,6 +59,7 @@ data Command =
   | CreateEmployment Employment.CreateContractAll
   | CreateInvoice
   | FormNewSimpleContract SimpleContract.CreateContractAll'
+  | FormValidateSimpleContract Text -- TODO Use SubmitContract.
   | ViewQueue QueueName
     -- ^ View queue. The queues can be filters applied to objects, not
     -- necessarily explicit list in database.
@@ -551,11 +552,18 @@ parserForms = A.subparser $ A.command
   )
 
 parserFormSimpleContract :: A.Parser Command
-parserFormSimpleContract = A.subparser $ A.command
-  "new"
-  ( A.info (parserFormNewSimpleContract <**> A.helper)
-  $ A.progDesc "Fill and validate forms"
-  )
+parserFormSimpleContract =
+  A.subparser
+    $  A.command
+         "new"
+         ( A.info (parserFormNewSimpleContract <**> A.helper)
+         $ A.progDesc "Create a new form session"
+         )
+    <> A.command
+         "validate"
+         ( A.info (parserFormValidateSimpleContract <**> A.helper)
+         $ A.progDesc "Run validation rules against a form"
+         )
 
 parserFormNewSimpleContract :: A.Parser Command
 parserFormNewSimpleContract = do
@@ -570,6 +578,13 @@ parserFormNewSimpleContract = do
         { SimpleContract._createContractAmount = amount
         }
     }
+
+parserFormValidateSimpleContract :: A.Parser Command
+parserFormValidateSimpleContract = do
+  key <- A.argument
+    A.str
+    (A.metavar "KEY" <> A.help "A simple contract form identifier.")
+  pure $ FormValidateSimpleContract key
 
 -- TODO I'm using subcommands to have all queue names appear in `--help` but
 -- the word COMMAND seems wrong:

--- a/src/Curiosity/Data/SimpleContract.hs
+++ b/src/Curiosity/Data/SimpleContract.hs
@@ -20,6 +20,7 @@ module Curiosity.Data.SimpleContract
   , CreateContractLocDates(..)
   , CreateContractRisks(..)
   , CreateContractInvoice(..)
+  , SelectRole(..)
   , AddExpense(..)
     -- * Empty values
     --
@@ -117,6 +118,15 @@ data CreateContractInvoice = CreateContractInvoice
 
 instance FromForm CreateContractInvoice where
   fromForm f = pure CreateContractInvoice
+
+data SelectRole = SelectRole
+  { _selectRoleRole :: Text
+  }
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm SelectRole where
+  fromForm f = SelectRole <$> parseUnique "role" f
 
 data AddExpense = AddExpense
   { _addExpenseAmount :: Int

--- a/src/Curiosity/Data/SimpleContract.hs
+++ b/src/Curiosity/Data/SimpleContract.hs
@@ -34,7 +34,7 @@ module Curiosity.Data.SimpleContract
   , emptyCreateContractInvoice
   , emptyAddDate
   , emptyAddExpense
-    -- * Form submittal
+    -- * Form submittal and validation
   , SubmitContract(..)
   , validateCreateSimpleContract
     -- * Main data representation

--- a/src/Curiosity/Data/SimpleContract.hs
+++ b/src/Curiosity/Data/SimpleContract.hs
@@ -90,13 +90,17 @@ instance FromForm CreateContractAll' where
 data CreateContractType = CreateContractType
   { _createContractRole        :: Text
   , _createContractDescription :: Text
+  , _createContractWorkCountry :: Text
   }
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
 instance FromForm CreateContractType where
   fromForm f =
-    CreateContractType <$> parseUnique "role" f <*> parseUnique "description" f
+    CreateContractType
+      <$> parseUnique "role"         f
+      <*> parseUnique "description"  f
+      <*> parseUnique "work-country" f
 
 data CreateContractLocDates = CreateContractLocDates
   deriving (Generic, Eq, Show)
@@ -157,8 +161,10 @@ emptyCreateContractType :: CreateContractType
 emptyCreateContractType = CreateContractType
   { _createContractRole        = "coloriste"
     -- TODO Proper type, and proper default value (probably to be set in the
-    -- user profile).
+    -- user profile). The value here is looked up to display the right label in
+    -- the forms.
   , _createContractDescription = ""
+  , _createContractWorkCountry = "BE"
   }
 
 emptyCreateContractLocDates :: CreateContractLocDates

--- a/src/Curiosity/Data/SimpleContract.hs
+++ b/src/Curiosity/Data/SimpleContract.hs
@@ -17,18 +17,17 @@ module Curiosity.Data.SimpleContract
     CreateContractAll(..)
   , CreateContractAll'(..)
   , CreateContractType(..)
-  , CreateContractLocDates(..)
   , CreateContractRisks(..)
   , CreateContractInvoice(..)
   , SelectRole(..)
   , AddDate(..)
+  , SelectVAT(..)
   , AddExpense(..)
     -- * Empty values
     --
     -- $emptyValues
   , emptyCreateContractAll
   , emptyCreateContractType
-  , emptyCreateContractLocDates
   , emptyCreateContractRisks
   , emptyCreateContractInvoice
   , emptyAddDate
@@ -63,7 +62,6 @@ import           Web.FormUrlEncoded             ( FromForm(..)
 -- "submitted", using the `SubmitContract` data type below, and the key.
 data CreateContractAll = CreateContractAll
   { _createContractType     :: CreateContractType
-  , _createContractLocDates :: CreateContractLocDates
   , _createContractRisks    :: CreateContractRisks
   , _createContractInvoice  :: CreateContractInvoice
   , _createContractDates    :: [AddDate]
@@ -76,7 +74,6 @@ data CreateContractAll = CreateContractAll
 -- the main panels into a `FromForm` instance. Simply leaving out the expenses
 -- would also work but be less explicit.
 data CreateContractAll' = CreateContractAll' CreateContractType
-                                             CreateContractLocDates
                                              CreateContractRisks
                                              CreateContractInvoice
   deriving (Generic, Eq, Show)
@@ -86,7 +83,6 @@ instance FromForm CreateContractAll' where
   fromForm f =
     CreateContractAll'
       <$> fromForm f
-      <*> fromForm f
       <*> fromForm f
       <*> fromForm f
 
@@ -107,13 +103,6 @@ instance FromForm CreateContractType where
       <*> parseUnique "work-country" f
       <*> parseUnique "has-risks"    f
 
-data CreateContractLocDates = CreateContractLocDates
-  deriving (Generic, Eq, Show)
-  deriving anyclass (ToJSON, FromJSON)
-
-instance FromForm CreateContractLocDates where
-  fromForm f = pure CreateContractLocDates
-
 data CreateContractRisks = CreateContractRisks
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
@@ -122,11 +111,13 @@ instance FromForm CreateContractRisks where
   fromForm f = pure CreateContractRisks
 
 data CreateContractInvoice = CreateContractInvoice
+  { _createContractVAT :: Int
+  }
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
 instance FromForm CreateContractInvoice where
-  fromForm f = pure CreateContractInvoice
+  fromForm f = CreateContractInvoice <$> parseUnique "vat" f
 
 data SelectRole = SelectRole
   { _selectRoleRole :: Text
@@ -145,6 +136,15 @@ data AddDate = AddDate
 
 instance FromForm AddDate where
   fromForm f = AddDate <$> parseUnique "date" f
+
+data SelectVAT = SelectVAT
+  { _selectVATRate :: Int
+  }
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm SelectVAT where
+  fromForm f = SelectVAT <$> parseUnique "vat" f
 
 data AddExpense = AddExpense
   { _addExpenseAmount :: Int
@@ -166,7 +166,6 @@ instance FromForm AddExpense where
 
 emptyCreateContractAll :: CreateContractAll
 emptyCreateContractAll = CreateContractAll emptyCreateContractType
-                                           emptyCreateContractLocDates
                                            emptyCreateContractRisks
                                            emptyCreateContractInvoice
                                            []
@@ -183,14 +182,11 @@ emptyCreateContractType = CreateContractType
   , _createContractHasRisks = False -- TODO We probably want no default choice here.
   }
 
-emptyCreateContractLocDates :: CreateContractLocDates
-emptyCreateContractLocDates = CreateContractLocDates
-
 emptyCreateContractRisks :: CreateContractRisks
 emptyCreateContractRisks = CreateContractRisks
 
 emptyCreateContractInvoice :: CreateContractInvoice
-emptyCreateContractInvoice = CreateContractInvoice
+emptyCreateContractInvoice = CreateContractInvoice { _createContractVAT = 21 }
 
 emptyAddDate :: AddDate
 emptyAddDate = AddDate { _addDateDate = "1970-01-01" }

--- a/src/Curiosity/Data/SimpleContract.hs
+++ b/src/Curiosity/Data/SimpleContract.hs
@@ -21,6 +21,7 @@ module Curiosity.Data.SimpleContract
   , CreateContractRisks(..)
   , CreateContractInvoice(..)
   , SelectRole(..)
+  , AddDate(..)
   , AddExpense(..)
     -- * Empty values
     --
@@ -30,6 +31,7 @@ module Curiosity.Data.SimpleContract
   , emptyCreateContractLocDates
   , emptyCreateContractRisks
   , emptyCreateContractInvoice
+  , emptyAddDate
   , emptyAddExpense
     -- * Form submittal
   , SubmitContract(..)
@@ -64,6 +66,7 @@ data CreateContractAll = CreateContractAll
   , _createContractLocDates :: CreateContractLocDates
   , _createContractRisks    :: CreateContractRisks
   , _createContractInvoice  :: CreateContractInvoice
+  , _createContractDates    :: [AddDate]
   , _createContractExpenses :: [AddExpense]
   }
   deriving (Generic, Eq, Show)
@@ -134,6 +137,15 @@ data SelectRole = SelectRole
 instance FromForm SelectRole where
   fromForm f = SelectRole <$> parseUnique "role" f
 
+data AddDate = AddDate
+  { _addDateDate :: Text -- TODO Proper type.
+  }
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm AddDate where
+  fromForm f = AddDate <$> parseUnique "date" f
+
 data AddExpense = AddExpense
   { _addExpenseAmount :: Int
   }
@@ -158,6 +170,7 @@ emptyCreateContractAll = CreateContractAll emptyCreateContractType
                                            emptyCreateContractRisks
                                            emptyCreateContractInvoice
                                            []
+                                           []
 
 emptyCreateContractType :: CreateContractType
 emptyCreateContractType = CreateContractType
@@ -178,6 +191,9 @@ emptyCreateContractRisks = CreateContractRisks
 
 emptyCreateContractInvoice :: CreateContractInvoice
 emptyCreateContractInvoice = CreateContractInvoice
+
+emptyAddDate :: AddDate
+emptyAddDate = AddDate { _addDateDate = "1970-01-01" }
 
 emptyAddExpense :: AddExpense
 emptyAddExpense = AddExpense { _addExpenseAmount = 0 }

--- a/src/Curiosity/Data/SimpleContract.hs
+++ b/src/Curiosity/Data/SimpleContract.hs
@@ -91,6 +91,7 @@ data CreateContractType = CreateContractType
   { _createContractRole        :: Text
   , _createContractDescription :: Text
   , _createContractWorkCountry :: Text
+  , _createContractHasRisks    :: Bool
   }
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
@@ -101,6 +102,7 @@ instance FromForm CreateContractType where
       <$> parseUnique "role"         f
       <*> parseUnique "description"  f
       <*> parseUnique "work-country" f
+      <*> parseUnique "has-risks"    f
 
 data CreateContractLocDates = CreateContractLocDates
   deriving (Generic, Eq, Show)
@@ -165,6 +167,7 @@ emptyCreateContractType = CreateContractType
     -- the forms.
   , _createContractDescription = ""
   , _createContractWorkCountry = "BE"
+  , _createContractHasRisks = False -- TODO We probably want no default choice here.
   }
 
 emptyCreateContractLocDates :: CreateContractLocDates

--- a/src/Curiosity/Data/SimpleContract.hs
+++ b/src/Curiosity/Data/SimpleContract.hs
@@ -1,0 +1,212 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{- |
+Module: Curiosity.Data.SimpleContract
+Description: Simple contract (also called 3in1) related datatypes
+
+This module contains data types used to represent simple contracts, both as
+used when filling a form, and used as proper validated data.
+
+See also the [related documentation page](/documentation/objects/invoices).
+
+-}
+module Curiosity.Data.SimpleContract
+  ( -- * Form data representation
+    --
+    -- $formDataTypes
+    CreateContractAll(..)
+  , CreateContractAll'(..)
+  , CreateContractType(..)
+  , CreateContractLocDates(..)
+  , CreateContractRisks(..)
+  , CreateContractInvoice(..)
+  , AddExpense(..)
+    -- * Empty values
+    --
+    -- $emptyValues
+  , emptyCreateContractAll
+  , emptyCreateContractType
+  , emptyCreateContractLocDates
+  , emptyCreateContractRisks
+  , emptyCreateContractInvoice
+  , emptyAddExpense
+    -- * Form submittal
+  , SubmitContract(..)
+  , validateCreateContract
+    -- * Main data representation
+  , Contract(..)
+  , ContractId(..)
+  , Err(..)
+  ) where
+
+import qualified Commence.Types.Wrapped        as W
+import qualified Curiosity.Data.User           as User
+import           Data.Aeson
+import qualified Text.Blaze.Html5              as H
+import           Web.FormUrlEncoded             ( FromForm(..)
+                                                , parseUnique
+                                                )
+
+--------------------------------------------------------------------------------
+-- $formDataTypes
+--
+-- A contract form, as displayed on a web page, is made of multiple input
+-- groups (or panels, or even of separate pages). Different data types are
+-- provided to represent those sets of input fields.
+
+-- | This represents a form being filled in. In particular, it can represent
+-- invalid inputs. As it is filled, it is kept in a Map in "Curiosity.Data",
+-- where it is identified by a key. The form data are validated when they are
+-- "submitted", using the `SubmitContract` data type below, and the key.
+data CreateContractAll = CreateContractAll CreateContractType
+                                           CreateContractLocDates
+                                           CreateContractRisks
+                                           CreateContractInvoice
+                                           [AddExpense]
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+-- | Same as above, but without the expenses. This is used to group together
+-- the main panels into a `FromForm` instance. Simply leaving out the expenses
+-- would also work but be less explicit.
+data CreateContractAll' = CreateContractAll' CreateContractType
+                                             CreateContractLocDates
+                                             CreateContractRisks
+                                             CreateContractInvoice
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm CreateContractAll' where
+  fromForm f =
+    CreateContractAll'
+      <$> fromForm f
+      <*> fromForm f
+      <*> fromForm f
+      <*> fromForm f
+
+data CreateContractType = CreateContractType
+  { _createContractRole        :: Text
+  , _createContractDescription :: Text
+  }
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm CreateContractType where
+  fromForm f =
+    CreateContractType
+      <$> parseUnique "role"        f
+      <*> parseUnique "description" f
+
+data CreateContractLocDates = CreateContractLocDates
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm CreateContractLocDates where
+  fromForm f = pure CreateContractLocDates
+
+data CreateContractRisks = CreateContractRisks
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm CreateContractRisks where
+  fromForm f = pure CreateContractRisks
+
+data CreateContractInvoice = CreateContractInvoice
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm CreateContractInvoice where
+  fromForm f = pure CreateContractInvoice
+
+data AddExpense = AddExpense
+  { _addExpenseAmount :: Int
+  }
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm AddExpense where
+  fromForm f = AddExpense <$> parseUnique "amount" f
+
+
+--------------------------------------------------------------------------------
+-- $emptyValues
+--
+-- Since forms are designed to be submitted after a confirmation page, it
+-- should be possible to re-display a form with pre-filled values. The initial
+-- form, when no value has been provided by a user, is actually rendering
+-- \"empty" values, defined here.
+
+emptyCreateContractAll :: CreateContractAll
+emptyCreateContractAll = CreateContractAll emptyCreateContractType
+                                           emptyCreateContractLocDates
+                                           emptyCreateContractRisks
+                                           emptyCreateContractInvoice
+                                           []
+
+emptyCreateContractType :: CreateContractType
+emptyCreateContractType = CreateContractType
+  { _createContractRole        = ""
+  , _createContractDescription = ""
+  }
+
+emptyCreateContractLocDates :: CreateContractLocDates
+emptyCreateContractLocDates = CreateContractLocDates
+
+emptyCreateContractRisks :: CreateContractRisks
+emptyCreateContractRisks = CreateContractRisks
+
+emptyCreateContractInvoice :: CreateContractInvoice
+emptyCreateContractInvoice = CreateContractInvoice
+
+emptyAddExpense :: AddExpense
+emptyAddExpense = AddExpense { _addExpenseAmount = 0 }
+
+
+--------------------------------------------------------------------------------
+-- | This represents the submittal of a CreateContractAll, identified by its
+-- key.
+data SubmitContract = SubmitContract
+  { _submitContractKey :: Text
+  }
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm SubmitContract where
+  fromForm f = SubmitContract <$> parseUnique "key" f
+
+-- | Given a contract form, tries to return a proper `Contract` value, although
+-- the ID is dummy. Maybe we should have separate data types (with or without
+-- the ID).
+-- This is a pure function: everything required to perform the validation
+-- should be provided as arguments.
+validateCreateContract
+  :: User.UserProfile -> CreateContractAll -> Either Err Contract
+validateCreateContract profile = do
+  if User.CanCreateContracts `elem` User._userProfileRights profile
+    then pure $ Right Contract { _contractId = ContractId "TODO-DUMMY" }
+    else pure . Left $ Err "User has not the right CanCreateContracts."
+
+
+--------------------------------------------------------------------------------
+-- | This represents a contract in database. TODO The notion of contract
+-- includes more than amployment contract and all should share most of their
+-- structure.
+data Contract = Contract
+  { _contractId :: ContractId
+  }
+  deriving (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+-- | Record ID of the form EMP-xxx.
+newtype ContractId = ContractId { unContractId :: Text }
+               deriving (Eq, Show)
+               deriving ( IsString
+                        , FromJSON
+                        , ToJSON
+                        , H.ToMarkup
+                        , H.ToValue
+                        ) via Text
+               deriving FromForm via W.Wrapped "contract-id" Text
+
+data Err = Err Text
+  deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/SimpleContract.hs
+++ b/src/Curiosity/Data/SimpleContract.hs
@@ -59,11 +59,13 @@ import           Web.FormUrlEncoded             ( FromForm(..)
 -- invalid inputs. As it is filled, it is kept in a Map in "Curiosity.Data",
 -- where it is identified by a key. The form data are validated when they are
 -- "submitted", using the `SubmitContract` data type below, and the key.
-data CreateContractAll = CreateContractAll CreateContractType
-                                           CreateContractLocDates
-                                           CreateContractRisks
-                                           CreateContractInvoice
-                                           [AddExpense]
+data CreateContractAll = CreateContractAll
+  { _createContractType     :: CreateContractType
+  , _createContractLocDates :: CreateContractLocDates
+  , _createContractRisks    :: CreateContractRisks
+  , _createContractInvoice  :: CreateContractInvoice
+  , _createContractExpenses :: [AddExpense]
+  }
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
@@ -94,9 +96,7 @@ data CreateContractType = CreateContractType
 
 instance FromForm CreateContractType where
   fromForm f =
-    CreateContractType
-      <$> parseUnique "role"        f
-      <*> parseUnique "description" f
+    CreateContractType <$> parseUnique "role" f <*> parseUnique "description" f
 
 data CreateContractLocDates = CreateContractLocDates
   deriving (Generic, Eq, Show)
@@ -155,7 +155,9 @@ emptyCreateContractAll = CreateContractAll emptyCreateContractType
 
 emptyCreateContractType :: CreateContractType
 emptyCreateContractType = CreateContractType
-  { _createContractRole        = ""
+  { _createContractRole        = "coloriste"
+    -- TODO Proper type, and proper default value (probably to be set in the
+    -- user profile).
   , _createContractDescription = ""
   }
 

--- a/src/Curiosity/Data/SimpleContract.hs
+++ b/src/Curiosity/Data/SimpleContract.hs
@@ -37,6 +37,7 @@ module Curiosity.Data.SimpleContract
     -- * Form submittal and validation
   , SubmitContract(..)
   , validateCreateSimpleContract
+  , validateCreateSimpleContract'
     -- * Main data representation
   , Contract(..)
   , ContractId(..)
@@ -289,6 +290,11 @@ validateCreateSimpleContract profile CreateContractAll {..} = if null errors
       then [Err "Amount to invoice must be strictly positive."]
       else []
     ]
+
+-- | Similar to `validateCreateSimpleContract` but throw away the returned
+-- contract, i.e. keep only the errors.
+validateCreateSimpleContract' profile contract = either identity (const []) $
+  validateCreateSimpleContract profile contract
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -26,6 +26,7 @@ module Curiosity.Html.Misc
   , buttonGroup
   , buttonBar
   , buttonPrimary
+  , buttonSecondary
 
   -- View
   , editButton
@@ -297,6 +298,15 @@ buttonPrimary submitUrl label =
     $ do
         H.span ! A.class_ "c-button__label" $ H.text label
         divIconCheck
+
+buttonSecondary submitUrl label =
+  H.button
+    ! A.class_ "c-button c-button--secondary"
+    ! A.formaction submitUrl
+    ! A.formmethod "POST"
+    $ H.span
+    ! A.class_ "c-button__content"
+    $ H.span ! A.class_ "c-button__label" $ H.text label
 
 buttonAdd submitUrl label =
   H.button

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -1,0 +1,391 @@
+{-# LANGUAGE DataKinds #-}
+{- |
+Module: Curiosity.Html.SimpleContract
+Description: Employment contract pages (view and edit) for the "simple" (also
+called 3in1) contract flow.
+-}
+module Curiosity.Html.SimpleContract
+  ( SimpleContractView(..)
+  , CreateSimpleContractPage(..)
+  , SelectRolePage(..)
+  , ConfirmRolePage(..)
+  --, AddExpensePage(..)
+  --, RemoveExpensePage(..)
+  , ConfirmSimpleContractPage(..)
+  ) where
+
+import qualified Curiosity.Data.Employment     as Employment
+import qualified Curiosity.Data.User           as User
+import           Curiosity.Html.Misc
+import qualified Smart.Html.Alert              as Alert
+import qualified Smart.Html.Button             as Button
+import           Smart.Html.Shared.Html.Icons
+import qualified Smart.Html.Misc               as Misc
+import           Smart.Html.Panel               ( Panel(..) )
+import qualified Text.Blaze.Html5              as H
+import           Text.Blaze.Html5               ( (!) )
+import qualified Text.Blaze.Html5.Attributes   as A
+
+
+--------------------------------------------------------------------------------
+data SimpleContractView = SimpleContractView
+  { _contractViewSimpleContract      :: Employment.Contract
+  , _contractViewHasEditButton :: Maybe H.AttributeValue
+  }
+
+instance H.ToMarkup SimpleContractView where
+  toMarkup (SimpleContractView contract hasEditButton) =
+    renderView $ contractView contract hasEditButton
+
+contractView contract hasEditButton = containerLarge $ do
+  title' "Employment contract" hasEditButton
+  H.dl ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short" $ do
+    keyValuePair "ID" (Employment._contractId contract)
+
+
+--------------------------------------------------------------------------------
+data CreateSimpleContractPage = CreateSimpleContractPage
+  { _createSimpleContractPageUserProfile   :: User.UserProfile
+    -- ^ The user creating the contract
+  , _createSimpleContractPageKey           :: Maybe Text
+    -- ^ The form editing session key, if the form was already saved
+  , _createSimpleContractContract          :: Employment.CreateContractAll
+    -- ^ The contract being edited
+  , _createSimpleContractPageSaveURL       :: H.AttributeValue
+  , _createSimpleContractPageAddExpenseURL :: H.AttributeValue
+  }
+
+instance H.ToMarkup CreateSimpleContractPage where
+  toMarkup (CreateSimpleContractPage profile mkey (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractType {} Employment.CreateContractLocDates{} Employment.CreateContractRisks{} Employment.CreateContractInvoice{} expenses) saveUrl addExpenseUrl)
+    = renderFormLarge profile $ do
+      autoReload
+      title "New simple contract"
+
+      let iconInformation = Just
+            $ OSvgIconDiv @"circle-information" svgIconCircleInformation
+      H.div ! A.class_ "u-spacer-bottom-l" $
+        H.toMarkup $ Alert.Alert Alert.AlertDefault iconInformation "Message about the 3 simple contracts, possible without social shares." Button.NoButton
+
+      (! A.id "panel-type") $ panel "Service type" $ do
+        H.div ! A.class_ "o-form-group" $ do
+          H.label ! A.class_ "o-form-group__label" ! A.for "worker" $ "Role"
+          H.div ! A.class_ "o-form-group__controls o-form-group__controls--full-width" $ do
+            H.div ! A.class_ "o-flex o-flex--vertical-center u-maximize-width" $ do
+              H.span ! A.class_ "u-spacer-right-s" $
+                "Art and craft creation > Entertainment arts > Dancer"
+              H.button ! A.class_ "c-button c-button--borderless c-button--icon"
+                       ! A.formaction "/echo/new-simple-contract-and-select-role"
+                       ! A.formmethod "POST" $
+                H.span ! A.class_ "c-button__content" $ do
+                  divIconEdit
+                  H.div ! A.class_ "u-sr-accessible" $ "Edit"
+            H.p ! A.class_ "c-form-help-text" $
+              "Your most frequently used role has been automatically selected. Click the edit button if you want to select a different role for this work."
+
+        inputText "Work type"
+                  "type"
+                  (Just $ H.toValue _createContractType)
+                  Nothing
+        Misc.inputTextarea "description"
+                           "Description"
+                           6
+                           "Describe your work (minimum 10 characters)"
+                           _createContractDescription
+                           True
+      panel "Employment type" $ groupEmployment
+      panel "Location and dates" $ do
+        inputText "Work country" "country" Nothing Nothing
+        inputText "Work dates"   "dates"   Nothing Nothing
+      panel "Risks" $ groupRisks
+      panel "Invoicing" $ groupInvoicing
+      (! A.id "panel-expenses") $ panelStandard "Expenses" $ groupExpenses
+        mkey
+        expenses
+        addExpenseUrl
+
+      groupLayout $ do
+        submitButton saveUrl "Save changes"
+   where
+    username =
+      User.unUserName . User._userCredsName $ User._userProfileCreds profile
+
+groupRisks = H.div ! A.class_ "o-form-group" $ do
+  H.label ! A.class_ "o-form-group__label" $ "Work risks"
+  H.div
+    ! A.class_ "o-form-group__controls"
+    $ H.div
+    ! A.class_ "c-radio-group c-radio-group--inline"
+    $ do
+        H.div ! A.class_ "c-radio" $ H.label $ do
+          H.input ! A.type_ "radio" ! A.name "radio1"
+          "Without risks"
+        H.div ! A.class_ "c-radio" $ H.label $ do
+          H.input ! A.type_ "radio" ! A.name "radio1"
+          "With risks"
+        H.p ! A.class_ "c-form-help-text" $ do
+          "For your safety and your colleagues safety, if your role "
+          "involves risks, you have to select \"With risks\". "
+          H.a ! A.class_ "c-link" ! A.href "#" $ "Learn more about risks."
+
+groupInvoicing = do
+  inputText "Client" "client" Nothing Nothing
+  inputText "Amount" "amount" Nothing Nothing
+  inputText "VAT"    "vat"    Nothing Nothing
+  H.div ! A.class_ "o-form-group" $ do
+    H.label ! A.class_ "o-form-group__label" $ "Include VAT ?"
+    H.div
+      ! A.class_ "o-form-group__controls"
+      $ H.div
+      ! A.class_ "c-radio-group c-radio-group--inline"
+      $ do
+          H.div ! A.class_ "c-radio" $ H.label $ do
+            H.input ! A.type_ "radio" ! A.name "radio2"
+            "Include"
+          H.div ! A.class_ "c-radio" $ H.label $ do
+            H.input ! A.type_ "radio" ! A.name "radio2"
+            "Exclude"
+          H.p
+            ! A.class_ "c-form-help-text"
+            $ "Usually, business clients prefer to see amounts VAT excluded."
+  inputText "Down payment" "down-payment" Nothing Nothing
+
+groupExpenses mkey expenses submitUrl = do
+  H.div ! A.class_ "o-form-group" $ do
+    when (null expenses)
+      $ H.div
+      ! A.class_ "c-blank-slate c-blank-slate--bg-alt"
+      $ do
+          H.p
+            ! A.class_ "u-text-muted c-body-1"
+            $ "When using a project, you can choose to add expenses directly or later."
+          H.div ! A.class_ "c-button-toolbar" $ buttonAdd submitUrl
+                                                          "Add expense"
+    case mkey of
+      Just key | not (null expenses) ->
+        Misc.table titles (uncurry $ display key) $ zip [0 ..] expenses
+      _ -> pure ()
+    when (not $ null expenses) $ buttonGroup $ buttonAdd submitUrl "Add expense"
+ where
+  titles = ["Amount"]
+  display
+    :: Text
+    -> Int
+    -> Employment.AddExpense
+    -> ([Text], [(H.Html, Text, Text)], Maybe Text)
+  display key i Employment.AddExpense {..} =
+    ( [show _addExpenseAmount]
+    , [ ( Misc.divIconDelete
+        , "Remove"
+        , "/forms/remove-expense/" <> key <> "/" <> show i
+        )
+      ]
+    , (Just $ "/forms/edit-expense/" <> key <> "/" <> show i)
+    )
+
+groupEmployment = do
+  inputText "Withholding tax"     "withholding-tax" Nothing Nothing
+  inputText "Student / au cachet" "TODO"            Nothing Nothing
+  inputText "Interim"             "interim"         Nothing Nothing
+
+formKeyValue :: Text -> Text -> H.Html
+formKeyValue label value = H.div ! A.class_ "o-form-group" $ do
+  H.label ! A.class_ "o-form-group__label" $ H.text label
+  H.div
+    ! A.class_ "o-form-group__controls o-form-group__controls--full-width"
+    $ H.label
+    $ H.text value
+
+
+--------------------------------------------------------------------------------
+data SelectRolePage = SelectRolePage
+  { _selectRolePageUserProfile :: User.UserProfile
+    -- ^ The user creating the simple contract
+  , _selectRolePageKey         :: Text
+    -- ^ The key of the contract form
+  , _selectRolePageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup SelectRolePage where
+  toMarkup (SelectRolePage profile key submitUrl) =
+    renderFormLarge profile $ do
+      autoReload
+      title' "Select role" Nothing
+
+      H.div ! A.class_ "c-display" $ do
+        H.h4 "Arts du spectacle"
+        H.h4 "Arts littéraires"
+        H.h4 "Arts plastiques et graphiques"
+        H.ul $ do
+          mapM_ (\(sym, label) -> H.li $ H.a ! A.href (H.toValue $ "/forms/confirm-role/" <> key <> "/" <> sym) $ H.text label)
+            [ ("coloriste", "Coloriste")
+            , ("dessinateur", "Dessinateur-rice / illustrateur-rice")
+            , ("graffitiste", "Graffitiste / graffeur-euse")
+            , ("graphiste", "Graphiste / infographiste / webdesigner-euse")
+            , ("graveur", "Graveur-euse / sérigraphe")
+            , ("peintre", "Peintre-esse")
+            , ("performeur", "Performeur-euse")
+            , ("photographe", "Photographe")
+            , ("plasticien", "Plasticien-ne / installateur-rice 3d")
+            , ("scenographe", "Scénographe")
+            , ("sculpteur", "Sculpteur-rice")
+            , ("body-painter", "Body-painter")
+            , ("autre", "Autre")
+            ]
+        H.h4 "Architecture / mode / design / décoration"
+
+
+--------------------------------------------------------------------------------
+data ConfirmRolePage = ConfirmRolePage
+  { _confirmRolePageUserProfile :: User.UserProfile
+    -- ^ The user creating the simple contract
+  , _confirmRolePageKey         :: Text
+    -- ^ The key of the contract form
+  , _confirmRolePageRole        :: Text
+    -- ^ The role being selected
+  , _confirmRolePageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup ConfirmRolePage where
+  toMarkup (ConfirmRolePage profile key role submitUrl) =
+    renderFormLarge profile $ do
+      autoReload
+      H.toMarkup $ PanelHeaderAndBody "Confirm selected role"
+        $ H.dl
+        ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
+        $ do
+            keyValuePair "Role" role
+
+      H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
+        (H.toValue key)
+
+      buttonBar $ do
+        buttonLink
+          (H.toValue $ "/forms/edit-simple-contract/" <> key <> "#panel-type")
+          "Cancel"
+        buttonPrimary submitUrl "Select role"
+
+
+--------------------------------------------------------------------------------
+data AddExpensePage = AddExpensePage
+  { _addExpensePageUserProfile :: User.UserProfile
+    -- ^ The user creating the expense within a contract
+  , _addExpensePageKey         :: Text
+    -- ^ The key of the contract form
+  , _addExpensePageIndex       :: Maybe Int
+    -- ^ The index of the expense within CreateContractAll, if it was already
+    -- added
+  , _addExpensePageExpense     :: Employment.AddExpense
+  , _addExpensePageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup AddExpensePage where
+  toMarkup (AddExpensePage profile key mindex expense submitUrl) =
+    renderFormLarge profile $ do
+      title' label Nothing
+
+      panel "General information" $ do
+        H.input
+          ! A.type_ "hidden"
+          ! A.id "contract-key"
+          ! A.name "contract-key"
+          ! A.value (H.toValue key)
+        inputText "Amount" "amount" mamount Nothing
+
+      H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
+        (H.toValue key)
+      buttonBar $ do
+        buttonLink
+          (H.toValue $ "/forms/edit-contract/" <> key <> "#panel-expenses")
+          "Cancel"
+        buttonPrimary submitUrl label
+   where
+    label   = if isJust mindex then "Update expense" else "Add expense"
+    mamount = if amount /= 0 then Just (H.toValue amount) else Nothing
+    amount  = Employment._addExpenseAmount expense
+
+
+--------------------------------------------------------------------------------
+data RemoveExpensePage = RemoveExpensePage
+  { _removeExpensePageUserProfile :: User.UserProfile
+    -- ^ The user creating the expense within a contract
+  , _removeExpensePageKey         :: Text
+    -- ^ The key of the contract form
+  , _removeExpensePageIndex       :: Int
+    -- ^ The index of the expense within CreateContractAll
+  , _removeExpensePageExpense     :: Employment.AddExpense
+  , _removeExpensePageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup RemoveExpensePage where
+  toMarkup (RemoveExpensePage profile key mindex expense submitUrl) =
+    renderFormLarge profile $ do
+      title' "Remove expense" Nothing
+
+      panel "General information" $ do
+        keyValuePair "Amount" mamount
+
+      button submitUrl "Remove expense"
+   where
+    mamount = if amount /= 0 then show amount else "/" :: Text
+    amount  = Employment._addExpenseAmount expense
+
+
+--------------------------------------------------------------------------------
+data ConfirmSimpleContractPage = ConfirmSimpleContractPage
+  { _confirmSimpleContractPageUserProfile :: User.UserProfile
+    -- ^ The user creating the contract
+  , _confirmSimpleContractPageKey         :: Text
+  , _confirmSimpleContractPageContract    :: Employment.CreateContractAll
+  , _confirmSimpleContractPageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup ConfirmSimpleContractPage where
+  toMarkup (ConfirmSimpleContractPage profile key (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractType {} Employment.CreateContractLocDates{} Employment.CreateContractRisks{} Employment.CreateContractInvoice{} expenses) submitUrl)
+    = renderFormLarge profile $ do
+      title' "New employment contract"
+        .  Just
+        .  H.toValue
+        $  "/forms/edit-contract/"
+        <> key
+
+      H.div
+        ! A.class_ "u-padding-vertical-l"
+        $ H.toMarkup
+        $ PanelHeaderAndBody "General information"
+        $ H.dl
+        ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
+        $ do
+            keyValuePair "Worker username" username
+            keyValuePair "Project"         _createContractProject
+            keyValuePair "Purchase order"  _createContractPO
+            keyValuePair "Role"            _createContractRole
+            keyValuePair "Work type"       _createContractType
+            keyValuePair "Description"     _createContractDescription
+
+      H.div
+        ! A.class_ "u-padding-vertical-l"
+        $ H.toMarkup
+        $ PanelHeaderAndBody "Expenses"
+        $ H.dl
+        ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
+        $ if null expenses
+            then H.div ! A.class_ "c-blank-slate c-blank-slate--bg-alt" $ do
+              H.p
+                ! A.class_ "u-text-muted c-body-1"
+                $ "You have no expenses right now."
+            else Misc.table titles (uncurry $ display key) $ zip [0 ..] expenses
+
+      H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
+        (H.toValue key)
+      button submitUrl "Submit contract"
+   where
+    username =
+      User.unUserName . User._userCredsName $ User._userProfileCreds profile
+    titles = ["Amount"]
+    display
+      :: Text
+      -> Int
+      -> Employment.AddExpense
+      -> ([Text], [(H.Html, Text, Text)], Maybe Text)
+    display key i Employment.AddExpense {..} =
+      ([show _addExpenseAmount], [], Nothing)

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TupleSections #-}
 {- |
 Module: Curiosity.Html.SimpleContract
 Description: Employment contract pages (view and edit) for the "simple" (also
@@ -60,7 +61,7 @@ data CreateSimpleContractPage = CreateSimpleContractPage
   }
 
 instance H.ToMarkup CreateSimpleContractPage where
-  toMarkup (CreateSimpleContractPage profile mkey (SimpleContract.CreateContractAll SimpleContract.CreateContractType {..} SimpleContract.CreateContractLocDates{} SimpleContract.CreateContractRisks{} SimpleContract.CreateContractInvoice{} expenses) roleLabel saveUrl addExpenseUrl)
+  toMarkup (CreateSimpleContractPage profile mkey contract roleLabel saveUrl addExpenseUrl)
     = renderFormLarge profile $ do
       autoReload
       title "New simple contract"
@@ -73,44 +74,11 @@ instance H.ToMarkup CreateSimpleContractPage where
         "Message about the 3 simple contracts, possible without social shares."
         Button.NoButton
 
-      (! A.id "panel-type") $ panel "Service type" $ do
-        H.div ! A.class_ "o-form-group" $ do
-          H.label ! A.class_ "o-form-group__label" ! A.for "worker" $ "Role"
-          H.div
-            ! A.class_
-                "o-form-group__controls o-form-group__controls--full-width"
-            $ do
-                H.div
-                  ! A.class_ "o-flex o-flex--vertical-center u-maximize-width"
-                  $ do
-                      H.span ! A.class_ "u-spacer-right-s" $ H.text roleLabel
-                      H.button
-                        ! A.class_
-                            "c-button c-button--borderless c-button--icon"
-                        ! A.formaction
-                            "/echo/new-simple-contract-and-select-role"
-                        ! A.formmethod "POST"
-                        $ H.span
-                        ! A.class_ "c-button__content"
-                        $ do
-                            divIconEdit
-                            H.div ! A.class_ "u-sr-accessible" $ "Edit"
-                H.p
-                  ! A.class_ "c-form-help-text"
-                  $ "Your most frequently used role has been automatically selected. Click the edit button if you want to select a different role for this work."
-
-        H.input ! A.type_ "hidden" ! A.id "role" ! A.name "role" ! A.value
-          (H.toValue _createContractRole)
-        Misc.inputTextarea "description"
-                           "Description"
-                           6
-                           "Describe your work (minimum 10 characters)"
-                           _createContractDescription
-                           True
+      (! A.id "panel-type") $ panel "Service type" $ groupType contract
+                                                               roleLabel
       panel "Employment type" $ groupEmployment
       panel "Location and dates" $ do
-        inputText "Work country" "country" Nothing Nothing
-        inputText "Work dates"   "dates"   Nothing Nothing
+        inputText "Work dates" "dates" Nothing Nothing
       panel "Risks" $ groupRisks
       panel "Invoicing" $ groupInvoicing
       (! A.id "panel-expenses") $ panelStandard "Expenses" $ groupExpenses
@@ -121,8 +89,49 @@ instance H.ToMarkup CreateSimpleContractPage where
       groupLayout $ do
         submitButton saveUrl "Save changes"
    where
+    expenses = SimpleContract._createContractExpenses contract
     username =
       User.unUserName . User._userCredsName $ User._userProfileCreds profile
+
+groupType SimpleContract.CreateContractAll {..} roleLabel = do
+  H.div ! A.class_ "o-form-group" $ do
+    H.label ! A.class_ "o-form-group__label" ! A.for "worker" $ "Role"
+    H.div
+      ! A.class_ "o-form-group__controls o-form-group__controls--full-width"
+      $ do
+          H.div
+            ! A.class_ "o-flex o-flex--vertical-center u-maximize-width"
+            $ do
+                H.span ! A.class_ "u-spacer-right-s" $ H.text roleLabel
+                H.button
+                  ! A.class_ "c-button c-button--borderless c-button--icon"
+                  ! A.formaction "/echo/new-simple-contract-and-select-role"
+                  ! A.formmethod "POST"
+                  $ H.span
+                  ! A.class_ "c-button__content"
+                  $ do
+                      divIconEdit
+                      H.div ! A.class_ "u-sr-accessible" $ "Edit"
+          H.p
+            ! A.class_ "c-form-help-text"
+            $ "Your most frequently used role has been automatically selected. Click the edit button if you want to select a different role for this work."
+
+  H.input ! A.type_ "hidden" ! A.id "role" ! A.name "role" ! A.value
+    (H.toValue $ SimpleContract._createContractRole _createContractType)
+  Misc.inputTextarea
+    "description"
+    "Description"
+    6
+    "A description of your work. This will appear on the invoice sent to the client. (Minimum 10 characters.)"
+    (SimpleContract._createContractDescription _createContractType)
+    True
+  Misc.inputSelect_
+    "work-country"
+    "Work country"
+    countries
+    Nothing
+    (Just $ SimpleContract._createContractWorkCountry _createContractType)
+    False
 
 groupRisks = H.div ! A.class_ "o-form-group" $ do
   H.label ! A.class_ "o-form-group__label" $ "Work risks"
@@ -417,6 +426,8 @@ instance H.ToMarkup ConfirmSimpleContractPage where
             keyValuePair "Worker username" username
             keyValuePair "Role"            roleLabel
             keyValuePair "Description"     _createContractDescription
+            keyValuePair "Work country" $ maybe "TODO" identity $ lookupCountry
+              _createContractWorkCountry
 
       H.div
         ! A.class_ "u-padding-vertical-l"
@@ -445,3 +456,262 @@ instance H.ToMarkup ConfirmSimpleContractPage where
       -> ([Text], [(H.Html, Text, Text)], Maybe Text)
     display key i SimpleContract.AddExpense {..} =
       ([show _addExpenseAmount], [], Nothing)
+
+
+--------------------------------------------------------------------------------
+-- | From https://github.com/noteed/start-web/blob/main/data/countries.sql.
+-- Originally from pycountry.
+countries :: [(Text, Text)]
+countries =
+  [ ("AW", "Aruba")
+  , ("AF", "Afghanistan")
+  , ("AO", "Angola")
+  , ("AI", "Anguilla")
+  , ("AX", "Åland Islands")
+  , ("AL", "Albania")
+  , ("AD", "Andorra")
+  , ("AE", "United Arab Emirates")
+  , ("AR", "Argentina")
+  , ("AM", "Armenia")
+  , ("AS", "American Samoa")
+  , ("AQ", "Antarctica")
+  , ("TF", "French Southern Territories")
+  , ("AG", "Antigua and Barbuda")
+  , ("AU", "Australia")
+  , ("AT", "Austria")
+  , ("AZ", "Azerbaijan")
+  , ("BI", "Burundi")
+  , ("BE", "Belgium")
+  , ("BJ", "Benin")
+  , ("BQ", "Bonaire, Sint Eustatius and Saba")
+  , ("BF", "Burkina Faso")
+  , ("BD", "Bangladesh")
+  , ("BG", "Bulgaria")
+  , ("BH", "Bahrain")
+  , ("BS", "Bahamas")
+  , ("BA", "Bosnia and Herzegovina")
+  , ("BL", "Saint Barthélemy")
+  , ("BY", "Belarus")
+  , ("BZ", "Belize")
+  , ("BM", "Bermuda")
+  , ("BO", "Bolivia, Plurinational State of")
+  , ("BR", "Brazil")
+  , ("BB", "Barbados")
+  , ("BN", "Brunei Darussalam")
+  , ("BT", "Bhutan")
+  , ("BV", "Bouvet Island")
+  , ("BW", "Botswana")
+  , ("CF", "Central African Republic")
+  , ("CA", "Canada")
+  , ("CC", "Cocos , (Keeling) Islands")
+  , ("CH", "Switzerland")
+  , ("CL", "Chile")
+  , ("CN", "China")
+  , ("CI", "Côte d'Ivoire")
+  , ("CM", "Cameroon")
+  , ("CD", "Congo, The Democratic Republic of the")
+  , ("CG", "Congo")
+  , ("CK", "Cook Islands")
+  , ("CO", "Colombia")
+  , ("KM", "Comoros")
+  , ("CV", "Cabo Verde")
+  , ("CR", "Costa Rica")
+  , ("CU", "Cuba")
+  , ("CW", "Curaçao")
+  , ("CX", "Christmas Island")
+  , ("KY", "Cayman Islands")
+  , ("CY", "Cyprus")
+  , ("CZ", "Czechia")
+  , ("DE", "Germany")
+  , ("DJ", "Djibouti")
+  , ("DM", "Dominica")
+  , ("DK", "Denmark")
+  , ("DO", "Dominican Republic")
+  , ("DZ", "Algeria")
+  , ("EC", "Ecuador")
+  , ("EG", "Egypt")
+  , ("ER", "Eritrea")
+  , ("EH", "Western Sahara")
+  , ("ES", "Spain")
+  , ("EE", "Estonia")
+  , ("ET", "Ethiopia")
+  , ("FI", "Finland")
+  , ("FJ", "Fiji")
+  , ("FK", "Falkland Islands , (Malvinas)")
+  , ("FR", "France")
+  , ("FO", "Faroe Islands")
+  , ("FM", "Micronesia, Federated States of")
+  , ("GA", "Gabon")
+  , ("GB", "United Kingdom")
+  , ("GE", "Georgia")
+  , ("GG", "Guernsey")
+  , ("GH", "Ghana")
+  , ("GI", "Gibraltar")
+  , ("GN", "Guinea")
+  , ("GP", "Guadeloupe")
+  , ("GM", "Gambia")
+  , ("GW", "Guinea-Bissau")
+  , ("GQ", "Equatorial Guinea")
+  , ("GR", "Greece")
+  , ("GD", "Grenada")
+  , ("GL", "Greenland")
+  , ("GT", "Guatemala")
+  , ("GF", "French Guiana")
+  , ("GU", "Guam")
+  , ("GY", "Guyana")
+  , ("HK", "Hong Kong")
+  , ("HM", "Heard Island and McDonald Islands")
+  , ("HN", "Honduras")
+  , ("HR", "Croatia")
+  , ("HT", "Haiti")
+  , ("HU", "Hungary")
+  , ("ID", "Indonesia")
+  , ("IM", "Isle of Man")
+  , ("IN", "India")
+  , ("IO", "British Indian Ocean Territory")
+  , ("IE", "Ireland")
+  , ("IR", "Iran, Islamic Republic of")
+  , ("IQ", "Iraq")
+  , ("IS", "Iceland")
+  , ("IL", "Israel")
+  , ("IT", "Italy")
+  , ("JM", "Jamaica")
+  , ("JE", "Jersey")
+  , ("JO", "Jordan")
+  , ("JP", "Japan")
+  , ("KZ", "Kazakhstan")
+  , ("KE", "Kenya")
+  , ("KG", "Kyrgyzstan")
+  , ("KH", "Cambodia")
+  , ("KI", "Kiribati")
+  , ("KN", "Saint Kitts and Nevis")
+  , ("KR", "Korea, Republic of")
+  , ("KW", "Kuwait")
+  , ("LA", "Lao People's Democratic Republic")
+  , ("LB", "Lebanon")
+  , ("LR", "Liberia")
+  , ("LY", "Libya")
+  , ("LC", "Saint Lucia")
+  , ("LI", "Liechtenstein")
+  , ("LK", "Sri Lanka")
+  , ("LS", "Lesotho")
+  , ("LT", "Lithuania")
+  , ("LU", "Luxembourg")
+  , ("LV", "Latvia")
+  , ("MO", "Macao")
+  , ("MF", "Saint Martin , (French part)")
+  , ("MA", "Morocco")
+  , ("MC", "Monaco")
+  , ("MD", "Moldova, Republic of")
+  , ("MG", "Madagascar")
+  , ("MV", "Maldives")
+  , ("MX", "Mexico")
+  , ("MH", "Marshall Islands")
+  , ("MK", "North Macedonia")
+  , ("ML", "Mali")
+  , ("MT", "Malta")
+  , ("MM", "Myanmar")
+  , ("ME", "Montenegro")
+  , ("MN", "Mongolia")
+  , ("MP", "Northern Mariana Islands")
+  , ("MZ", "Mozambique")
+  , ("MR", "Mauritania")
+  , ("MS", "Montserrat")
+  , ("MQ", "Martinique")
+  , ("MU", "Mauritius")
+  , ("MW", "Malawi")
+  , ("MY", "Malaysia")
+  , ("YT", "Mayotte")
+  , ("NA", "Namibia")
+  , ("NC", "New Caledonia")
+  , ("NE", "Niger")
+  , ("NF", "Norfolk Island")
+  , ("NG", "Nigeria")
+  , ("NI", "Nicaragua")
+  , ("NU", "Niue")
+  , ("NL", "Netherlands")
+  , ("NO", "Norway")
+  , ("NP", "Nepal")
+  , ("NR", "Nauru")
+  , ("NZ", "New Zealand")
+  , ("OM", "Oman")
+  , ("PK", "Pakistan")
+  , ("PA", "Panama")
+  , ("PN", "Pitcairn")
+  , ("PE", "Peru")
+  , ("PH", "Philippines")
+  , ("PW", "Palau")
+  , ("PG", "Papua New Guinea")
+  , ("PL", "Poland")
+  , ("PR", "Puerto Rico")
+  , ("KP", "Korea, Democratic People's Republic of")
+  , ("PT", "Portugal")
+  , ("PY", "Paraguay")
+  , ("PS", "Palestine, State of")
+  , ("PF", "French Polynesia")
+  , ("QA", "Qatar")
+  , ("RE", "Réunion")
+  , ("RO", "Romania")
+  , ("RU", "Russian Federation")
+  , ("RW", "Rwanda")
+  , ("SA", "Saudi Arabia")
+  , ("SD", "Sudan")
+  , ("SN", "Senegal")
+  , ("SG", "Singapore")
+  , ("GS", "South Georgia and the South Sandwich Islands")
+  , ("SH", "Saint Helena, Ascension and Tristan da Cunha")
+  , ("SJ", "Svalbard and Jan Mayen")
+  , ("SB", "Solomon Islands")
+  , ("SL", "Sierra Leone")
+  , ("SV", "El Salvador")
+  , ("SM", "San Marino")
+  , ("SO", "Somalia")
+  , ("PM", "Saint Pierre and Miquelon")
+  , ("RS", "Serbia")
+  , ("SS", "South Sudan")
+  , ("ST", "Sao Tome and Principe")
+  , ("SR", "Suriname")
+  , ("SK", "Slovakia")
+  , ("SI", "Slovenia")
+  , ("SE", "Sweden")
+  , ("SZ", "Eswatini")
+  , ("SX", "Sint Maarten , (Dutch part)")
+  , ("SC", "Seychelles")
+  , ("SY", "Syrian Arab Republic")
+  , ("TC", "Turks and Caicos Islands")
+  , ("TD", "Chad")
+  , ("TG", "Togo")
+  , ("TH", "Thailand")
+  , ("TJ", "Tajikistan")
+  , ("TK", "Tokelau")
+  , ("TM", "Turkmenistan")
+  , ("TL", "Timor-Leste")
+  , ("TO", "Tonga")
+  , ("TT", "Trinidad and Tobago")
+  , ("TN", "Tunisia")
+  , ("TR", "Turkey")
+  , ("TV", "Tuvalu")
+  , ("TW", "Taiwan, Province of China")
+  , ("TZ", "Tanzania, United Republic of")
+  , ("UG", "Uganda")
+  , ("UA", "Ukraine")
+  , ("UM", "United States Minor Outlying Islands")
+  , ("UY", "Uruguay")
+  , ("US", "United States")
+  , ("UZ", "Uzbekistan")
+  , ("VA", "Holy See , (Vatican City State)")
+  , ("VC", "Saint Vincent and the Grenadines")
+  , ("VE", "Venezuela, Bolivarian Republic of")
+  , ("VG", "Virgin Islands, British")
+  , ("VI", "Virgin Islands, U.S.")
+  , ("VN", "Viet Nam")
+  , ("VU", "Vanuatu")
+  , ("WF", "Wallis and Futuna")
+  , ("WS", "Samoa")
+  , ("YE", "Yemen")
+  , ("ZA", "South Africa")
+  , ("ZM", "Zambia")
+  , ("ZW", "Zimbabwe")
+  ]
+
+lookupCountry code = lookup code countries

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -202,16 +202,16 @@ data SelectRolePage = SelectRolePage
     -- ^ The user creating the simple contract
   , _selectRolePageKey         :: Text
     -- ^ The key of the contract form
-  , _selectRolePageSubmitURL   :: H.AttributeValue
   }
 
 instance H.ToMarkup SelectRolePage where
-  toMarkup (SelectRolePage profile key submitUrl) =
+  toMarkup (SelectRolePage profile key) =
     renderFormLarge profile $ do
       autoReload
       title' "Select role" Nothing
 
       H.div ! A.class_ "c-display" $ do
+        H.h3 "Fonction de création artistique et artisanale"
         H.h4 "Arts du spectacle"
         H.h4 "Arts littéraires"
         H.h4 "Arts plastiques et graphiques"
@@ -254,6 +254,8 @@ instance H.ToMarkup ConfirmRolePage where
         ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
         $ do
             keyValuePair "Role" role
+            H.input ! A.type_ "hidden" ! A.id "role" ! A.name "role" ! A.value
+              (H.toValue role)
 
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)
@@ -342,16 +344,17 @@ data ConfirmSimpleContractPage = ConfirmSimpleContractPage
 instance H.ToMarkup ConfirmSimpleContractPage where
   toMarkup (ConfirmSimpleContractPage profile key (SimpleContract.CreateContractAll SimpleContract.CreateContractType {..} SimpleContract.CreateContractLocDates{} SimpleContract.CreateContractRisks{} SimpleContract.CreateContractInvoice{} expenses) submitUrl)
     = renderFormLarge profile $ do
-      title' "New employment contract"
+      autoReload
+      title' "New simple contract"
         .  Just
         .  H.toValue
-        $  "/forms/edit-contract/"
+        $  "/forms/edit-simple-contract/"
         <> key
 
       H.div
         ! A.class_ "u-padding-vertical-l"
         $ H.toMarkup
-        $ PanelHeaderAndBody "General information"
+        $ PanelHeaderAndBody "Service type"
         $ H.dl
         ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
         $ do

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -69,7 +69,6 @@ data CreateSimpleContractPage = CreateSimpleContractPage
 instance H.ToMarkup CreateSimpleContractPage where
   toMarkup (CreateSimpleContractPage profile mkey contract roleLabel saveUrl addDateUrl selectVATUrl  addExpenseUrl)
     = renderFormLarge profile $ do
-      autoReload
       title "New simple contract"
 
       information
@@ -256,6 +255,9 @@ groupInvoicing inv selectVATUrl = do
           H.div ! A.class_ "c-radio" $ H.label $ do
             H.input ! A.type_ "radio" ! A.name "vat-incl-excl" ! A.value "Excluded"
             "VAT Excluded"
+          H.p
+            ! A.class_ "c-form-help-text"
+            $ "Specify if the above amount includes VAT or not."
   inputText "Prepaid amount" "prepaid-amount" Nothing Nothing
   inputText "Withholding tax"     "withholding-tax" Nothing Nothing
   Misc.inputSelect_
@@ -324,7 +326,6 @@ data SelectRolePage = SelectRolePage
 
 instance H.ToMarkup SelectRolePage where
   toMarkup (SelectRolePage profile key) = renderFormLarge profile $ do
-    autoReload
     title' "Select role" Nothing
 
     H.div ! A.class_ "c-display" $ do
@@ -404,7 +405,6 @@ data ConfirmRolePage = ConfirmRolePage
 instance H.ToMarkup ConfirmRolePage where
   toMarkup (ConfirmRolePage profile key role label submitUrl) =
     renderFormLarge profile $ do
-      autoReload
       H.toMarkup
         $ PanelHeaderAndBody "Confirm selected role"
         $ H.dl
@@ -494,7 +494,6 @@ data SelectVATPage = SelectVATPage
 
 instance H.ToMarkup SelectVATPage where
   toMarkup (SelectVATPage profile key) = renderFormLarge profile $ do
-    autoReload
     title' "Select VAT" Nothing
 
     displayRate key ("0", "0% For some reason")
@@ -521,7 +520,6 @@ data ConfirmVATPage = ConfirmVATPage
 instance H.ToMarkup ConfirmVATPage where
   toMarkup (ConfirmVATPage profile key rate submitUrl) =
     renderFormLarge profile $ do
-      autoReload
       H.toMarkup
         $ PanelHeaderAndBody "Confirm selected VAT"
         $ H.dl
@@ -620,7 +618,6 @@ data ConfirmSimpleContractPage = ConfirmSimpleContractPage
 instance H.ToMarkup ConfirmSimpleContractPage where
   toMarkup (ConfirmSimpleContractPage profile key (SimpleContract.CreateContractAll SimpleContract.CreateContractType {..} SimpleContract.CreateContractRisks{} SimpleContract.CreateContractInvoice{} dates expenses) roleLabel submitUrl)
     = renderFormLarge profile $ do
-      autoReload
       title' "New simple contract"
         .  Just
         .  H.toValue

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -14,7 +14,7 @@ module Curiosity.Html.SimpleContract
   , ConfirmSimpleContractPage(..)
   ) where
 
-import qualified Curiosity.Data.Employment     as Employment
+import qualified Curiosity.Data.SimpleContract as SimpleContract
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
 import qualified Smart.Html.Alert              as Alert
@@ -29,7 +29,7 @@ import qualified Text.Blaze.Html5.Attributes   as A
 
 --------------------------------------------------------------------------------
 data SimpleContractView = SimpleContractView
-  { _contractViewSimpleContract      :: Employment.Contract
+  { _contractViewSimpleContract      :: SimpleContract.Contract
   , _contractViewHasEditButton :: Maybe H.AttributeValue
   }
 
@@ -40,7 +40,7 @@ instance H.ToMarkup SimpleContractView where
 contractView contract hasEditButton = containerLarge $ do
   title' "Employment contract" hasEditButton
   H.dl ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short" $ do
-    keyValuePair "ID" (Employment._contractId contract)
+    keyValuePair "ID" (SimpleContract._contractId contract)
 
 
 --------------------------------------------------------------------------------
@@ -49,14 +49,14 @@ data CreateSimpleContractPage = CreateSimpleContractPage
     -- ^ The user creating the contract
   , _createSimpleContractPageKey           :: Maybe Text
     -- ^ The form editing session key, if the form was already saved
-  , _createSimpleContractContract          :: Employment.CreateContractAll
+  , _createSimpleContractContract          :: SimpleContract.CreateContractAll
     -- ^ The contract being edited
   , _createSimpleContractPageSaveURL       :: H.AttributeValue
   , _createSimpleContractPageAddExpenseURL :: H.AttributeValue
   }
 
 instance H.ToMarkup CreateSimpleContractPage where
-  toMarkup (CreateSimpleContractPage profile mkey (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractType {} Employment.CreateContractLocDates{} Employment.CreateContractRisks{} Employment.CreateContractInvoice{} expenses) saveUrl addExpenseUrl)
+  toMarkup (CreateSimpleContractPage profile mkey (SimpleContract.CreateContractAll SimpleContract.CreateContractType {..} SimpleContract.CreateContractLocDates{} SimpleContract.CreateContractRisks{} SimpleContract.CreateContractInvoice{} expenses) saveUrl addExpenseUrl)
     = renderFormLarge profile $ do
       autoReload
       title "New simple contract"
@@ -82,9 +82,9 @@ instance H.ToMarkup CreateSimpleContractPage where
             H.p ! A.class_ "c-form-help-text" $
               "Your most frequently used role has been automatically selected. Click the edit button if you want to select a different role for this work."
 
-        inputText "Work type"
-                  "type"
-                  (Just $ H.toValue _createContractType)
+        inputText "Role"
+                  "role"
+                  (Just $ H.toValue _createContractRole)
                   Nothing
         Misc.inputTextarea "description"
                            "Description"
@@ -170,9 +170,9 @@ groupExpenses mkey expenses submitUrl = do
   display
     :: Text
     -> Int
-    -> Employment.AddExpense
+    -> SimpleContract.AddExpense
     -> ([Text], [(H.Html, Text, Text)], Maybe Text)
-  display key i Employment.AddExpense {..} =
+  display key i SimpleContract.AddExpense {..} =
     ( [show _addExpenseAmount]
     , [ ( Misc.divIconDelete
         , "Remove"
@@ -274,7 +274,7 @@ data AddExpensePage = AddExpensePage
   , _addExpensePageIndex       :: Maybe Int
     -- ^ The index of the expense within CreateContractAll, if it was already
     -- added
-  , _addExpensePageExpense     :: Employment.AddExpense
+  , _addExpensePageExpense     :: SimpleContract.AddExpense
   , _addExpensePageSubmitURL   :: H.AttributeValue
   }
 
@@ -301,7 +301,7 @@ instance H.ToMarkup AddExpensePage where
    where
     label   = if isJust mindex then "Update expense" else "Add expense"
     mamount = if amount /= 0 then Just (H.toValue amount) else Nothing
-    amount  = Employment._addExpenseAmount expense
+    amount  = SimpleContract._addExpenseAmount expense
 
 
 --------------------------------------------------------------------------------
@@ -312,7 +312,7 @@ data RemoveExpensePage = RemoveExpensePage
     -- ^ The key of the contract form
   , _removeExpensePageIndex       :: Int
     -- ^ The index of the expense within CreateContractAll
-  , _removeExpensePageExpense     :: Employment.AddExpense
+  , _removeExpensePageExpense     :: SimpleContract.AddExpense
   , _removeExpensePageSubmitURL   :: H.AttributeValue
   }
 
@@ -327,7 +327,7 @@ instance H.ToMarkup RemoveExpensePage where
       button submitUrl "Remove expense"
    where
     mamount = if amount /= 0 then show amount else "/" :: Text
-    amount  = Employment._addExpenseAmount expense
+    amount  = SimpleContract._addExpenseAmount expense
 
 
 --------------------------------------------------------------------------------
@@ -335,12 +335,12 @@ data ConfirmSimpleContractPage = ConfirmSimpleContractPage
   { _confirmSimpleContractPageUserProfile :: User.UserProfile
     -- ^ The user creating the contract
   , _confirmSimpleContractPageKey         :: Text
-  , _confirmSimpleContractPageContract    :: Employment.CreateContractAll
+  , _confirmSimpleContractPageContract    :: SimpleContract.CreateContractAll
   , _confirmSimpleContractPageSubmitURL   :: H.AttributeValue
   }
 
 instance H.ToMarkup ConfirmSimpleContractPage where
-  toMarkup (ConfirmSimpleContractPage profile key (Employment.CreateContractAll Employment.CreateContractGenInfo {..} Employment.CreateContractType {} Employment.CreateContractLocDates{} Employment.CreateContractRisks{} Employment.CreateContractInvoice{} expenses) submitUrl)
+  toMarkup (ConfirmSimpleContractPage profile key (SimpleContract.CreateContractAll SimpleContract.CreateContractType {..} SimpleContract.CreateContractLocDates{} SimpleContract.CreateContractRisks{} SimpleContract.CreateContractInvoice{} expenses) submitUrl)
     = renderFormLarge profile $ do
       title' "New employment contract"
         .  Just
@@ -356,10 +356,7 @@ instance H.ToMarkup ConfirmSimpleContractPage where
         ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
         $ do
             keyValuePair "Worker username" username
-            keyValuePair "Project"         _createContractProject
-            keyValuePair "Purchase order"  _createContractPO
             keyValuePair "Role"            _createContractRole
-            keyValuePair "Work type"       _createContractType
             keyValuePair "Description"     _createContractDescription
 
       H.div
@@ -385,7 +382,7 @@ instance H.ToMarkup ConfirmSimpleContractPage where
     display
       :: Text
       -> Int
-      -> Employment.AddExpense
+      -> SimpleContract.AddExpense
       -> ([Text], [(H.Html, Text, Text)], Maybe Text)
-    display key i Employment.AddExpense {..} =
+    display key i SimpleContract.AddExpense {..} =
       ([show _addExpenseAmount], [], Nothing)

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -61,13 +61,14 @@ data CreateSimpleContractPage = CreateSimpleContractPage
   , _createSimpleContractRoleLabel         :: Text
     -- ^ The human text for the role, already looked un in `roles'`.
   , _createSimpleContractPageSaveURL       :: H.AttributeValue
+  , _createSimpleContractPageSelectRoleURL :: H.AttributeValue
   , _createSimpleContractPageAddDateURL    :: H.AttributeValue
   , _createSimpleContractPageSelectVATURL  :: H.AttributeValue
   , _createSimpleContractPageAddExpenseURL :: H.AttributeValue
   }
 
 instance H.ToMarkup CreateSimpleContractPage where
-  toMarkup (CreateSimpleContractPage profile mkey contract roleLabel saveUrl addDateUrl selectVATUrl  addExpenseUrl)
+  toMarkup (CreateSimpleContractPage profile mkey contract roleLabel saveUrl selectRoleUrl addDateUrl selectVATUrl  addExpenseUrl)
     = renderFormLarge profile $ do
       title "New simple contract"
 
@@ -75,6 +76,7 @@ instance H.ToMarkup CreateSimpleContractPage where
 
       (! A.id "panel-type") $ panel "Service type" $ groupType contract
                                                                roleLabel
+                                                               selectRoleUrl
       panel "Risks" $ groupRisks
       (! A.id "panel-dates") $ panelStandard "Work dates" $ groupDates
         mkey
@@ -106,7 +108,7 @@ information =
 iconInformation =
   Just $ OSvgIconDiv @"circle-information" svgIconCircleInformation
 
-groupType SimpleContract.CreateContractAll {..} roleLabel = do
+groupType SimpleContract.CreateContractAll {..} roleLabel selectRoleUrl = do
   H.div ! A.class_ "o-form-group" $ do
     H.label ! A.class_ "o-form-group__label" ! A.for "worker" $ "Role"
     H.div
@@ -118,7 +120,7 @@ groupType SimpleContract.CreateContractAll {..} roleLabel = do
                 H.span ! A.class_ "u-spacer-right-s" $ H.text roleLabel
                 H.button
                   ! A.class_ "c-button c-button--borderless c-button--icon"
-                  ! A.formaction "/echo/new-simple-contract-and-select-role"
+                  ! A.formaction selectRoleUrl
                   ! A.formmethod "POST"
                   $ H.span
                   ! A.class_ "c-button__content"

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -437,7 +437,8 @@ handleCommand runtime@Runtime {..} user command = do
                 merror <- submitCreateContractForm' _rDb (profile, input)
                 -- TODO Should we have a type to combine multiple possible errors ?
                 case merror of
-                  Left (Employment.Err err) -> pure . Left $ User.UserNotFound err
+                  Left (Employment.Err err) ->
+                    pure . Left $ User.UserNotFound err
                   Right id -> pure $ Right id
               Nothing -> pure . Left . User.UserNotFound $ User.unUserName user
       case output of
@@ -815,13 +816,14 @@ addRoleToSimpleContractForm
    . Data.StmDb runtime
   -> (User.UserProfile, Text, SimpleContract.SelectRole)
   -> STM () -- TODO Possible errors
-addRoleToSimpleContractForm db (profile, key, SimpleContract.SelectRole role) = do
-  STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
+addRoleToSimpleContractForm db (profile, key, SimpleContract.SelectRole role) =
+  do
+    STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
  where
   save = M.adjust
     (\(SimpleContract.CreateContractAll ty ld rs inv es) ->
       let ty' = ty { SimpleContract._createContractRole = role }
-      in SimpleContract.CreateContractAll ty' ld rs inv es
+      in  SimpleContract.CreateContractAll ty' ld rs inv es
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -44,6 +44,7 @@ module Curiosity.Runtime
   -- ** Simple Contract
   , newCreateSimpleContractForm
   , readCreateSimpleContractForm
+  , writeCreateSimpleContractForm
   , addRoleToSimpleContractForm
   -- * ID generation
   , generateUserId
@@ -810,6 +811,24 @@ readCreateSimpleContractForm db (profile, key) = do
   let mform = M.lookup (username, key) m
   pure $ maybe (Left ()) Right mform
   where username = User._userCredsName $ User._userProfileCreds profile
+
+writeCreateSimpleContractForm
+  :: forall runtime
+   . Data.StmDb runtime
+  -> (User.UserProfile, Text, SimpleContract.CreateContractAll')
+  -> STM Text
+writeCreateSimpleContractForm db (profile, key, SimpleContract.CreateContractAll' ty ld rs inv)
+  = do
+    STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
+    pure key
+ where
+  -- TODO Return an error when the key is not found.
+  save = M.adjust
+    (\(SimpleContract.CreateContractAll _ _ _ _ es) ->
+      SimpleContract.CreateContractAll ty ld rs inv es
+    )
+    (username, key)
+  username = User._userCredsName $ User._userProfileCreds profile
 
 addRoleToSimpleContractForm
   :: forall runtime

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -798,14 +798,14 @@ newCreateSimpleContractForm
    . Data.StmDb runtime
   -> (User.UserProfile, SimpleContract.CreateContractAll')
   -> STM Text
-newCreateSimpleContractForm db (profile, SimpleContract.CreateContractAll' ty rs inv)
+newCreateSimpleContractForm db (profile, SimpleContract.CreateContractAll' ty rs cl inv)
   = do
     key <- Data.genRandomText db
     STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) (add key)
     pure key
  where
   add key =
-    M.insert (username, key) (SimpleContract.CreateContractAll ty rs inv [] [])
+    M.insert (username, key) (SimpleContract.CreateContractAll ty rs cl inv [] [])
   username = User._userCredsName $ User._userProfileCreds profile
 
 readCreateSimpleContractForm
@@ -824,15 +824,15 @@ writeCreateSimpleContractForm
    . Data.StmDb runtime
   -> (User.UserProfile, Text, SimpleContract.CreateContractAll')
   -> STM Text
-writeCreateSimpleContractForm db (profile, key, SimpleContract.CreateContractAll' ty rs inv)
+writeCreateSimpleContractForm db (profile, key, SimpleContract.CreateContractAll' ty rs cl inv)
   = do
     STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
     pure key
  where
   -- TODO Return an error when the key is not found.
   save = M.adjust
-    (\(SimpleContract.CreateContractAll _ _ _ ds es) ->
-      SimpleContract.CreateContractAll ty rs inv ds es
+    (\(SimpleContract.CreateContractAll _ _ _ _ ds es) ->
+      SimpleContract.CreateContractAll ty rs cl inv ds es
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -847,9 +847,9 @@ addRoleToSimpleContractForm db (profile, key, SimpleContract.SelectRole role) =
     STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
  where
   save = M.adjust
-    (\(SimpleContract.CreateContractAll ty rs inv ds es) ->
+    (\(SimpleContract.CreateContractAll ty rs cl inv ds es) ->
       let ty' = ty { SimpleContract._createContractRole = role }
-      in  SimpleContract.CreateContractAll ty' rs inv ds es
+      in  SimpleContract.CreateContractAll ty' rs cl inv ds es
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -863,8 +863,8 @@ addDateToSimpleContractForm db (profile, key, date) = do
   STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
  where
   save = M.adjust
-    (\(SimpleContract.CreateContractAll ty rs inv ds es) ->
-      SimpleContract.CreateContractAll ty rs inv (ds ++ [date]) es
+    (\(SimpleContract.CreateContractAll ty rs cl inv ds es) ->
+      SimpleContract.CreateContractAll ty rs cl inv (ds ++ [date]) es
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -878,10 +878,10 @@ writeDateToSimpleContractForm db (profile, key, index, date) = do
   STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
  where
   save = M.adjust
-    (\(SimpleContract.CreateContractAll ty rs inv ds es) ->
+    (\(SimpleContract.CreateContractAll ty rs cl inv ds es) ->
       let f i e = if i == index then date else e
           ds' = zipWith f [0 ..] ds
-      in  SimpleContract.CreateContractAll ty rs inv ds' es
+      in  SimpleContract.CreateContractAll ty rs cl inv ds' es
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -895,9 +895,9 @@ removeDateFromSimpleContractForm db (profile, key, index) = do
   STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
  where
   save = M.adjust
-    (\(SimpleContract.CreateContractAll ty rs inv ds es) ->
+    (\(SimpleContract.CreateContractAll ty rs cl inv ds es) ->
       let ds' = map snd . filter ((/= index) . fst) $ zip [0 ..] ds
-      in  SimpleContract.CreateContractAll ty rs inv ds' es
+      in  SimpleContract.CreateContractAll ty rs cl inv ds' es
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -912,9 +912,9 @@ addVATToSimpleContractForm db (profile, key, SimpleContract.SelectVAT rate) =
     STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
  where
   save = M.adjust
-    (\(SimpleContract.CreateContractAll ty rs inv ds es) ->
+    (\(SimpleContract.CreateContractAll ty rs cl inv ds es) ->
       let inv' = inv { SimpleContract._createContractVAT = rate }
-      in  SimpleContract.CreateContractAll ty rs inv' ds es
+      in  SimpleContract.CreateContractAll ty rs cl inv' ds es
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -928,8 +928,8 @@ addExpenseToSimpleContractForm db (profile, key, expense) = do
   STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
  where
   save = M.adjust
-    (\(SimpleContract.CreateContractAll ty ld rs inv es) ->
-      SimpleContract.CreateContractAll ty ld rs inv $ es ++ [expense]
+    (\(SimpleContract.CreateContractAll ty ld cl rs inv es) ->
+      SimpleContract.CreateContractAll ty ld cl rs inv $ es ++ [expense]
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -943,10 +943,10 @@ writeExpenseToSimpleContractForm db (profile, key, index, expense) = do
   STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
  where
   save = M.adjust
-    (\(SimpleContract.CreateContractAll ty ld rs inv es) ->
+    (\(SimpleContract.CreateContractAll ty ld rs cl inv es) ->
       let f i e = if i == index then expense else e
           es' = zipWith f [0 ..] es
-      in  SimpleContract.CreateContractAll ty ld rs inv es'
+      in  SimpleContract.CreateContractAll ty ld rs cl inv es'
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile
@@ -960,9 +960,9 @@ removeExpenseFromSimpleContractForm db (profile, key, index) = do
   STM.modifyTVar (Data._dbFormCreateSimpleContractAll db) save
  where
   save = M.adjust
-    (\(SimpleContract.CreateContractAll ty ld rs inv es) ->
+    (\(SimpleContract.CreateContractAll ty ld rs cl inv es) ->
       let es' = map snd . filter ((/= index) . fst) $ zip [0 ..] es
-      in  SimpleContract.CreateContractAll ty ld rs inv es'
+      in  SimpleContract.CreateContractAll ty ld rs cl inv es'
     )
     (username, key)
   username = User._userCredsName $ User._userProfileCreds profile

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -35,6 +35,7 @@ import           Curiosity.Data                 ( HaskDb
 import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Employment     as Employment
 import qualified Curiosity.Data.Legal          as Legal
+import qualified Curiosity.Data.SimpleContract as SimpleContract
 import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Form.Login          as Login
 import qualified Curiosity.Form.Signup         as Signup
@@ -216,18 +217,18 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                   :> Post '[B.HTML] Pages.EchoPage
 
              :<|> "echo" :> "new-simple-contract"
-                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractAll'
+                  :> ReqBody '[FormUrlEncoded] SimpleContract.CreateContractAll'
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
              :<|> "echo" :> "new-simple-contract-and-select-role"
-                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractAll'
+                  :> ReqBody '[FormUrlEncoded] SimpleContract.CreateContractAll'
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
              :<|> "echo" :> "save-simple-contract-and-select-role"
                   :> Capture "key" Text
-                  :> ReqBody '[FormUrlEncoded] Employment.CreateContractAll'
+                  :> ReqBody '[FormUrlEncoded] SimpleContract.CreateContractAll'
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
@@ -920,7 +921,7 @@ echoSubmitContract dataDir (Employment.SubmitContract key) = do
 echoNewSimpleContract
   :: ServerC m
   => FilePath
-  -> Employment.CreateContractAll'
+  -> SimpleContract.CreateContractAll'
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewSimpleContract dataDir contract = do
   -- profile <- readJson $ dataDir </> "alice.json"
@@ -933,7 +934,7 @@ echoNewSimpleContract dataDir contract = do
 echoNewSimpleContractAndSelectRole
   :: ServerC m
   => FilePath
-  -> Employment.CreateContractAll'
+  -> SimpleContract.CreateContractAll'
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewSimpleContractAndSelectRole dataDir contract = do
   -- profile <- readJson $ dataDir </> "alice.json"
@@ -947,7 +948,7 @@ echoSaveSimpleContractAndSelectRole
   :: ServerC m
   => FilePath
   -> Text
-  -> Employment.CreateContractAll'
+  -> SimpleContract.CreateContractAll'
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveSimpleContractAndSelectRole dataDir key contract = do
   -- profile <- readJson $ dataDir </> "alice.json"
@@ -963,7 +964,7 @@ documentCreateSimpleContractPage
   :: ServerC m => FilePath -> m Pages.CreateSimpleContractPage
 documentCreateSimpleContractPage dataDir = do
   profile <- readJson $ dataDir </> "alice.json"
-  let contractAll = Employment.emptyCreateContractAll
+  let contractAll = SimpleContract.emptyCreateContractAll
   pure $ Pages.CreateSimpleContractPage profile
                                         Nothing
                                         contractAll
@@ -974,7 +975,7 @@ documentEditSimpleContractPage
   :: ServerC m => FilePath -> Text -> m Pages.CreateSimpleContractPage
 documentEditSimpleContractPage dataDir key = do
   profile <- readJson $ dataDir </> "alice.json"
-  let contractAll = Employment.emptyCreateContractAll
+  let contractAll = SimpleContract.emptyCreateContractAll
   pure $ Pages.CreateSimpleContractPage profile
                                         Nothing
                                         contractAll

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1422,6 +1422,7 @@ documentConfirmRolePage dataDir key role = do
           key
           role
           roleLabel
+          (H.toValue $ "/forms/edit/simple-contract/" <> key <> "#panel-type")
           (H.toValue $ "/echo/select-role/" <> key)
         Nothing -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack role -- TODO Specific error.
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
@@ -1438,6 +1439,7 @@ documentAddDatePage dataDir key = do
       key
       Nothing
       SimpleContract.emptyAddDate
+      (H.toValue $ "/forms/edit/simple-contract/" <> key <> "#panel-dates")
       (H.toValue $ "/echo/add-date/" <> key)
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
@@ -1449,7 +1451,7 @@ documentEditDatePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
   case output of
-    Right (SimpleContract.CreateContractAll _ _ _ dates _) ->
+    Right (SimpleContract.CreateContractAll _ _ _ _ dates _) ->
       if index > length dates - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.AddDatePage
@@ -1457,6 +1459,7 @@ documentEditDatePage dataDir key index = do
           key
           (Just index)
           (dates !! index)
+          (H.toValue $ "/forms/edit/simple-contract/" <> key <> "#panel-dates")
           (H.toValue $ "/echo/save-date/" <> key <> "/" <> show index)
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
@@ -1467,7 +1470,7 @@ documentRemoveDatePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
   case output of
-    Right (SimpleContract.CreateContractAll _ _ _ dates _) ->
+    Right (SimpleContract.CreateContractAll _ _ _ _ dates _) ->
       if index > length dates - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.RemoveDatePage
@@ -1504,6 +1507,7 @@ documentConfirmVATPage dataDir key rate = do
           profile
           key
           rate
+          (H.toValue $ "/forms/edit/simple-contract/" <> key <> "#panel-invoicing")
           (H.toValue $ "/echo/select-vat/" <> key)
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
@@ -1519,6 +1523,7 @@ documentSimpleContractAddExpensePage dataDir key = do
       key
       Nothing
       SimpleContract.emptyAddExpense
+      (H.toValue $ "/forms/edit/simple-contract/" <> key <> "#panel-expenses")
       (H.toValue $ "/echo/simple-contract/add-expense/" <> key)
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
@@ -1530,7 +1535,7 @@ documentSimpleContractEditExpensePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
   case output of
-    Right (SimpleContract.CreateContractAll _ _ _ _ expenses) ->
+    Right (SimpleContract.CreateContractAll _ _ _ _ _ expenses) ->
       if index > length expenses - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.SimpleContractAddExpensePage
@@ -1538,6 +1543,7 @@ documentSimpleContractEditExpensePage dataDir key index = do
           key
           (Just index)
           (expenses !! index)
+          (H.toValue $ "/forms/edit/simple-contract/" <> key <> "#panel-expenses")
           (H.toValue $ "/echo/simple-contract/save-expense/" <> key <> "/" <> show index)
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
@@ -1548,7 +1554,7 @@ documentSimpleContractRemoveExpensePage dataDir key index = do
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
   case output of
-    Right (SimpleContract.CreateContractAll _ _ _ _ expenses) ->
+    Right (SimpleContract.CreateContractAll _ _ _ _ _ expenses) ->
       if index > length expenses - 1
         then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
         else pure $ Pages.SimpleContractRemoveExpensePage
@@ -1577,6 +1583,7 @@ documentConfirmSimpleContractPage dataDir key = do
           key
           contractAll
           roleLabel
+          (Just . H.toValue $ "/forms/edit/simple-contract/" <> key)
           "/echo/submit-simple-contract"
         Nothing -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack role -- TODO Specific error.
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1235,6 +1235,7 @@ documentCreateSimpleContractPage dataDir = do
       contractAll
       roleLabel
       "/echo/new-simple-contract"
+      "/echo/new-simple-contract-and-select-role"
       "/echo/new-simple-contract-and-add-date"
       "/echo/new-simple-contract-and-select-vat"
       "/echo/new-simple-contract-and-add-expense"
@@ -1259,6 +1260,7 @@ documentEditSimpleContractPage dataDir key = do
           contractAll
           roleLabel
           (H.toValue $ "/echo/save-simple-contract/" <> key)
+          (H.toValue $ "/echo/save-simple-contract-and-select-role/" <> key)
           (H.toValue $ "/echo/save-simple-contract-and-add-date/" <> key)
           (H.toValue $ "/echo/save-simple-contract-and-select-vat/" <> key)
           (H.toValue $ "/echo/save-simple-contract-and-add-expense/" <> key)

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -106,56 +106,68 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
              :<|> "forms" :> "signup" :> Get '[B.HTML] Signup.Page
              :<|> "forms" :> "profile" :> Get '[B.HTML] Pages.ProfilePage
 
-             :<|> "forms" :> "new-contract" :> Get '[B.HTML] Pages.CreateContractPage
-             :<|> "forms" :> "edit-contract"
+             :<|> "forms" :> "new" :> "contract"
+                  :> Get '[B.HTML] Pages.CreateContractPage
+             :<|> "forms" :> "edit" :> "contract"
                   :> Capture "key" Text
                   :> Get '[B.HTML] Pages.CreateContractPage
-             :<|> "forms" :> "add-expense"
+             :<|> "forms" :> "edit" :> "contract" :> "add-expense"
                   :> Capture "key" Text
                   :> Get '[B.HTML] Pages.AddExpensePage
-             :<|> "forms" :> "edit-expense"
+             :<|> "forms" :> "edit" :> "contract" :> "edit-expense"
                   :> Capture "key" Text
                   :> Capture "index" Int
                   :> Get '[B.HTML] Pages.AddExpensePage
-             :<|> "forms" :> "remove-expense"
+             :<|> "forms" :> "edit" :> "contract" :> "remove-expense"
                   :> Capture "key" Text
                   :> Capture "index" Int
                   :> Get '[B.HTML] Pages.RemoveExpensePage
-             :<|> "forms" :> "confirm-contract"
+             :<|> "forms" :> "edit" :> "contract" :> "confirm-contract"
                   :> Capture "key" Text
                   :> Get '[B.HTML] Pages.ConfirmContractPage
 
-             :<|> "forms" :> "new-simple-contract"
+             :<|> "forms" :> "new" :> "simple-contract"
                   :> Get '[B.HTML] Pages.CreateSimpleContractPage
-             :<|> "forms" :> "edit-simple-contract"
+             :<|> "forms" :> "edit" :> "simple-contract"
                   :> Capture "key" Text
                   :> Get '[B.HTML] Pages.CreateSimpleContractPage
-             :<|> "forms" :> "select-role"
+             :<|> "forms" :> "edit" :> "simple-contract" :> "select-role"
                   :> Capture "key" Text
                   :> Get '[B.HTML] Pages.SelectRolePage
-             :<|> "forms" :> "confirm-role"
+             :<|> "forms" :> "edit" :> "simple-contract" :> "confirm-role"
                   :> Capture "key" Text
                   :> Capture "role" Text
                   :> Get '[B.HTML] Pages.ConfirmRolePage
-             :<|> "forms" :> "add-date"
+             :<|> "forms" :> "edit" :> "simple-contract" :> "add-date"
                   :> Capture "key" Text
                   :> Get '[B.HTML] Pages.AddDatePage
-             :<|> "forms" :> "edit-date"
+             :<|> "forms" :> "edit" :> "simple-contract" :> "edit-date"
                   :> Capture "key" Text
                   :> Capture "index" Int
                   :> Get '[B.HTML] Pages.AddDatePage
-             :<|> "forms" :> "remove-date"
+             :<|> "forms" :> "edit" :> "simple-contract" :> "remove-date"
                   :> Capture "key" Text
                   :> Capture "index" Int
                   :> Get '[B.HTML] Pages.RemoveDatePage
-             :<|> "forms" :> "select-vat"
+             :<|> "forms" :> "edit" :> "simple-contract" :> "select-vat"
                   :> Capture "key" Text
                   :> Get '[B.HTML] Pages.SelectVATPage
-             :<|> "forms" :> "confirm-vat"
+             :<|> "forms" :> "edit" :> "simple-contract" :> "confirm-vat"
                   :> Capture "key" Text
                   :> Capture "rate" Int
                   :> Get '[B.HTML] Pages.ConfirmVATPage
-             :<|> "forms" :> "confirm-simple-contract"
+             :<|> "forms" :> "edit" :> "simple-contract" :> "add-expense"
+                  :> Capture "key" Text
+                  :> Get '[B.HTML] Pages.SimpleContractAddExpensePage
+             :<|> "forms" :> "edit" :> "simple-contract" :> "edit-expense"
+                  :> Capture "key" Text
+                  :> Capture "index" Int
+                  :> Get '[B.HTML] Pages.SimpleContractAddExpensePage
+             :<|> "forms" :> "edit" :> "simple-contract" :> "remove-expense"
+                  :> Capture "key" Text
+                  :> Capture "index" Int
+                  :> Get '[B.HTML] Pages.SimpleContractRemoveExpensePage
+             :<|> "forms" :> "edit" :> "simple-contract" :> "confirm-simple-contract"
                   :> Capture "key" Text
                   :> Get '[B.HTML] Pages.ConfirmSimpleContractPage
 
@@ -257,6 +269,11 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
+             :<|> "echo" :> "new-simple-contract-and-add-expense"
+                  :> ReqBody '[FormUrlEncoded] SimpleContract.CreateContractAll'
+                  :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
+                                              NoContent
+                                            )
              :<|> "echo" :> "save-simple-contract"
                   :> Capture "key" Text
                   :> ReqBody '[FormUrlEncoded] SimpleContract.CreateContractAll'
@@ -276,6 +293,12 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                                               NoContent
                                             )
              :<|> "echo" :> "save-simple-contract-and-select-vat"
+                  :> Capture "key" Text
+                  :> ReqBody '[FormUrlEncoded] SimpleContract.CreateContractAll'
+                  :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
+                                              NoContent
+                                            )
+             :<|> "echo" :> "save-simple-contract-and-add-expense"
                   :> Capture "key" Text
                   :> ReqBody '[FormUrlEncoded] SimpleContract.CreateContractAll'
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
@@ -309,6 +332,25 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
              :<|> "echo" :> "select-vat"
                   :> Capture "key" Text
                   :> ReqBody '[FormUrlEncoded] SimpleContract.SelectVAT
+                  :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
+                                              NoContent
+                                            )
+             :<|> "echo" :> "simple-contract" :> "add-expense"
+                  :> Capture "key" Text
+                  :> ReqBody '[FormUrlEncoded] SimpleContract.AddExpense
+                  :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
+                                              NoContent
+                                            )
+             :<|> "echo" :> "simple-contract" :> "save-expense"
+                  :> Capture "key" Text
+                  :> Capture "index" Int
+                  :> ReqBody '[FormUrlEncoded] SimpleContract.AddExpense
+                  :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
+                                              NoContent
+                                            )
+             :<|> "echo" :> "simple-contract" :> "remove-expense"
+                  :> Capture "key" Text
+                  :> Capture "index" Int
                   :> Verb 'POST 303 '[JSON] ( Headers '[ Header "Location" Text ]
                                               NoContent
                                             )
@@ -375,6 +417,9 @@ serverT natTrans ctx conf jwtS root dataDir =
     :<|> documentRemoveDatePage dataDir
     :<|> documentSelectVATPage dataDir
     :<|> documentConfirmVATPage dataDir
+    :<|> documentSimpleContractAddExpensePage dataDir
+    :<|> documentSimpleContractEditExpensePage dataDir
+    :<|> documentSimpleContractRemoveExpensePage dataDir
     :<|> documentConfirmSimpleContractPage dataDir
 
     :<|> documentProfilePage dataDir
@@ -405,15 +450,20 @@ serverT natTrans ctx conf jwtS root dataDir =
     :<|> echoNewSimpleContractAndSelectRole dataDir
     :<|> echoNewSimpleContractAndAddDate dataDir
     :<|> echoNewSimpleContractAndSelectVAT dataDir
+    :<|> echoNewSimpleContractAndAddExpense dataDir
     :<|> echoSaveSimpleContract dataDir
     :<|> echoSaveSimpleContractAndSelectRole dataDir
     :<|> echoSaveSimpleContractAndAddDate dataDir
     :<|> echoSaveSimpleContractAndSelectVAT dataDir
+    :<|> echoSaveSimpleContractAndAddExpense dataDir
     :<|> echoSelectRole dataDir
     :<|> echoAddDate dataDir
     :<|> echoSaveDate dataDir
     :<|> echoRemoveDate dataDir
     :<|> echoSelectVAT dataDir
+    :<|> echoSimpleContractAddExpense dataDir
+    :<|> echoSimpleContractSaveExpense dataDir
+    :<|> echoSimpleContractRemoveExpense dataDir
 
     :<|> partialUsernameBlocklist
     :<|> partialUsernameBlocklistAsJson
@@ -904,7 +954,7 @@ echoNewContract
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewContract dataDir contract = do
   key <- echoNewContract' dataDir contract
-  pure $ addHeader @"Location" ("/forms/confirm-contract/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/contract/confirm-contract/" <> key) NoContent
 
 -- | Create a form, then move to the add expense part.
 echoNewContractAndAddExpense
@@ -914,7 +964,7 @@ echoNewContractAndAddExpense
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewContractAndAddExpense dataDir contract = do
   key <- echoNewContract' dataDir contract
-  pure $ addHeader @"Location" ("/forms/add-expense/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/contract/add-expense/" <> key) NoContent
 
 -- | Save a form, re-using a key. This is normally used with a \"Location"
 -- header.
@@ -941,7 +991,7 @@ echoSaveContract
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveContract dataDir key contract = do
   echoSaveContract' dataDir key contract
-  pure $ addHeader @"Location" ("/forms/confirm-contract/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/contract/confirm-contract/" <> key) NoContent
 
 -- | Save a form, re-using a key, then move to the add expense part.
 echoSaveContractAndAddExpense
@@ -952,7 +1002,7 @@ echoSaveContractAndAddExpense
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveContractAndAddExpense dataDir key contract = do
   echoSaveContract' dataDir key contract
-  pure $ addHeader @"Location" ("/forms/add-expense/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/contract/add-expense/" <> key) NoContent
 
 echoAddExpense
   :: ServerC m
@@ -965,7 +1015,7 @@ echoAddExpense dataDir key expense = do
   db      <- asks Rt._rDb
   liftIO . atomically $ Rt.addExpenseToContractForm db (profile, key, expense)
   pure $ addHeader @"Location"
-    ("/forms/edit-contract/" <> key <> "#panel-expenses")
+    ("/forms/edit/contract/" <> key <> "#panel-expenses")
     NoContent
 
 -- | Save an expense, re-using a key and an index.
@@ -983,7 +1033,7 @@ echoSaveExpense dataDir key index expense = do
     db
     (profile, key, index, expense)
   pure $ addHeader @"Location"
-    ("/forms/edit-contract/" <> key <> "#panel-expenses")
+    ("/forms/edit/contract/" <> key <> "#panel-expenses")
     NoContent
 
 echoRemoveExpense
@@ -999,7 +1049,7 @@ echoRemoveExpense dataDir key index = do
     db
     (profile, key, index)
   pure $ addHeader @"Location"
-    ("/forms/edit-contract/" <> key <> "#panel-expenses")
+    ("/forms/edit/contract/" <> key <> "#panel-expenses")
     NoContent
 
 documentConfirmContractPage
@@ -1052,7 +1102,7 @@ echoNewSimpleContract
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewSimpleContract dataDir contract = do
   key <- echoNewSimpleContract' dataDir contract
-  pure $ addHeader @"Location" ("/forms/confirm-simple-contract/" <> key)
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/confirm-simple-contract/" <> key)
                                NoContent
 
 -- | Create a form, then move to the select role part.
@@ -1063,7 +1113,7 @@ echoNewSimpleContractAndSelectRole
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewSimpleContractAndSelectRole dataDir contract = do
   key <- echoNewSimpleContract' dataDir contract
-  pure $ addHeader @"Location" ("/forms/select-role/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/select-role/" <> key) NoContent
 
 -- | Create a form, then move to the add date part.
 echoNewSimpleContractAndAddDate
@@ -1073,7 +1123,7 @@ echoNewSimpleContractAndAddDate
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewSimpleContractAndAddDate dataDir contract = do
   key <- echoNewSimpleContract' dataDir contract
-  pure $ addHeader @"Location" ("/forms/add-date/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/add-date/" <> key) NoContent
 
 -- | Create a form, then move to the select VAT part.
 echoNewSimpleContractAndSelectVAT
@@ -1083,7 +1133,17 @@ echoNewSimpleContractAndSelectVAT
   -> m (Headers '[Header "Location" Text] NoContent)
 echoNewSimpleContractAndSelectVAT dataDir contract = do
   key <- echoNewSimpleContract' dataDir contract
-  pure $ addHeader @"Location" ("/forms/select-vat/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/select-vat/" <> key) NoContent
+
+-- | Create a form, then move to the add expense part.
+echoNewSimpleContractAndAddExpense
+  :: ServerC m
+  => FilePath
+  -> SimpleContract.CreateContractAll'
+  -> m (Headers '[Header "Location" Text] NoContent)
+echoNewSimpleContractAndAddExpense dataDir contract = do
+  key <- echoNewSimpleContract' dataDir contract
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/add-expense/" <> key) NoContent
 
 -- | Save a form, re-using a key. This is normally used with a \"Location"
 -- header.
@@ -1110,7 +1170,7 @@ echoSaveSimpleContract
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveSimpleContract dataDir key contract = do
   echoSaveSimpleContract' dataDir key contract
-  pure $ addHeader @"Location" ("/forms/confirm-simple-contract/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/confirm-simple-contract/" <> key) NoContent
 
 -- | Save a form, re-using a key, then move to the select role part.
 echoSaveSimpleContractAndSelectRole
@@ -1121,7 +1181,7 @@ echoSaveSimpleContractAndSelectRole
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveSimpleContractAndSelectRole dataDir key contract = do
   echoSaveSimpleContract' dataDir key contract
-  pure $ addHeader @"Location" ("/forms/select-role/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/select-role/" <> key) NoContent
 
 -- | Save a form, re-using a key, then move to the select date part.
 echoSaveSimpleContractAndAddDate
@@ -1132,7 +1192,7 @@ echoSaveSimpleContractAndAddDate
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveSimpleContractAndAddDate dataDir key contract = do
   echoSaveSimpleContract' dataDir key contract
-  pure $ addHeader @"Location" ("/forms/add-date/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/add-date/" <> key) NoContent
 
 -- | Save a form, re-using a key, then move to the select VAT part.
 echoSaveSimpleContractAndSelectVAT
@@ -1143,7 +1203,18 @@ echoSaveSimpleContractAndSelectVAT
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveSimpleContractAndSelectVAT dataDir key contract = do
   echoSaveSimpleContract' dataDir key contract
-  pure $ addHeader @"Location" ("/forms/select-vat/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/select-vat/" <> key) NoContent
+
+-- | Save a form, re-using a key, then move to the add expense part.
+echoSaveSimpleContractAndAddExpense
+  :: ServerC m
+  => FilePath
+  -> Text
+  -> SimpleContract.CreateContractAll'
+  -> m (Headers '[Header "Location" Text] NoContent)
+echoSaveSimpleContractAndAddExpense dataDir key contract = do
+  echoSaveSimpleContract' dataDir key contract
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/add-expense/" <> key) NoContent
 
 echoSelectRole
   :: ServerC m
@@ -1155,7 +1226,7 @@ echoSelectRole dataDir key role = do
   profile <- readJson $ dataDir </> "alice.json"
   db      <- asks Rt._rDb
   liftIO . atomically $ Rt.addRoleToSimpleContractForm db (profile, key, role)
-  pure $ addHeader @"Location" ("/forms/edit-simple-contract/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/" <> key) NoContent
 
 echoAddDate
   :: ServerC m
@@ -1168,7 +1239,7 @@ echoAddDate dataDir key date = do
   db      <- asks Rt._rDb
   liftIO . atomically $ Rt.addDateToSimpleContractForm db (profile, key, date)
   pure $ addHeader @"Location"
-    ("/forms/edit-simple-contract/" <> key <> "#panel-dates")
+    ("/forms/edit/simple-contract/" <> key <> "#panel-dates")
     NoContent
 
 -- | Save a date, re-using a key and an index.
@@ -1186,7 +1257,7 @@ echoSaveDate dataDir key index date = do
     db
     (profile, key, index, date)
   pure $ addHeader @"Location"
-    ("/forms/edit-simple-contract/" <> key <> "#panel-dates")
+    ("/forms/edit/simple-contract/" <> key <> "#panel-dates")
     NoContent
 
 echoRemoveDate
@@ -1202,7 +1273,7 @@ echoRemoveDate dataDir key index = do
     db
     (profile, key, index)
   pure $ addHeader @"Location"
-    ("/forms/edit-simple-contract/" <> key <> "#panel-dates")
+    ("/forms/edit/simple-contract/" <> key <> "#panel-dates")
     NoContent
 
 echoSelectVAT
@@ -1215,7 +1286,55 @@ echoSelectVAT dataDir key rate = do
   profile <- readJson $ dataDir </> "alice.json"
   db      <- asks Rt._rDb
   liftIO . atomically $ Rt.addVATToSimpleContractForm db (profile, key, rate)
-  pure $ addHeader @"Location" ("/forms/edit-simple-contract/" <> key) NoContent
+  pure $ addHeader @"Location" ("/forms/edit/simple-contract/" <> key) NoContent
+
+echoSimpleContractAddExpense
+  :: ServerC m
+  => FilePath
+  -> Text
+  -> SimpleContract.AddExpense
+  -> m (Headers '[Header "Location" Text] NoContent)
+echoSimpleContractAddExpense dataDir key expense = do
+  profile <- readJson $ dataDir </> "alice.json"
+  db      <- asks Rt._rDb
+  liftIO . atomically $ Rt.addExpenseToSimpleContractForm db (profile, key, expense)
+  pure $ addHeader @"Location"
+    ("/forms/edit/simple-contract/" <> key <> "#panel-expenses")
+    NoContent
+
+-- | Save an expense, re-using a key and an index.
+echoSimpleContractSaveExpense
+  :: ServerC m
+  => FilePath
+  -> Text
+  -> Int
+  -> SimpleContract.AddExpense
+  -> m (Headers '[Header "Location" Text] NoContent)
+echoSimpleContractSaveExpense dataDir key index expense = do
+  profile <- readJson $ dataDir </> "alice.json"
+  db      <- asks Rt._rDb
+  todo    <- liftIO . atomically $ Rt.writeExpenseToSimpleContractForm
+    db
+    (profile, key, index, expense)
+  pure $ addHeader @"Location"
+    ("/forms/edit/simple-contract/" <> key <> "#panel-expenses")
+    NoContent
+
+echoSimpleContractRemoveExpense
+  :: ServerC m
+  => FilePath
+  -> Text
+  -> Int
+  -> m (Headers '[Header "Location" Text] NoContent)
+echoSimpleContractRemoveExpense dataDir key index = do
+  profile <- readJson $ dataDir </> "alice.json"
+  db      <- asks Rt._rDb
+  todo    <- liftIO . atomically $ Rt.removeExpenseFromSimpleContractForm
+    db
+    (profile, key, index)
+  pure $ addHeader @"Location"
+    ("/forms/edit/simple-contract/" <> key <> "#panel-expenses")
+    NoContent
 
 
 --------------------------------------------------------------------------------
@@ -1237,8 +1356,12 @@ documentCreateSimpleContractPage dataDir = do
       "/echo/new-simple-contract"
       "/echo/new-simple-contract-and-select-role"
       "/echo/new-simple-contract-and-add-date"
+      "#" -- Should not appear
+      "#" -- Should not appear
       "/echo/new-simple-contract-and-select-vat"
       "/echo/new-simple-contract-and-add-expense"
+      "#" -- Should not appear
+      "#" -- Should not appear
     Nothing -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack role -- TODO Specific error.
 
 documentEditSimpleContractPage
@@ -1262,8 +1385,12 @@ documentEditSimpleContractPage dataDir key = do
           (H.toValue $ "/echo/save-simple-contract/" <> key)
           (H.toValue $ "/echo/save-simple-contract-and-select-role/" <> key)
           (H.toValue $ "/echo/save-simple-contract-and-add-date/" <> key)
+          "/forms/edit/simple-contract/edit-date/"
+          "/forms/edit/simple-contract/remove-date/"
           (H.toValue $ "/echo/save-simple-contract-and-select-vat/" <> key)
           (H.toValue $ "/echo/save-simple-contract-and-add-expense/" <> key)
+          "/forms/edit/simple-contract/edit-expense/"
+          "/forms/edit/simple-contract/remove-expense/"
         Nothing -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack role -- TODO Specific error.
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
@@ -1276,7 +1403,7 @@ documentSelectRolePage dataDir key = do
     db
     (profile, key)
   case output of
-    Right _ -> pure $ Pages.SelectRolePage profile key
+    Right _ -> pure $ Pages.SelectRolePage profile key "/forms/edit/simple-contract/confirm-role/"
     Left  _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
 documentConfirmRolePage
@@ -1360,7 +1487,7 @@ documentSelectVATPage dataDir key = do
     db
     (profile, key)
   case output of
-    Right _ -> pure $ Pages.SelectVATPage profile key
+    Right _ -> pure $ Pages.SelectVATPage profile key "/forms/edit/simple-contract/confirm-vat/"
     Left  _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
 documentConfirmVATPage
@@ -1378,6 +1505,58 @@ documentConfirmVATPage dataDir key rate = do
           key
           rate
           (H.toValue $ "/echo/select-vat/" <> key)
+    Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
+
+documentSimpleContractAddExpensePage
+  :: ServerC m => FilePath -> Text -> m Pages.SimpleContractAddExpensePage
+documentSimpleContractAddExpensePage dataDir key = do
+  profile <- readJson $ dataDir </> "alice.json"
+  db      <- asks Rt._rDb
+  output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
+  case output of
+    Right _ -> pure $ Pages.SimpleContractAddExpensePage
+      profile
+      key
+      Nothing
+      SimpleContract.emptyAddExpense
+      (H.toValue $ "/echo/simple-contract/add-expense/" <> key)
+    Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
+
+-- | Same as documentSimpleContractAddExpensePage, but use an existing form.
+documentSimpleContractEditExpensePage
+  :: ServerC m => FilePath -> Text -> Int -> m Pages.SimpleContractAddExpensePage
+documentSimpleContractEditExpensePage dataDir key index = do
+  profile <- readJson $ dataDir </> "alice.json"
+  db      <- asks Rt._rDb
+  output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
+  case output of
+    Right (SimpleContract.CreateContractAll _ _ _ _ expenses) ->
+      if index > length expenses - 1
+        then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
+        else pure $ Pages.SimpleContractAddExpensePage
+          profile
+          key
+          (Just index)
+          (expenses !! index)
+          (H.toValue $ "/echo/simple-contract/save-expense/" <> key <> "/" <> show index)
+    Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
+
+documentSimpleContractRemoveExpensePage
+  :: ServerC m => FilePath -> Text -> Int -> m Pages.SimpleContractRemoveExpensePage
+documentSimpleContractRemoveExpensePage dataDir key index = do
+  profile <- readJson $ dataDir </> "alice.json"
+  db      <- asks Rt._rDb
+  output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
+  case output of
+    Right (SimpleContract.CreateContractAll _ _ _ _ expenses) ->
+      if index > length expenses - 1
+        then Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
+        else pure $ Pages.SimpleContractRemoveExpensePage
+          profile
+          key
+          index
+          (expenses !! index)
+          (H.toValue $ "/echo/simple-contract/remove-expense/" <> key <> "/" <> show index)
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
 documentConfirmSimpleContractPage

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1577,11 +1577,15 @@ documentConfirmSimpleContractPage dataDir key = do
     Right contractAll -> do
       let role = SimpleContract._createContractRole
             $ SimpleContract._createContractType contractAll
+          errors = case SimpleContract.validateCreateSimpleContract profile contractAll of
+            Left errs -> errs
+            Right _ -> []
       case Pages.lookupRoleLabel role of
         Just roleLabel -> pure $ Pages.ConfirmSimpleContractPage
           profile
           key
           contractAll
+          errors
           roleLabel
           (Just . H.toValue $ "/forms/edit/simple-contract/" <> key)
           "/echo/submit-simple-contract"

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1577,9 +1577,7 @@ documentConfirmSimpleContractPage dataDir key = do
     Right contractAll -> do
       let role = SimpleContract._createContractRole
             $ SimpleContract._createContractType contractAll
-          errors = case SimpleContract.validateCreateSimpleContract profile contractAll of
-            Left errs -> errs
-            Right _ -> []
+          errors = SimpleContract.validateCreateSimpleContract' profile contractAll
       case Pages.lookupRoleLabel role of
         Just roleLabel -> pure $ Pages.ConfirmSimpleContractPage
           profile

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1087,7 +1087,7 @@ echoNewSimpleContract'
   -> SimpleContract.CreateContractAll'
   -> m Text
 echoNewSimpleContract' dataDir contract = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   key     <- liftIO . atomically $ Rt.newCreateSimpleContractForm
     db
@@ -1154,7 +1154,7 @@ echoSaveSimpleContract'
   -> SimpleContract.CreateContractAll'
   -> m ()
 echoSaveSimpleContract' dataDir key contract = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   todo    <- liftIO . atomically $ Rt.writeCreateSimpleContractForm
     db
@@ -1223,7 +1223,7 @@ echoSelectRole
   -> SimpleContract.SelectRole
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSelectRole dataDir key role = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   liftIO . atomically $ Rt.addRoleToSimpleContractForm db (profile, key, role)
   pure $ addHeader @"Location" ("/forms/edit/simple-contract/" <> key) NoContent
@@ -1235,7 +1235,7 @@ echoAddDate
   -> SimpleContract.AddDate
   -> m (Headers '[Header "Location" Text] NoContent)
 echoAddDate dataDir key date = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   liftIO . atomically $ Rt.addDateToSimpleContractForm db (profile, key, date)
   pure $ addHeader @"Location"
@@ -1251,7 +1251,7 @@ echoSaveDate
   -> SimpleContract.AddDate
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSaveDate dataDir key index date = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   todo    <- liftIO . atomically $ Rt.writeDateToSimpleContractForm
     db
@@ -1267,7 +1267,7 @@ echoRemoveDate
   -> Int
   -> m (Headers '[Header "Location" Text] NoContent)
 echoRemoveDate dataDir key index = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   todo    <- liftIO . atomically $ Rt.removeDateFromSimpleContractForm
     db
@@ -1283,7 +1283,7 @@ echoSelectVAT
   -> SimpleContract.SelectVAT
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSelectVAT dataDir key rate = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   liftIO . atomically $ Rt.addVATToSimpleContractForm db (profile, key, rate)
   pure $ addHeader @"Location" ("/forms/edit/simple-contract/" <> key) NoContent
@@ -1295,7 +1295,7 @@ echoSimpleContractAddExpense
   -> SimpleContract.AddExpense
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSimpleContractAddExpense dataDir key expense = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   liftIO . atomically $ Rt.addExpenseToSimpleContractForm db (profile, key, expense)
   pure $ addHeader @"Location"
@@ -1311,7 +1311,7 @@ echoSimpleContractSaveExpense
   -> SimpleContract.AddExpense
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSimpleContractSaveExpense dataDir key index expense = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   todo    <- liftIO . atomically $ Rt.writeExpenseToSimpleContractForm
     db
@@ -1327,7 +1327,7 @@ echoSimpleContractRemoveExpense
   -> Int
   -> m (Headers '[Header "Location" Text] NoContent)
 echoSimpleContractRemoveExpense dataDir key index = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   todo    <- liftIO . atomically $ Rt.removeExpenseFromSimpleContractForm
     db
@@ -1341,7 +1341,7 @@ echoSimpleContractRemoveExpense dataDir key index = do
 documentCreateSimpleContractPage
   :: ServerC m => FilePath -> m Pages.CreateSimpleContractPage
 documentCreateSimpleContractPage dataDir = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   let contractAll = SimpleContract.emptyCreateContractAll
       role        = SimpleContract._createContractRole
         $ SimpleContract._createContractType contractAll
@@ -1367,7 +1367,7 @@ documentCreateSimpleContractPage dataDir = do
 documentEditSimpleContractPage
   :: ServerC m => FilePath -> Text -> m Pages.CreateSimpleContractPage
 documentEditSimpleContractPage dataDir key = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm
     db
@@ -1397,7 +1397,7 @@ documentEditSimpleContractPage dataDir key = do
 documentSelectRolePage
   :: ServerC m => FilePath -> Text -> m Pages.SelectRolePage
 documentSelectRolePage dataDir key = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm
     db
@@ -1409,7 +1409,7 @@ documentSelectRolePage dataDir key = do
 documentConfirmRolePage
   :: ServerC m => FilePath -> Text -> Text -> m Pages.ConfirmRolePage
 documentConfirmRolePage dataDir key role = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm
     db
@@ -1430,7 +1430,7 @@ documentConfirmRolePage dataDir key role = do
 documentAddDatePage
   :: ServerC m => FilePath -> Text -> m Pages.AddDatePage
 documentAddDatePage dataDir key = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
   case output of
@@ -1447,7 +1447,7 @@ documentAddDatePage dataDir key = do
 documentEditDatePage
   :: ServerC m => FilePath -> Text -> Int -> m Pages.AddDatePage
 documentEditDatePage dataDir key index = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
   case output of
@@ -1466,7 +1466,7 @@ documentEditDatePage dataDir key index = do
 documentRemoveDatePage
   :: ServerC m => FilePath -> Text -> Int -> m Pages.RemoveDatePage
 documentRemoveDatePage dataDir key index = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
   case output of
@@ -1484,7 +1484,7 @@ documentRemoveDatePage dataDir key index = do
 documentSelectVATPage
   :: ServerC m => FilePath -> Text -> m Pages.SelectVATPage
 documentSelectVATPage dataDir key = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm
     db
@@ -1496,7 +1496,7 @@ documentSelectVATPage dataDir key = do
 documentConfirmVATPage
   :: ServerC m => FilePath -> Text -> Int -> m Pages.ConfirmVATPage
 documentConfirmVATPage dataDir key rate = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm
     db
@@ -1514,7 +1514,7 @@ documentConfirmVATPage dataDir key rate = do
 documentSimpleContractAddExpensePage
   :: ServerC m => FilePath -> Text -> m Pages.SimpleContractAddExpensePage
 documentSimpleContractAddExpensePage dataDir key = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
   case output of
@@ -1531,7 +1531,7 @@ documentSimpleContractAddExpensePage dataDir key = do
 documentSimpleContractEditExpensePage
   :: ServerC m => FilePath -> Text -> Int -> m Pages.SimpleContractAddExpensePage
 documentSimpleContractEditExpensePage dataDir key index = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
   case output of
@@ -1550,7 +1550,7 @@ documentSimpleContractEditExpensePage dataDir key index = do
 documentSimpleContractRemoveExpensePage
   :: ServerC m => FilePath -> Text -> Int -> m Pages.SimpleContractRemoveExpensePage
 documentSimpleContractRemoveExpensePage dataDir key index = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm db (profile, key)
   case output of
@@ -1568,7 +1568,7 @@ documentSimpleContractRemoveExpensePage dataDir key index = do
 documentConfirmSimpleContractPage
   :: ServerC m => FilePath -> Text -> m Pages.ConfirmSimpleContractPage
 documentConfirmSimpleContractPage dataDir key = do
-  profile <- readJson $ dataDir </> "alice.json"
+  profile <- readJson $ dataDir </> "mila.json"
   db      <- asks Rt._rDb
   output  <- liftIO . atomically $ Rt.readCreateSimpleContractForm
     db


### PR DESCRIPTION
The end goal would be to have a single contract form that accommodates two scenarios: what we call the "simple" or "3in1" form, that generates invoices, work contracts, and expenses from a single form, and the "business unit" or "Activité" where the different documents are created through separate forms. This is started in https://github.com/hypered/curiosity/pull/76

Here we add something similar to the existing "simple" contract: since it exists in the current system, it provides a complete flow upon which we can continue.