### PR TITLE
Show additional data in the documentation

### DIFF
--- a/content/documentation.md
+++ b/content/documentation.md
@@ -19,6 +19,7 @@ title: Curiosity
 - [Scenarios](/documentation/scenarios)
 - [Sitemap](/documentation/sitemap)
 - [Source code](/documentation/source)
+- [state-0](/documentation/state-0)
 - [UBL](/documentation/ubl)
 - [Validation rules](/documentation/validation)
 - [Views](/documentation/views)

--- a/content/documentation.md
+++ b/content/documentation.md
@@ -13,6 +13,7 @@ title: Curiosity
 - [Environments](/documentation/environments)
 - [Forms](/documentation/forms)
 - [Library documentation](/documentation/library)
+- [Live data](/documentation/live-data)
 - [Man pages](/documentation/man-pages)
 - [Messages](/documentation/messages)
 - [Objects](/documentation/objects)

--- a/content/documentation.md
+++ b/content/documentation.md
@@ -17,6 +17,7 @@ title: Curiosity
 - [Man pages](/documentation/man-pages)
 - [Messages](/documentation/messages)
 - [Objects](/documentation/objects)
+- [Permissions](/documentation/permissions)
 - [Scenarios](/documentation/scenarios)
 - [Sitemap](/documentation/sitemap)
 - [Source code](/documentation/source)

--- a/content/documentation/live-data.md
+++ b/content/documentation/live-data.md
@@ -1,0 +1,23 @@
+---
+title: Curiosity
+---
+
+
+# Live data
+
+This page documents live data that are almost part of the system, such as the
+list of legal entities.
+
+## Legal entities
+
+A list of all the legal entities existing currently in the system:
+
+<!--# include virtual="/partials/legal-entities" -->
+
+The list [as JSON](/partials/legal-entities.json).
+
+# See also
+
+- [state-0](/documentation/state-0)
+- [Validation rules](/documentation/validation)
+- [Validation data](/documentation/validation-data)

--- a/content/documentation/permissions.md
+++ b/content/documentation/permissions.md
@@ -1,0 +1,17 @@
+---
+title: Curiosity
+---
+
+
+# Permissions
+
+This page lists the existing permissions.
+
+<!--# include virtual="/partials/permissions" -->
+
+# See also
+
+- [state-0](/documentation/state-0)
+- [Validation rules](/documentation/validation)
+- [Validation data](/documentation/validation-data)
+- [Live data](/documentation/live-data)

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -32,3 +32,19 @@ often dependent on static data: data that are considered part of the system
 definition. Those data can be for instance hard-coded in the source code. The
 data driving the system are visible and explained in the documentation in the
 [validation data page](/documentation/validation-data).
+
+# Live data
+
+In addition to the above static validation data, parts of the system depend on
+live data. For instance, the rights a user has can evolve over time. The static
+validation data are presented in the documentation, and usually the live data
+are visible in the application itself.
+
+Still, some live data can be considered as some kind of system configuration
+and change slowly enough they deserve to be documented too. This is the case
+for instance of the legal entities: in a production system, they would stay
+almost always the same, but in a prototype, it is useful to be able to
+dynamically add, edit, and remove them in specific test scenarios.
+
+This kind of live data have their own [documentation
+page](/documentation/live-data).

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -21,58 +21,6 @@ through the web interface) a specific test scenario can be tedious if the
 system is initially empty. Fortunately, scripts can also be used to generate
 the necessary data and set the system state as desired.
 
-A specific set of example data is available with Curiosity, called `state-0`.
-(We envision that additional set of data could be created in the future.)
-
-Note: if you are operating Curiosity yourself, you can initialize Curiosity's
-state by running `cty run scenarios/state-0.txt`. Here is [an example
-scenario](https://github.com/hypered/curiosity/blob/main/scenarios/0.txt), and
-its [corresponding golden
-file](https://github.com/hypered/curiosity/blob/main/scenarios/0.golden).
-
-# `state-0`
-
-We intend `state-0` to serve as common knowledge among the team working with
-Curiosity. Here, we detail what it is comprised of.
-
-Note: sometimes, we provide links to specific pages of the web application.
-When those pages are displaying the live application state, it is possible that
-the underlying data have changed and are no longer how they were when the
-system was initialized.
-
-## Users
-
-- [Alice](/alice)
-- [Mila](/mila)
-
-## Legal entities
-
-- [One S.A.](/entity/one)
-
-## Business units
-
-- [Alpha](/alpha)
-
-## Forms
-
-Forms data are held separately from the rest of the regular objects in what we
-call the _staging area_. This is a place in memory where form data can be
-edited and eventually submitted. When they are submitted, they are validated
-against various rules. Only if they pass such validation, data are recorded in
-the regular state.
-
-In the staging area, invalid data can reside. The user can amend the data as
-much as they desire. Interestingly, this allows us to have example data in the
-staging area that will fail validation, and this can be used to exemplify
-validation rules.
-
-### Simple contract
-
-- [Amount `-100`](/forms/edit/simple-contract/confirm-simple-contract/TBPJLIUG)
-- [Amount `0`](/forms/edit/simple-contract/confirm-simple-contract/HNONWPTG)
-- [Amount `100`](/forms/edit/simple-contract/confirm-simple-contract/RZEMQMNF)
-
-Note: the validation rules are visible in the [source
-code](/haddock/src/Curiosity.Data.SimpleContract.html#validateCreateSimpleContract).
-We should try to expose them more clearly, both in the documentation, and in
-the code.
+A specific set of example data is available with Curiosity, called
+[`state-0`](/documentation/state-0). (We envision that additional set of data
+could be created in the future.)

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -24,3 +24,11 @@ the necessary data and set the system state as desired.
 A specific set of example data is available with Curiosity, called
 [`state-0`](/documentation/state-0). (We envision that additional set of data
 could be created in the future.)
+
+# Validation data
+
+The behavior of the system (in particular regarding its validation rules) is
+often dependent on static data: data that are considered part of the system
+definition. Those data can be for instance hard-coded in the source code. The
+data driving the system are visible and explained in the documentation in the
+[validation data page](/documentation/validation-data).

--- a/content/documentation/state-0.md
+++ b/content/documentation/state-0.md
@@ -56,3 +56,8 @@ code](/haddock/src/Curiosity.Data.SimpleContract.html#validateCreateSimpleContra
 We should try to expose them more clearly, both in the documentation, and in
 the code.
 
+# See also
+
+- [Validation rules](/documentation/validation)
+- [Validation data](/documentation/validation-data)
+- [Live data](/documentation/live-data)

--- a/content/documentation/state-0.md
+++ b/content/documentation/state-0.md
@@ -1,0 +1,58 @@
+---
+title: Curiosity
+---
+
+# `state-0`
+
+We intend `state-0` to be a set of example data that can serve as common
+knowledge among the team working with Curiosity. Here, we detail what it is
+comprised of.
+
+Note: sometimes, we provide links to specific pages of the web application.
+When those pages are displaying the live application state, it is possible that
+the underlying data have changed and are no longer how they were when the
+system was initialized.
+
+Note: if you are operating Curiosity yourself, you can initialize Curiosity's
+state by running `cty run scenarios/state-0.txt`. Here is [an example
+scenario](https://github.com/hypered/curiosity/blob/main/scenarios/0.txt), and
+its [corresponding golden
+file](https://github.com/hypered/curiosity/blob/main/scenarios/0.golden).
+
+## Users
+
+- [Alice](/alice)
+- [Mila](/mila)
+
+## Legal entities
+
+- [One S.A.](/entity/one)
+
+## Business units
+
+- [Alpha](/alpha)
+
+## Forms
+
+Forms data are held separately from the rest of the regular objects in what we
+call the _staging area_. This is a place in memory where form data can be
+edited and eventually submitted. When they are submitted, they are validated
+against various rules. Only if they pass such validation, data are recorded in
+the regular state.
+
+In the staging area, invalid data can reside. The user can amend the data as
+much as they desire. Interestingly, this allows us to have example data in the
+staging area that will fail validation, and this can be used to exemplify
+validation rules.
+
+### Simple contract
+
+- [Amount `-100`](/forms/edit/simple-contract/confirm-simple-contract/TBPJLIUG)
+- [Amount `0`](/forms/edit/simple-contract/confirm-simple-contract/HNONWPTG)
+- [Amount `100`](/forms/edit/simple-contract/confirm-simple-contract/RZEMQMNF)
+
+Note: the validation rules are visible in the [source
+code](/haddock/src/Curiosity.Data.SimpleContract.html#validateCreateSimpleContract).
+We should try to expose them more clearly, both in the documentation, and in
+the code.
+

--- a/content/documentation/state.md
+++ b/content/documentation/state.md
@@ -55,5 +55,5 @@ state file is `cty init`.
 
 The virtual machine shipped with the prototype (and featured at
 [`smartcoop.sh`](https://smartcoop.sh)) is configured to start with an initial
-state, called `state-0`. You can read more about it in the section about [test
-scenarios](/documentation/scenarios).
+state, called [`state-0`](/documentation/state-0). This is the same state used
+in automated [test scenarios](/documentation/scenarios).

--- a/content/documentation/validation-data.md
+++ b/content/documentation/validation-data.md
@@ -1,0 +1,39 @@
+---
+title: Curiosity
+---
+
+
+# Validation data
+
+Validation data are driving the system behavior, similarly to its source code
+(validation data can actually be hard-coded within the source code, but not
+necessarily). They are considered part of the system (i.e. a change in the
+source code or the validation data would both result in a new system version
+number).
+
+## Users
+
+A list of usernames that cannot be used:
+
+<!--# include virtual="/partials/username-blocklist" -->
+
+The list [as JSON](/partials/username-blocklist.json).
+
+## Simple contracts
+
+Roles
+
+:   Roles mentioned in contracts come from a closed list:
+
+    <!--# include virtual="/partials/roles" -->
+
+    The list [as JSON](/partials/roles.json).
+
+Countries
+
+:   Countries mentioned in contracts come from a closed list:
+
+    <!--# include virtual="/partials/countries" -->
+
+    The list [as JSON](/partials/countries.json).
+

--- a/content/documentation/validation-data.md
+++ b/content/documentation/validation-data.md
@@ -38,6 +38,14 @@ Countries
 
     The list [as JSON](/partials/countries.json).
 
+VAT rates
+
+:   VAT rates that can be selected in contracts come from a closed list:
+
+    <!--# include virtual="/partials/vat-rates" -->
+
+    The list [as JSON](/partials/vat-rates.json).
+
 # See also
 
 - [state-0](/documentation/state-0)

--- a/content/documentation/validation-data.md
+++ b/content/documentation/validation-data.md
@@ -37,3 +37,8 @@ Countries
 
     The list [as JSON](/partials/countries.json).
 
+# See also
+
+- [state-0](/documentation/state-0)
+- [Validation rules](/documentation/validation)
+- [Live data](/documentation/live-data)

--- a/content/documentation/validation-data.md
+++ b/content/documentation/validation-data.md
@@ -9,7 +9,8 @@ Validation data are driving the system behavior, similarly to its source code
 (validation data can actually be hard-coded within the source code, but not
 necessarily). They are considered part of the system (i.e. a change in the
 source code or the validation data would both result in a new system version
-number).
+number). [Permissions](/documentation/permissions) are presented on their own
+page.
 
 ## Users
 
@@ -42,3 +43,4 @@ Countries
 - [state-0](/documentation/state-0)
 - [Validation rules](/documentation/validation)
 - [Live data](/documentation/live-data)
+- [Permissions](/documentation/permissions)

--- a/content/documentation/validation.md
+++ b/content/documentation/validation.md
@@ -7,11 +7,8 @@ title: Curiosity
 
 ## Users
 
-Usernames from the following list cannot be used:
-
-<!--# include virtual="/partials/username-blocklist" -->
-
-The list [as JSON](/partials/username-blocklist.json).
+Some usernames cannot be used. A list of blocked usernames is [available
+here](/documentation/validation-data#users)
 
 ## Simple contracts
 
@@ -20,18 +17,5 @@ Example data
 :   See [state-0](/documentation/state-0#simple-contract) for example data,
     displayed with validation errors.
 
-Roles
-
-:   Roles mentioned in contracts come from a closed list:
-
-    <!--# include virtual="/partials/roles" -->
-
-    The list [as JSON](/partials/roles.json).
-
-Countries
-
-:   Countries mentioned in contracts come from a closed list:
-
-    <!--# include virtual="/partials/countries" -->
-
-    The list [as JSON](/partials/countries.json).
+Some validation data are used to describe and validate contracts. See
+[validation data]( (/documentation/validation-data#simple-contracts).

--- a/content/documentation/validation.md
+++ b/content/documentation/validation.md
@@ -15,17 +15,23 @@ The list [as JSON](/partials/username-blocklist.json).
 
 ## Simple contracts
 
-See [state-0](/documentation/scenarios#simple-contract) for example data,
-displayed with validation errors.
+Example data
 
-Roles mentioned in contracts come from a closed list:
+:   See [state-0](/documentation/state-0#simple-contract) for example data,
+    displayed with validation errors.
 
-<!--# include virtual="/partials/roles" -->
+Roles
 
-The list [as JSON](/partials/roles.json).
+:   Roles mentioned in contracts come from a closed list:
 
-Countries mentioned in contracts come from a closed list:
+    <!--# include virtual="/partials/roles" -->
 
-<!--# include virtual="/partials/countries" -->
+    The list [as JSON](/partials/roles.json).
 
-The list [as JSON](/partials/countries.json).
+Countries
+
+:   Countries mentioned in contracts come from a closed list:
+
+    <!--# include virtual="/partials/countries" -->
+
+    The list [as JSON](/partials/countries.json).

--- a/content/documentation/validation.md
+++ b/content/documentation/validation.md
@@ -19,3 +19,9 @@ Example data
 
 Some validation data are used to describe and validate contracts. See
 [validation data]( (/documentation/validation-data#simple-contracts).
+
+# See also
+
+- [state-0](/documentation/state-0)
+- [Validation data](/documentation/validation-data)
+- [Live data](/documentation/live-data)

--- a/src/Curiosity/Data/SimpleContract.hs
+++ b/src/Curiosity/Data/SimpleContract.hs
@@ -50,6 +50,10 @@ module Curiosity.Data.SimpleContract
   , Role(..)
   , roles
   , lookupRoleLabel
+    -- * VAT rates
+    --
+    -- $vatRates
+  , vatRates
   ) where
 
 import qualified Commence.Types.Wrapped        as W
@@ -388,3 +392,16 @@ roles' = concatMap go0 roles
     (value, unwords [title0, ">", title1, ">", label])
 
 lookupRoleLabel role = lookup role roles'
+
+--------------------------------------------------------------------------------
+-- $vatRates
+--
+-- List of possible VAT rates with their reason.
+
+-- | List of possible VAT rates with their reason.
+vatRates :: [(Text, Text)]
+vatRates =
+  [ ("0", "0% For some reason")
+  , ("6", "6% For some reason")
+  , ("21", "21% For some reason")
+  ]

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -18,6 +18,7 @@ module Curiosity.Data.User
   , UserCompletion1(..)
   , UserCompletion2(..)
   , AccessRight(..)
+  , permissions
   , userProfileCreds
   , userProfileId
   , userProfileDisplayName
@@ -166,8 +167,11 @@ data UserCompletion2 = UserCompletion2
 
 -- Enable/disable some accesses.
 data AccessRight = CanCreateContracts | CanVerifyEmailAddr
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Enum, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
+
+permissions :: [AccessRight]
+permissions = [toEnum 0..]
 
 -- | The username is an identifier (i.e. it is unique).
 newtype UserName = UserName { unUserName :: Text }

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -469,9 +469,7 @@ instance H.ToMarkup SelectVATPage where
   toMarkup (SelectVATPage profile key confirmVatBaseUrl) = renderFormLarge profile $ do
     title' "Select VAT" Nothing
 
-    displayRate confirmVatBaseUrl key ("0", "0% For some reason")
-    displayRate confirmVatBaseUrl key ("6", "6% For some reason")
-    displayRate confirmVatBaseUrl key ("21", "21% For some reason")
+    H.ul $ mapM_ (displayRate confirmVatBaseUrl key) SimpleContract.vatRates
 
 displayRate confirmVatBaseUrl key (value, label) =
   H.li

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -31,6 +31,7 @@ module Curiosity.Runtime
   , checkCredentials
   -- * High-level entity operations
   , selectEntityBySlug
+  , readLegalEntities
   -- * High-level unit operations
   , selectUnitBySlug
   -- * Form edition
@@ -1216,6 +1217,13 @@ selectEntityBySlug db name = do
   let tvar = Data._dbLegalEntities db
   records <- STM.readTVar tvar
   pure $ find ((== name) . Legal._entitySlug) records
+
+readLegalEntities
+  :: forall runtime . Data.StmDb runtime -> STM [Legal.Entity]
+readLegalEntities db = do
+  let tvar = Data._dbLegalEntities db
+  records <- STM.readTVar tvar
+  pure records
 
 selectUnitBySlug
   :: forall runtime . Data.StmDb runtime -> Text -> STM (Maybe Business.Entity)

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -78,7 +78,9 @@ import qualified Servant.Server                as Server
 import           Smart.Server.Page              ( PageEither )
 import qualified Smart.Server.Page             as SS.P
 import           System.FilePath                ( (</>) )
+import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5              as H
+import qualified Text.Blaze.Html5.Attributes   as A
 import qualified Text.Blaze.Renderer.Text      as R
                                                 ( renderMarkup )
 import           Text.Blaze.Renderer.Utf8       ( renderMarkup )
@@ -356,6 +358,7 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                                               NoContent
                                             )
 
+             -- static data
              :<|> "partials" :> "username-blocklist" :> Get '[B.HTML] H.Html
              :<|> "partials" :> "username-blocklist.json" :> Get '[JSON] [User.UserName]
 
@@ -364,6 +367,10 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
 
              :<|> "partials" :> "countries" :> Get '[B.HTML] H.Html
              :<|> "partials" :> "countries.json" :> Get '[JSON] [(Text, Text)]
+
+             -- live data
+             :<|> "partials" :> "legal-entities" :> Get '[B.HTML] H.Html
+             :<|> "partials" :> "legal-entities.json" :> Get '[JSON] [Legal.Entity]
 
              :<|> "login" :> Get '[B.HTML] Login.Page
              :<|> "signup" :> Get '[B.HTML] Signup.Page
@@ -472,12 +479,17 @@ serverT natTrans ctx conf jwtS root dataDir =
     :<|> echoSimpleContractSaveExpense dataDir
     :<|> echoSimpleContractRemoveExpense dataDir
 
+    -- static data
     :<|> partialUsernameBlocklist
     :<|> partialUsernameBlocklistAsJson
     :<|> partialRoles
     :<|> partialRolesAsJson
     :<|> partialCountries
     :<|> partialCountriesAsJson
+
+    -- live data
+    :<|> partialLegalEntities
+    :<|> partialLegalEntitiesAsJson
 
     :<|> showLoginPage
     :<|> showSignupPage
@@ -664,6 +676,25 @@ partialCountries =
 
 partialCountriesAsJson :: ServerC m => m [(Text, Text)]
 partialCountriesAsJson = pure Country.countries
+
+
+--------------------------------------------------------------------------------
+partialLegalEntities :: ServerC m => m H.Html
+partialLegalEntities = do
+  db       <- asks Rt._rDb
+  entities <- liftIO . atomically $ Rt.readLegalEntities db
+  pure . H.ul $ mapM_ displayEntity entities
+ where
+  displayEntity Legal.Entity {..} =
+    H.li $ do
+      H.a ! A.href (H.toValue $ "/entity/" <> _entitySlug) $
+        H.text (Legal.unRegistrationName _entityName)
+
+partialLegalEntitiesAsJson :: ServerC m => m [Legal.Entity]
+partialLegalEntitiesAsJson = do
+  db       <- asks Rt._rDb
+  entities <- liftIO . atomically $ Rt.readLegalEntities db
+  pure entities
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -368,6 +368,9 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
              :<|> "partials" :> "countries" :> Get '[B.HTML] H.Html
              :<|> "partials" :> "countries.json" :> Get '[JSON] [(Text, Text)]
 
+             :<|> "partials" :> "permissions" :> Get '[B.HTML] H.Html
+             :<|> "partials" :> "permissions.json" :> Get '[JSON] [User.AccessRight]
+
              -- live data
              :<|> "partials" :> "legal-entities" :> Get '[B.HTML] H.Html
              :<|> "partials" :> "legal-entities.json" :> Get '[JSON] [Legal.Entity]
@@ -486,6 +489,8 @@ serverT natTrans ctx conf jwtS root dataDir =
     :<|> partialRolesAsJson
     :<|> partialCountries
     :<|> partialCountriesAsJson
+    :<|> partialPermissions
+    :<|> partialPermissionsAsJson
 
     -- live data
     :<|> partialLegalEntities
@@ -676,6 +681,18 @@ partialCountries =
 
 partialCountriesAsJson :: ServerC m => m [(Text, Text)]
 partialCountriesAsJson = pure Country.countries
+
+
+--------------------------------------------------------------------------------
+partialPermissions :: ServerC m => m H.Html
+partialPermissions =
+  pure . H.ul $ mapM_ displayPermission User.permissions
+ where
+  displayPermission p =
+    H.li $ H.code . H.text $ show p
+
+partialPermissionsAsJson :: ServerC m => m [User.AccessRight]
+partialPermissionsAsJson = pure User.permissions
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -368,6 +368,9 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
              :<|> "partials" :> "countries" :> Get '[B.HTML] H.Html
              :<|> "partials" :> "countries.json" :> Get '[JSON] [(Text, Text)]
 
+             :<|> "partials" :> "vat-rates" :> Get '[B.HTML] H.Html
+             :<|> "partials" :> "vat-rates.json" :> Get '[JSON] [(Text, Text)]
+
              :<|> "partials" :> "permissions" :> Get '[B.HTML] H.Html
              :<|> "partials" :> "permissions.json" :> Get '[JSON] [User.AccessRight]
 
@@ -489,6 +492,8 @@ serverT natTrans ctx conf jwtS root dataDir =
     :<|> partialRolesAsJson
     :<|> partialCountries
     :<|> partialCountriesAsJson
+    :<|> partialVatRates
+    :<|> partialVatRatesAsJson
     :<|> partialPermissions
     :<|> partialPermissionsAsJson
 
@@ -681,6 +686,20 @@ partialCountries =
 
 partialCountriesAsJson :: ServerC m => m [(Text, Text)]
 partialCountriesAsJson = pure Country.countries
+
+
+--------------------------------------------------------------------------------
+partialVatRates :: ServerC m => m H.Html
+partialVatRates =
+  pure . H.ul $ mapM_ displayVatRate SimpleContract.vatRates
+ where
+  displayVatRate (value, label) =
+    H.li $ do
+      H.text label
+      H.code $ H.text value
+
+partialVatRatesAsJson :: ServerC m => m [(Text, Text)]
+partialVatRatesAsJson = pure SimpleContract.vatRates
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
- Static data: we display roles, countries, and VAT rates (the username blocklist was already present)
- Static data: we display permissions on their own page
- Live data: we display the legal entities in the documentation since those are slowly changing data