### PR TITLE
Implement the basis of a quotation scenario

### DIFF
--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -98,6 +98,7 @@ library
     Curiosity.Data.Employment
     Curiosity.Data.Invoice
     Curiosity.Data.Legal
+    Curiosity.Data.Order
     Curiosity.Data.Quotation
     Curiosity.Data.SimpleContract
     Curiosity.Data.User

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -101,6 +101,7 @@ library
     Curiosity.Data.Legal
     Curiosity.Data.Order
     Curiosity.Data.Quotation
+    Curiosity.Data.RemittanceAdv
     Curiosity.Data.SimpleContract
     Curiosity.Data.User
     Curiosity.Dsl

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -113,9 +113,9 @@ library
     Curiosity.Html.Legal
     Curiosity.Html.Misc
     Curiosity.Html.Navbar
-    Curiosity.Html.Profile
     Curiosity.Html.Run
     Curiosity.Html.SimpleContract
+    Curiosity.Html.User
     Curiosity.Interpret
     Curiosity.Parse
     Curiosity.Process

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -98,6 +98,7 @@ library
     Curiosity.Data.Employment
     Curiosity.Data.Invoice
     Curiosity.Data.Legal
+    Curiosity.Data.Quotation
     Curiosity.Data.SimpleContract
     Curiosity.Data.User
     Curiosity.Dsl

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -95,6 +95,7 @@ library
     Curiosity.Data.Command
     Curiosity.Data.Counter
     Curiosity.Data.Country
+    Curiosity.Data.Email
     Curiosity.Data.Employment
     Curiosity.Data.Invoice
     Curiosity.Data.Legal

--- a/data/one.json
+++ b/data/one.json
@@ -3,5 +3,6 @@
   "_entitySlug": "one",
   "_entityName": "One S.A.",
   "_entityCbeNumber": "100200300",
-  "_entityVatNumber": "BE0100200300"
+  "_entityVatNumber": "BE0100200300",
+  "_entityUsersAndRoles": []
 }

--- a/scenarios/1.golden
+++ b/scenarios/1.golden
@@ -1,7 +1,7 @@
 4: reset
 Resetting to the empty state.
 5: as alice
-Modifiying default user.
+Modifying default user.
 6: user create alice secret alice@example.com --accept-tos
 User created: USER-1
 7: user create bob secret bob@example.com --accept-tos
@@ -13,7 +13,7 @@ EmailAddrAlreadyVerified
 11: reset
 Resetting to the empty state.
 12: as bob
-Modifiying default user.
+Modifying default user.
 13: user create alice secret alice@example.com --accept-tos
 User created: USER-1
 14: user create bob secret bob@example.com --accept-tos

--- a/scenarios/init-form-simple-contracts.golden
+++ b/scenarios/init-form-simple-contracts.golden
@@ -1,5 +1,5 @@
 1: as mila
-Modifiying default user.
+Modifying default user.
 2: forms simple-contract new --amount -100
 UserNotFound "mila"
 3: forms simple-contract new

--- a/scenarios/init-users.golden
+++ b/scenarios/init-users.golden
@@ -1,7 +1,7 @@
 2: user create alice a alice@example.com --accept-tos
 User created: USER-1
 3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
-Right (Right (Right [UserId {unUserId = "USER-1"}]))
+User updated: USER-1
 5: user create bob b bob@example.com --accept-tos
 User created: USER-2
 6: user create charlie c charlie@example.com --accept-tos
@@ -9,4 +9,4 @@ User created: USER-3
 8: user create mila m mila@example.com --accept-tos
 User created: USER-4
 9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
-Right (Right (Right [UserId {unUserId = "USER-4"}]))
+User updated: USER-4

--- a/scenarios/quotation-flow.golden
+++ b/scenarios/quotation-flow.golden
@@ -11,7 +11,7 @@ User created: USER-3
 8: user update USER-3 Charlie I'm Charlie, a Client in the quotation-flow scenario.
 User updated: USER-3
 10: as susie
-Modifiying default user.
+Modifying default user.
 11: forms quotation new
 Quotation form created: TBPJLIUG
 13: forms quotation submit TBPJLIUG
@@ -19,11 +19,11 @@ Quotation form validated.
 Quotation created: QUOT-1
 Quotation sent to client: QUOT-1
 15: as charlie
-Modifiying default user.
+Modifying default user.
 16: quotation sign QUOT-1
 Order created: ORD-1
 18: as susie
-Modifiying default user.
+Modifying default user.
 19: invoice emit --from ORD-1
 Invoice created: INV-1
 Internal (proxy) invoice created: INV-2
@@ -32,7 +32,7 @@ Remittance advice (using proxy bank account) created: REM-1
 Remittance advice (using business unit bank account) created: REM-2
 Invoice sent to client: INV-1
 21: as system
-Modifiying default user.
+Modifying default user.
 22: reminder send INV-1
 Reminder for invoice sent: INV-1
 23: payment match INV-1

--- a/scenarios/quotation-flow.golden
+++ b/scenarios/quotation-flow.golden
@@ -1,0 +1,41 @@
+1: reset
+Resetting to the empty state.
+2: user create alice a alice@example.com --accept-tos
+User created: USER-1
+4: user create susie s susie@example.com --accept-tos
+User created: USER-2
+5: user update USER-2 Susie I'm Susie, the Seller in the quotation-flow scenario.
+User updated: USER-2
+7: user create charlie c charlie@example.com --accept-tos
+User created: USER-3
+8: user update USER-3 Charlie I'm Charlie, a Client in the quotation-flow scenario.
+User updated: USER-3
+10: as susie
+Modifiying default user.
+11: forms quotation new
+Quotation form created: TBPJLIUG
+13: forms quotation submit TBPJLIUG
+Quotation form validated.
+Quotation created: QUOT-1
+Quotation sent to client: QUOT-1
+15: as charlie
+Modifiying default user.
+16: quotation sign QUOT-1
+Order created: ORD-1
+18: as susie
+Modifiying default user.
+19: invoice emit --from ORD-1
+Invoice created: INV-1
+Internal (proxy) invoice created: INV-2
+Generating payment for INV-2...
+Remittance advice (using proxy bank account) created: REM-1
+Remittance advice (using business unit bank account) created: REM-2
+Invoice sent to client: INV-1
+21: as system
+Modifiying default user.
+22: reminder send INV-1
+Reminder for invoice sent: INV-1
+23: payment match INV-1
+Generating payment for INV-1...
+Remittance advice (using client bank account) created: REM-3
+Remittance advice (using business unit bank account) created: REM-4

--- a/scenarios/quotation-flow.txt
+++ b/scenarios/quotation-flow.txt
@@ -1,0 +1,23 @@
+reset
+user create alice a alice@example.com --accept-tos
+
+user create susie s susie@example.com --accept-tos
+user update USER-2 Susie "I'm Susie, the Seller in the quotation-flow scenario."
+
+user create charlie c charlie@example.com --accept-tos
+user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
+
+as susie
+forms quotation new
+# forms quotation edit
+forms quotation submit TBPJLIUG
+
+as charlie
+quotation sign QUOT-1
+
+as susie
+invoice emit --from ORD-1
+
+as system
+reminder send INV-1
+payment match INV-1

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -4,7 +4,7 @@ Resetting to the empty state.
 2: user create alice a alice@example.com --accept-tos
 User created: USER-1
 3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
-Right (Right (Right [UserId {unUserId = "USER-1"}]))
+User updated: USER-1
 5: user create bob b bob@example.com --accept-tos
 User created: USER-2
 6: user create charlie c charlie@example.com --accept-tos
@@ -12,7 +12,7 @@ User created: USER-3
 8: user create mila m mila@example.com --accept-tos
 User created: USER-4
 9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
-Right (Right (Right [UserId {unUserId = "USER-4"}]))
+User updated: USER-4
 3: run init-entities.txt
 1: legal create one One S.A. 100200300 BE0100200300
 Legal entity created: LENT-1

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -25,7 +25,7 @@ Business entity created: BENT-1
 Business unit updated: alpha
 5: run init-form-simple-contracts.txt
 1: as mila
-Modifiying default user.
+Modifying default user.
 2: forms simple-contract new --amount -100
 Simple contract form created: TBPJLIUG
 3: forms simple-contract new

--- a/scripts/ghci-dsl.conf
+++ b/scripts/ghci-dsl.conf
@@ -1,4 +1,4 @@
 :load ../smart-design-hs/lib/src/Prelude.hs
-import Prelude hding ( state )
+import Prelude hiding ( state )
 :set -XImplicitPrelude
 :load src/Curiosity/Dsl.hs

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -66,7 +66,7 @@ data Command =
     -- ^ Notify the system that a payment matching an invoice was done.
   | SendReminder Text
     -- ^ Send an email to remind of an unpaid invoice.
-  | FormNewQuotation
+  | FormNewQuotation Quotation.CreateQuotationAll
     -- ^ Create a new instance of the quotation creation form.
   | FormValidateQuotation Text
     -- ^ Run validation rules only (the same ones used in `FormSubmitQuotation`).
@@ -642,7 +642,7 @@ parserFormQuotation =
          )
 
 parserFormNewQuotation :: A.Parser Command
-parserFormNewQuotation = pure $ FormNewQuotation
+parserFormNewQuotation = pure $ FormNewQuotation Quotation.emptyCreateQuotationAll
 
 parserFormValidateQuotation :: A.Parser Command
 parserFormValidateQuotation = do

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -17,6 +17,7 @@ import qualified Commence.Runtime.Storage      as S
 import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Employment     as Employment
 import qualified Curiosity.Data.Legal          as Legal
+import qualified Curiosity.Data.Invoice        as Invoice
 import qualified Curiosity.Data.Order          as Order
 import qualified Curiosity.Data.Quotation      as Quotation
 import qualified Curiosity.Data.SimpleContract as SimpleContract
@@ -65,7 +66,7 @@ data Command =
     -- ^ Generate and invoice and send an email with it (or a link to it).
   | MatchPayment Text
     -- ^ Notify the system that a payment matching an invoice was done.
-  | SendReminder Text
+  | SendReminder Invoice.InvoiceId
     -- ^ Send an email to remind of an unpaid invoice.
   | FormNewQuotation Quotation.CreateQuotationAll
     -- ^ Create a new instance of the quotation creation form.

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -64,7 +64,7 @@ data Command =
   | CreateInvoice
   | EmitInvoice Order.OrderId
     -- ^ Generate and invoice and send an email with it (or a link to it).
-  | MatchPayment Text
+  | MatchPayment Invoice.InvoiceId
     -- ^ Notify the system that a payment matching an invoice was done.
   | SendReminder Invoice.InvoiceId
     -- ^ Send an email to remind of an unpaid invoice.

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -17,6 +17,7 @@ import qualified Commence.Runtime.Storage      as S
 import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Employment     as Employment
 import qualified Curiosity.Data.Legal          as Legal
+import qualified Curiosity.Data.Order          as Order
 import qualified Curiosity.Data.Quotation      as Quotation
 import qualified Curiosity.Data.SimpleContract as SimpleContract
 import qualified Curiosity.Data.User           as User
@@ -60,7 +61,7 @@ data Command =
   | SignQuotation Quotation.QuotationId
   | CreateEmployment Employment.CreateContractAll
   | CreateInvoice
-  | EmitInvoice Text
+  | EmitInvoice Order.OrderId
     -- ^ Generate and invoice and send an email with it (or a link to it).
   | MatchPayment Text
     -- ^ Notify the system that a payment matching an invoice was done.
@@ -602,7 +603,7 @@ parserEmitInvoice :: A.Parser Command
 parserEmitInvoice = do
   id <- A.strOption $ A.long "from" <> A.metavar "ORDER-ID" <> A.help
     "An order identifier."
-  pure $ EmitInvoice id
+  pure $ EmitInvoice $ Order.OrderId id
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -70,10 +70,10 @@ data Command =
     -- ^ Create a new instance of the quotation creation form.
   | FormValidateQuotation Text
     -- ^ Run validation rules only (the same ones used in `FormSubmitQuotation`).
-  | FormSubmitQuotation Text
+  | FormSubmitQuotation Quotation.SubmitQuotation
     -- ^ Submit a quotation.
   | FormNewSimpleContract SimpleContract.CreateContractAll'
-  | FormValidateSimpleContract Text -- TODO Use SubmitContract.
+  | FormValidateSimpleContract Text
   | ViewQueue QueueName
     -- ^ View queue. The queues can be filters applied to objects, not
     -- necessarily explicit list in database.
@@ -654,7 +654,7 @@ parserFormSubmitQuotation :: A.Parser Command
 parserFormSubmitQuotation = do
   key <- A.argument A.str
                     (A.metavar "KEY" <> A.help "A quotation form identifier.")
-  pure $ FormSubmitQuotation key
+  pure $ FormSubmitQuotation $ Quotation.SubmitQuotation key
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -364,7 +364,7 @@ parserUpdateBusinessEntity = do
   description <- A.argument A.str (A.metavar "TEXT" <> A.help "A description")
   pure $ UpdateBusinessEntity $ Business.Update slug (Just description)
 
-argumentUnitId = Legal.LegalId <$> A.argument A.str metavarUnitId
+argumentUnitId = Legal.EntityId <$> A.argument A.str metavarUnitId
 
 metavarUnitId = A.metavar "BENT-ID" <> A.completer complete <> A.help
   "A business unit ID"
@@ -416,7 +416,7 @@ parserUpdateLegalEntity = do
   description <- A.argument A.str (A.metavar "TEXT" <> A.help "A description")
   pure $ UpdateLegalEntity $ Legal.Update slug (Just description)
 
-argumentEntityId = Legal.LegalId <$> A.argument A.str metavarEntityId
+argumentEntityId = Legal.EntityId <$> A.argument A.str metavarEntityId
 
 metavarEntityId = A.metavar "LENT-ID" <> A.completer complete <> A.help
   "A legal entity ID"

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -17,6 +17,7 @@ import qualified Commence.Runtime.Storage      as S
 import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Employment     as Employment
 import qualified Curiosity.Data.Legal          as Legal
+import qualified Curiosity.Data.Quotation      as Quotation
 import qualified Curiosity.Data.SimpleContract as SimpleContract
 import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Parse               as P
@@ -56,6 +57,7 @@ data Command =
   | UpdateUser (S.DBUpdate User.UserProfile)
   | SetUserEmailAddrAsVerified User.UserName
     -- ^ High-level operations on users.
+  | SignQuotation Quotation.QuotationId
   | CreateEmployment Employment.CreateContractAll
   | CreateInvoice
   | EmitInvoice Text
@@ -254,6 +256,12 @@ parser =
            "employment"
            ( A.info (parserEmployment <**> A.helper)
            $ A.progDesc "Commands related to employment contracts"
+           )
+
+      <> A.command
+           "quotation"
+           ( A.info (parserQuotation <**> A.helper)
+           $ A.progDesc "Commands related to quotations"
            )
 
       <> A.command
@@ -557,6 +565,21 @@ parserEmployment = A.subparser $ A.command
 parserCreateEmployment :: A.Parser Command
 parserCreateEmployment =
   pure $ CreateEmployment Employment.emptyCreateContractAll
+
+parserQuotation :: A.Parser Command
+parserQuotation =
+  A.subparser
+    $  A.command
+         "sign"
+         ( A.info (parserSignQuotation <**> A.helper)
+         $ A.progDesc "Accept (sign) a quotation"
+         )
+
+parserSignQuotation :: A.Parser Command
+parserSignQuotation = do
+  id <- A.argument A.str
+                   (A.metavar "QUOTATION-ID" <> A.help "A quotation identifier.")
+  pure $ SignQuotation id
 
 parserInvoice :: A.Parser Command
 parserInvoice =

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -60,7 +60,7 @@ a container type of the database.
 -}
 data Db (datastore :: Type -> Type) (runtime :: Type) = Db
   { _dbNextBusinessId   :: C.CounterValue datastore Int
-  , _dbBusinessEntities :: datastore [Business.Unit]
+  , _dbBusinessUnits    :: datastore [Business.Unit]
   , _dbNextLegalId      :: C.CounterValue datastore Int
   , _dbLegalEntities    :: datastore [Legal.Entity]
   , _dbNextUserId       :: C.CounterValue datastore Int
@@ -108,7 +108,7 @@ instantiateStmDb
   :: forall runtime m . MonadIO m => HaskDb runtime -> m (StmDb runtime)
 instantiateStmDb Db
   { _dbNextBusinessId   = C.CounterValue (Identity seedNextBusinessId)
-  , _dbBusinessEntities = Identity seedBusinessEntities
+  , _dbBusinessUnits    = Identity seedBusinessUnits
   , _dbNextLegalId      = C.CounterValue (Identity seedNextLegalId)
   , _dbLegalEntities    = Identity seedLegalEntities
   , _dbNextUserId       = C.CounterValue (Identity seedNextUserId)
@@ -127,7 +127,7 @@ instantiateStmDb Db
   -- instantiation under a single STM transaction (@atomically@).
     liftIO . STM.atomically $ do
     _dbNextBusinessId   <- C.newCounter seedNextBusinessId
-    _dbBusinessEntities <- STM.newTVar seedBusinessEntities
+    _dbBusinessUnits    <- STM.newTVar seedBusinessUnits
     _dbNextLegalId      <- C.newCounter seedNextLegalId
     _dbLegalEntities    <- STM.newTVar seedLegalEntities
     _dbNextUserId       <- C.newCounter seedNextUserId
@@ -153,7 +153,7 @@ resetStmDb = liftIO . STM.atomically . resetStmDb'
 
 resetStmDb' stmDb = do
   C.writeCounter (_dbNextBusinessId stmDb) seedNextBusinessId
-  STM.writeTVar (_dbBusinessEntities stmDb) seedBusinessEntities
+  STM.writeTVar (_dbBusinessUnits stmDb) seedBusinessUnits
   C.writeCounter (_dbNextLegalId stmDb) seedNextLegalId
   STM.writeTVar (_dbLegalEntities stmDb) seedLegalEntities
   C.writeCounter (_dbNextUserId stmDb) seedNextUserId
@@ -168,7 +168,7 @@ resetStmDb' stmDb = do
  where
   Db
     { _dbNextBusinessId   = C.CounterValue (Identity seedNextBusinessId)
-    , _dbBusinessEntities = Identity seedBusinessEntities
+    , _dbBusinessUnits    = Identity seedBusinessUnits
     , _dbNextLegalId      = C.CounterValue (Identity seedNextLegalId)
     , _dbLegalEntities    = Identity seedLegalEntities
     , _dbNextUserId       = C.CounterValue (Identity seedNextUserId)
@@ -198,7 +198,7 @@ readFullStmDbInHask = liftIO . STM.atomically . readFullStmDbInHask'
 
 readFullStmDbInHask' stmDb = do
   _dbNextBusinessId   <- pure <$> C.readCounter (_dbNextBusinessId stmDb)
-  _dbBusinessEntities <- pure <$> STM.readTVar (_dbBusinessEntities stmDb)
+  _dbBusinessUnits    <- pure <$> STM.readTVar (_dbBusinessUnits stmDb)
   _dbNextLegalId      <- pure <$> C.readCounter (_dbNextLegalId stmDb)
   _dbLegalEntities    <- pure <$> STM.readTVar (_dbLegalEntities stmDb)
   _dbNextUserId       <- pure <$> C.readCounter (_dbNextUserId stmDb)

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -30,14 +30,16 @@ module Curiosity.Data
   , Command.Command(..)
   ) where
 
-import qualified Curiosity.Data.Counter        as C
-import qualified Curiosity.Data.Command        as Command ( Command(..) )
 import qualified Commence.Runtime.Errors       as E
 import qualified Control.Concurrent.STM        as STM
 import qualified Curiosity.Data.Business       as Business
+import qualified Curiosity.Data.Command        as Command
+                                                ( Command(..) )
+import qualified Curiosity.Data.Counter        as C
 import qualified Curiosity.Data.Employment     as Employment
 import qualified Curiosity.Data.Invoice        as Invoice
 import qualified Curiosity.Data.Legal          as Legal
+import qualified Curiosity.Data.Quotation      as Quotation
 import qualified Curiosity.Data.SimpleContract as SimpleContract
 import qualified Curiosity.Data.User           as User
 import           Data.Aeson
@@ -58,6 +60,7 @@ however, also be an `STM.TVar` if the datastore is to be STM based.
 Additionally, we want to parameterise over a @runtime@ type parameter. This is
 a container type of the database.
 -}
+-- brittany-disable-next-binding
 data Db (datastore :: Type -> Type) (runtime :: Type) = Db
   { _dbNextBusinessId   :: C.CounterValue datastore Int
   , _dbBusinessUnits    :: datastore [Business.Unit]
@@ -65,13 +68,18 @@ data Db (datastore :: Type -> Type) (runtime :: Type) = Db
   , _dbLegalEntities    :: datastore [Legal.Entity]
   , _dbNextUserId       :: C.CounterValue datastore Int
   , _dbUserProfiles     :: datastore [User.UserProfile]
+  , _dbNextQuotationId  :: C.CounterValue datastore Int
+  , _dbQuotations       :: datastore [Quotation.Quotation]
   , _dbNextInvoiceId    :: C.CounterValue datastore Int
   , _dbInvoices         :: datastore [Invoice.Invoice]
   , _dbNextEmploymentId :: C.CounterValue datastore Int
   , _dbEmployments      :: datastore [Employment.Contract]
 
-  , _dbRandomGenState     :: datastore (Word64, Word64)
+  , _dbRandomGenState   :: datastore (Word64, Word64)
     -- ^ The internal representation of a StdGen.
+
+  , _dbFormCreateQuotationAll ::
+      datastore (Map (User.UserName, Text) Quotation.CreateQuotationAll)
   , _dbFormCreateContractAll ::
       datastore (Map (User.UserName, Text) Employment.CreateContractAll)
   , _dbFormCreateSimpleContractAll ::
@@ -93,53 +101,49 @@ type StmDb runtime = Db STM.TVar runtime
 
 -- | Instantiate a seed database that is empty.
 emptyHask :: forall runtime . HaskDb runtime
-emptyHask = Db
-  (pure 1) (pure mempty)
-  (pure 1) (pure mempty)
-  (pure 1) (pure mempty)
-  (pure 1) (pure mempty)
-  (pure 1) (pure mempty)
+emptyHask = Db (pure 1)
+               (pure mempty)
+               (pure 1)
+               (pure mempty)
+               (pure 1)
+               (pure mempty)
+               (pure 1)
+               (pure mempty)
+               (pure 1)
+               (pure mempty)
+               (pure 1)
+               (pure mempty)
 
-  (pure $ randomGenState 42) -- Deterministic initial seed.
-  (pure mempty)
-  (pure mempty)
+               (pure $ randomGenState 42) -- Deterministic initial seed.
+               (pure mempty)
+               (pure mempty)
+               (pure mempty)
 
 instantiateStmDb
   :: forall runtime m . MonadIO m => HaskDb runtime -> m (StmDb runtime)
-instantiateStmDb Db
-  { _dbNextBusinessId   = C.CounterValue (Identity seedNextBusinessId)
-  , _dbBusinessUnits    = Identity seedBusinessUnits
-  , _dbNextLegalId      = C.CounterValue (Identity seedNextLegalId)
-  , _dbLegalEntities    = Identity seedLegalEntities
-  , _dbNextUserId       = C.CounterValue (Identity seedNextUserId)
-  , _dbUserProfiles     = Identity seedProfiles
-  , _dbNextInvoiceId    = C.CounterValue (Identity seedNextInvoiceId)
-  , _dbInvoices         = Identity seedInvoices
-  , _dbNextEmploymentId = C.CounterValue (Identity seedNextEmploymentId)
-  , _dbEmployments      = Identity seedEmployments
-
-  , _dbRandomGenState        = Identity seedRandomGenState
-  , _dbFormCreateContractAll = Identity seedFormCreateContractAll
-  , _dbFormCreateSimpleContractAll = Identity seedFormCreateSimpleContractAll
-  }
+instantiateStmDb Db { _dbNextBusinessId = C.CounterValue (Identity seedNextBusinessId), _dbBusinessUnits = Identity seedBusinessUnits, _dbNextLegalId = C.CounterValue (Identity seedNextLegalId), _dbLegalEntities = Identity seedLegalEntities, _dbNextUserId = C.CounterValue (Identity seedNextUserId), _dbUserProfiles = Identity seedProfiles, _dbNextQuotationId = C.CounterValue (Identity seedNextQuotationId), _dbQuotations = Identity seedQuotations, _dbNextInvoiceId = C.CounterValue (Identity seedNextInvoiceId), _dbInvoices = Identity seedInvoices, _dbNextEmploymentId = C.CounterValue (Identity seedNextEmploymentId), _dbEmployments = Identity seedEmployments, _dbRandomGenState = Identity seedRandomGenState, _dbFormCreateQuotationAll = Identity seedFormCreateQuotationAll, _dbFormCreateContractAll = Identity seedFormCreateContractAll, _dbFormCreateSimpleContractAll = Identity seedFormCreateSimpleContractAll }
   =
   -- We don't use `newTVarIO` repeatedly under here and instead wrap the whole
   -- instantiation under a single STM transaction (@atomically@).
     liftIO . STM.atomically $ do
-    _dbNextBusinessId   <- C.newCounter seedNextBusinessId
-    _dbBusinessUnits    <- STM.newTVar seedBusinessUnits
-    _dbNextLegalId      <- C.newCounter seedNextLegalId
-    _dbLegalEntities    <- STM.newTVar seedLegalEntities
-    _dbNextUserId       <- C.newCounter seedNextUserId
-    _dbUserProfiles     <- STM.newTVar seedProfiles
-    _dbNextInvoiceId    <- C.newCounter seedNextInvoiceId
-    _dbInvoices         <- STM.newTVar seedInvoices
-    _dbNextEmploymentId <- C.newCounter seedNextEmploymentId
-    _dbEmployments      <- STM.newTVar seedEmployments
+    _dbNextBusinessId              <- C.newCounter seedNextBusinessId
+    _dbBusinessUnits               <- STM.newTVar seedBusinessUnits
+    _dbNextLegalId                 <- C.newCounter seedNextLegalId
+    _dbLegalEntities               <- STM.newTVar seedLegalEntities
+    _dbNextUserId                  <- C.newCounter seedNextUserId
+    _dbUserProfiles                <- STM.newTVar seedProfiles
+    _dbNextQuotationId             <- C.newCounter seedNextQuotationId
+    _dbQuotations                  <- STM.newTVar seedQuotations
+    _dbNextInvoiceId               <- C.newCounter seedNextInvoiceId
+    _dbInvoices                    <- STM.newTVar seedInvoices
+    _dbNextEmploymentId            <- C.newCounter seedNextEmploymentId
+    _dbEmployments                 <- STM.newTVar seedEmployments
 
-    _dbRandomGenState        <- STM.newTVar seedRandomGenState
-    _dbFormCreateContractAll <- STM.newTVar seedFormCreateContractAll
-    _dbFormCreateSimpleContractAll <- STM.newTVar seedFormCreateSimpleContractAll
+    _dbRandomGenState              <- STM.newTVar seedRandomGenState
+    _dbFormCreateQuotationAll      <- STM.newTVar seedFormCreateQuotationAll
+    _dbFormCreateContractAll       <- STM.newTVar seedFormCreateContractAll
+    _dbFormCreateSimpleContractAll <- STM.newTVar
+      seedFormCreateSimpleContractAll
     pure Db { .. }
 
 instantiateEmptyStmDb :: forall runtime m . MonadIO m => m (StmDb runtime)
@@ -147,8 +151,7 @@ instantiateEmptyStmDb = instantiateStmDb emptyHask
 
 -- | Reset all values of the `Db` product type from `STM.STM` to the empty
 -- state.
-resetStmDb
-  :: forall runtime m . MonadIO m => StmDb runtime -> m ()
+resetStmDb :: forall runtime m . MonadIO m => StmDb runtime -> m ()
 resetStmDb = liftIO . STM.atomically . resetStmDb'
 
 resetStmDb' stmDb = do
@@ -158,29 +161,20 @@ resetStmDb' stmDb = do
   STM.writeTVar (_dbLegalEntities stmDb) seedLegalEntities
   C.writeCounter (_dbNextUserId stmDb) seedNextUserId
   STM.writeTVar (_dbUserProfiles stmDb) seedProfiles
+  C.writeCounter (_dbNextQuotationId stmDb) seedNextQuotationId
+  STM.writeTVar (_dbQuotations stmDb) seedQuotations
   C.writeCounter (_dbNextInvoiceId stmDb) seedNextInvoiceId
   STM.writeTVar (_dbInvoices stmDb) seedInvoices
   C.writeCounter (_dbNextEmploymentId stmDb) seedNextEmploymentId
   STM.writeTVar (_dbEmployments stmDb) seedEmployments
 
+  STM.writeTVar (_dbFormCreateQuotationAll stmDb) seedFormCreateQuotationAll
   STM.writeTVar (_dbFormCreateContractAll stmDb) seedFormCreateContractAll
-  STM.writeTVar (_dbFormCreateSimpleContractAll stmDb) seedFormCreateSimpleContractAll
+  STM.writeTVar (_dbFormCreateSimpleContractAll stmDb)
+                seedFormCreateSimpleContractAll
  where
-  Db
-    { _dbNextBusinessId   = C.CounterValue (Identity seedNextBusinessId)
-    , _dbBusinessUnits    = Identity seedBusinessUnits
-    , _dbNextLegalId      = C.CounterValue (Identity seedNextLegalId)
-    , _dbLegalEntities    = Identity seedLegalEntities
-    , _dbNextUserId       = C.CounterValue (Identity seedNextUserId)
-    , _dbUserProfiles     = Identity seedProfiles
-    , _dbNextInvoiceId    = C.CounterValue (Identity seedNextInvoiceId)
-    , _dbInvoices         = Identity seedInvoices
-    , _dbNextEmploymentId = C.CounterValue (Identity seedNextEmploymentId)
-    , _dbEmployments      = Identity seedEmployments
-
-    , _dbFormCreateContractAll = Identity seedFormCreateContractAll
-    , _dbFormCreateSimpleContractAll = Identity seedFormCreateSimpleContractAll
-    } = emptyHask
+  Db { _dbNextBusinessId = C.CounterValue (Identity seedNextBusinessId), _dbBusinessUnits = Identity seedBusinessUnits, _dbNextLegalId = C.CounterValue (Identity seedNextLegalId), _dbLegalEntities = Identity seedLegalEntities, _dbNextUserId = C.CounterValue (Identity seedNextUserId), _dbUserProfiles = Identity seedProfiles, _dbNextQuotationId = C.CounterValue (Identity seedNextQuotationId), _dbQuotations = Identity seedQuotations, _dbNextInvoiceId = C.CounterValue (Identity seedNextInvoiceId), _dbInvoices = Identity seedInvoices, _dbNextEmploymentId = C.CounterValue (Identity seedNextEmploymentId), _dbEmployments = Identity seedEmployments, _dbFormCreateQuotationAll = Identity seedFormCreateQuotationAll, _dbFormCreateContractAll = Identity seedFormCreateContractAll, _dbFormCreateSimpleContractAll = Identity seedFormCreateSimpleContractAll }
+    = emptyHask
 
 -- | Reads all values of the `Db` product type from `STM.STM` to @Hask@.
 readFullStmDbInHaskFromRuntime
@@ -197,20 +191,26 @@ readFullStmDbInHask
 readFullStmDbInHask = liftIO . STM.atomically . readFullStmDbInHask'
 
 readFullStmDbInHask' stmDb = do
-  _dbNextBusinessId   <- pure <$> C.readCounter (_dbNextBusinessId stmDb)
-  _dbBusinessUnits    <- pure <$> STM.readTVar (_dbBusinessUnits stmDb)
-  _dbNextLegalId      <- pure <$> C.readCounter (_dbNextLegalId stmDb)
-  _dbLegalEntities    <- pure <$> STM.readTVar (_dbLegalEntities stmDb)
-  _dbNextUserId       <- pure <$> C.readCounter (_dbNextUserId stmDb)
-  _dbUserProfiles     <- pure <$> STM.readTVar (_dbUserProfiles stmDb)
-  _dbNextInvoiceId    <- pure <$> C.readCounter (_dbNextInvoiceId stmDb)
-  _dbInvoices         <- pure <$> STM.readTVar (_dbInvoices stmDb)
+  _dbNextBusinessId         <- pure <$> C.readCounter (_dbNextBusinessId stmDb)
+  _dbBusinessUnits          <- pure <$> STM.readTVar (_dbBusinessUnits stmDb)
+  _dbNextLegalId            <- pure <$> C.readCounter (_dbNextLegalId stmDb)
+  _dbLegalEntities          <- pure <$> STM.readTVar (_dbLegalEntities stmDb)
+  _dbNextUserId             <- pure <$> C.readCounter (_dbNextUserId stmDb)
+  _dbUserProfiles           <- pure <$> STM.readTVar (_dbUserProfiles stmDb)
+  _dbNextQuotationId        <- pure <$> C.readCounter (_dbNextQuotationId stmDb)
+  _dbQuotations             <- pure <$> STM.readTVar (_dbQuotations stmDb)
+  _dbNextInvoiceId          <- pure <$> C.readCounter (_dbNextInvoiceId stmDb)
+  _dbInvoices               <- pure <$> STM.readTVar (_dbInvoices stmDb)
   _dbNextEmploymentId <- pure <$> C.readCounter (_dbNextEmploymentId stmDb)
-  _dbEmployments      <- pure <$> STM.readTVar (_dbEmployments stmDb)
+  _dbEmployments            <- pure <$> STM.readTVar (_dbEmployments stmDb)
 
-  _dbRandomGenState        <- pure <$> STM.readTVar (_dbRandomGenState stmDb)
-  _dbFormCreateContractAll <- pure <$> STM.readTVar (_dbFormCreateContractAll stmDb)
-  _dbFormCreateSimpleContractAll <- pure <$> STM.readTVar (_dbFormCreateSimpleContractAll stmDb)
+  _dbRandomGenState         <- pure <$> STM.readTVar (_dbRandomGenState stmDb)
+  _dbFormCreateQuotationAll <- pure
+    <$> STM.readTVar (_dbFormCreateQuotationAll stmDb)
+  _dbFormCreateContractAll <- pure
+    <$> STM.readTVar (_dbFormCreateContractAll stmDb)
+  _dbFormCreateSimpleContractAll <- pure
+    <$> STM.readTVar (_dbFormCreateSimpleContractAll stmDb)
   pure Db { .. }
 
 {- | Provides us with the ability to constrain on a larger product-type (the
@@ -248,8 +248,9 @@ deserialiseDb = first (DbDecodeFailed . T.pack) . eitherDecode
 {-# INLINE deserialiseDb #-}
 
 -- | Read an entire db state from bytes.
-deserialiseDbStrict :: forall runtime . ByteString -> Either DbErr (HaskDb runtime)
-deserialiseDbStrict = first (DbDecodeFailed . T.pack) . eitherDecodeStrict 
+deserialiseDbStrict
+  :: forall runtime . ByteString -> Either DbErr (HaskDb runtime)
+deserialiseDbStrict = first (DbDecodeFailed . T.pack) . eitherDecodeStrict
 {-# INLINE deserialiseDbStrict #-}
 
 --------------------------------------------------------------------------------
@@ -273,9 +274,10 @@ writeStdGen db g = do
 genRandomText :: forall runtime . StmDb runtime -> STM Text
 genRandomText db = do
   g1 <- readStdGen db
-  let ags = take 8 $ unfoldr (\g -> let (a, g') = Rand.uniformR ('A', 'Z') g
-                                     in Just ((a, g'), g')) g1
-      s = T.pack $ fst <$> ags
+  let ags = take 8 $ unfoldr
+        (\g -> let (a, g') = Rand.uniformR ('A', 'Z') g in Just ((a, g'), g'))
+        g1
+      s  = T.pack $ fst <$> ags
       g2 = snd $ L.last ags
   writeStdGen db g2
   pure s

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -114,10 +114,12 @@ emptyHask = Db (pure 1)
                (pure 1)
                (pure mempty)
 
-               (pure $ randomGenState 42) -- Deterministic initial seed.
+               (pure initialGenState)
                (pure mempty)
                (pure mempty)
                (pure mempty)
+
+initialGenState = randomGenState 42 -- Deterministic initial seed.
 
 instantiateStmDb
   :: forall runtime m . MonadIO m => HaskDb runtime -> m (StmDb runtime)
@@ -168,12 +170,13 @@ resetStmDb' stmDb = do
   C.writeCounter (_dbNextEmploymentId stmDb) seedNextEmploymentId
   STM.writeTVar (_dbEmployments stmDb) seedEmployments
 
+  STM.writeTVar (_dbRandomGenState stmDb) seedRandomGenState
   STM.writeTVar (_dbFormCreateQuotationAll stmDb) seedFormCreateQuotationAll
   STM.writeTVar (_dbFormCreateContractAll stmDb) seedFormCreateContractAll
   STM.writeTVar (_dbFormCreateSimpleContractAll stmDb)
                 seedFormCreateSimpleContractAll
  where
-  Db { _dbNextBusinessId = C.CounterValue (Identity seedNextBusinessId), _dbBusinessUnits = Identity seedBusinessUnits, _dbNextLegalId = C.CounterValue (Identity seedNextLegalId), _dbLegalEntities = Identity seedLegalEntities, _dbNextUserId = C.CounterValue (Identity seedNextUserId), _dbUserProfiles = Identity seedProfiles, _dbNextQuotationId = C.CounterValue (Identity seedNextQuotationId), _dbQuotations = Identity seedQuotations, _dbNextInvoiceId = C.CounterValue (Identity seedNextInvoiceId), _dbInvoices = Identity seedInvoices, _dbNextEmploymentId = C.CounterValue (Identity seedNextEmploymentId), _dbEmployments = Identity seedEmployments, _dbFormCreateQuotationAll = Identity seedFormCreateQuotationAll, _dbFormCreateContractAll = Identity seedFormCreateContractAll, _dbFormCreateSimpleContractAll = Identity seedFormCreateSimpleContractAll }
+  Db { _dbNextBusinessId = C.CounterValue (Identity seedNextBusinessId), _dbBusinessUnits = Identity seedBusinessUnits, _dbNextLegalId = C.CounterValue (Identity seedNextLegalId), _dbLegalEntities = Identity seedLegalEntities, _dbNextUserId = C.CounterValue (Identity seedNextUserId), _dbUserProfiles = Identity seedProfiles, _dbNextQuotationId = C.CounterValue (Identity seedNextQuotationId), _dbQuotations = Identity seedQuotations, _dbNextInvoiceId = C.CounterValue (Identity seedNextInvoiceId), _dbInvoices = Identity seedInvoices, _dbNextEmploymentId = C.CounterValue (Identity seedNextEmploymentId), _dbEmployments = Identity seedEmployments, _dbRandomGenState = Identity seedRandomGenState, _dbFormCreateQuotationAll = Identity seedFormCreateQuotationAll, _dbFormCreateContractAll = Identity seedFormCreateContractAll, _dbFormCreateSimpleContractAll = Identity seedFormCreateSimpleContractAll }
     = emptyHask
 
 -- | Reads all values of the `Db` product type from `STM.STM` to @Hask@.

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -60,7 +60,7 @@ a container type of the database.
 -}
 data Db (datastore :: Type -> Type) (runtime :: Type) = Db
   { _dbNextBusinessId   :: C.CounterValue datastore Int
-  , _dbBusinessEntities :: datastore [Business.Entity]
+  , _dbBusinessEntities :: datastore [Business.Unit]
   , _dbNextLegalId      :: C.CounterValue datastore Int
   , _dbLegalEntities    :: datastore [Legal.Entity]
   , _dbNextUserId       :: C.CounterValue datastore Int

--- a/src/Curiosity/Data/Business.hs
+++ b/src/Curiosity/Data/Business.hs
@@ -5,10 +5,10 @@ Module: Curiosity.Data.Business
 Description: Business entities related datatypes
 -}
 module Curiosity.Data.Business
-  ( Entity(..)
+  ( Unit(..)
   , Create(..)
   , Update(..)
-  , BusinessId(..)
+  , UnitId(..)
   , Err(..)
   ) where
 
@@ -43,8 +43,8 @@ instance FromForm Update where
 
 
 --------------------------------------------------------------------------------
-data Entity = Entity
-  { _entityId          :: BusinessId
+data Unit = Unit
+  { _entityId          :: UnitId
   , _entitySlug        :: Text
     -- An identifier suitable for URLs
   , _entityName        :: Text
@@ -54,7 +54,7 @@ data Entity = Entity
   deriving anyclass (ToJSON, FromJSON)
 
 -- | Record ID of the form BENT-xxx.
-newtype BusinessId = BusinessId { unBusinessId :: Text }
+newtype UnitId = UnitId { unUnitId :: Text }
                deriving (Eq, Show)
                deriving ( IsString
                         , FromJSON
@@ -62,7 +62,7 @@ newtype BusinessId = BusinessId { unBusinessId :: Text }
                         , H.ToMarkup
                         , H.ToValue
                         ) via Text
-               deriving FromForm via W.Wrapped "business-id" Text
+               deriving FromForm via W.Wrapped "unit-id" Text
 
 data Err = Err
   deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/Command.hs
+++ b/src/Curiosity/Data/Command.hs
@@ -10,27 +10,9 @@ module Curiosity.Data.Command
   ( Command(..)
   ) where
 
-import qualified Commence.Runtime.Errors       as Errs
-import qualified Commence.Runtime.Storage      as Storage
-import qualified Commence.Types.Secret         as Secret
-import qualified Commence.Types.Wrapped        as W
-import           Control.Lens
-import qualified Curiosity.Html.Errors         as Pages
-import           Data.Aeson
-import qualified Data.Text                     as T
-import qualified Data.Text.Lazy                as LT
-import qualified Network.HTTP.Types            as HTTP
-import qualified Servant.Auth.Server           as SAuth
-import qualified Smart.Server.Page.Navbar      as Nav
-import qualified Text.Blaze.Html5              as H
-import           Text.Blaze.Html5               ( (!) )
-import qualified Text.Blaze.Html5.Attributes   as A
-import           Text.Blaze.Renderer.Text       ( renderMarkup )
 import           Web.FormUrlEncoded             ( FromForm(..)
-                                                , parseMaybe
                                                 , parseUnique
                                                 )
-import           Web.HttpApiData                ( FromHttpApiData(..) )
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/Demand.hs
+++ b/src/Curiosity/Data/Demand.hs
@@ -1,0 +1,107 @@
+-- | This is an alternative employment contract demand (or proposal)
+-- representation, focusing on the generic nature of "contracts", i.e. they can
+-- represent employment contracts, service or good sales, ... 
+module Curiosity.Data.Demand where
+
+import qualified Curiosity.Data.Business as Business
+import qualified Curiosity.Data.Legal as Legal
+import qualified Curiosity.Data.User as User
+
+
+--------------------------------------------------------------------------------
+-- | A form to represent an employment contract /demand/. We've tried to make
+-- field names independant from the employment aspect, and focus on the
+-- contract.
+data FormDemand = FormDemand
+  { formDemandAuthor     :: User.UserId
+    -- ^ The user filling the form
+  , formDemandBuyer      :: Legal.EntityId
+    -- ^ For an employment contract, this is the employer
+  , formDemandBuyerAgent :: Maybe Business.UnitId
+    -- ^ For an employment contract, this is an (optional) agent of the employer
+  , formDemandSeller     :: User.UserId
+    -- ^ For an employment contract, this is the employee
+  , formDemandClient     :: Maybe FormClient
+    -- ^ For en employment contract, this is the entity providing the paiement
+    -- source to the buyer
+  }
+  deriving Show
+
+-- | Represent the optional client in a `FormDemand`.
+data FormClient = FormClient
+  { formClient      :: Legal.EntityId
+  , formClientAgent :: Maybe Business.UnitId
+  }
+  deriving Show
+
+-- | Well formedness: a well formed form means that the system can receive it,
+-- store it, and process it.
+--
+-- Legal.Entity and Business.Unit are related: all agent parties must be listed
+-- within the legal entities. Each unit is within 1 or more entities.
+isWellFormed :: [Business.UnitId] -> FormDemand -> WellFormedness
+isWellFormed buyerAgentParties FormDemand {..} = toWellFormedness
+  [ maybe True (`elem` buyerAgentParties) formDemandBuyerAgent -->
+      "A buyer agent is given, but it is not a listed party of the buyer"
+  ]
+
+data WellFormedness = WellFormed | IllFormed [Err]
+  deriving Show
+
+toWellFormedness :: [[Err]] -> WellFormedness
+toWellFormedness errs = if null errs' then WellFormed else IllFormed errs'
+  where errs' = concat errs
+
+-- | If the condition is `False`, returns the error message, otherwise returns
+-- nothing.
+(-->) bool msg = if bool then [] else [msg]
+
+type Err = Text
+
+
+
+--------------------------------------------------------------------------------
+-- Examples
+--
+-- 24 cases:
+--
+-- whether formAuthor == formSeller (2 cases)
+--
+-- formSeller is representative of formBuyer or formBuyerAgent (4 cases)
+--
+-- formBuyerAgent is Department or Activity or Nothing (3 cases)
+
+entity222AgentParties :: [Business.UnitId]
+entity222AgentParties = ["UNIT-444"]
+
+form0 = FormDemand
+  { formDemandAuthor     = "USER-111"
+  , formDemandBuyer      = "ENT-222"
+  , formDemandBuyerAgent = Nothing
+  , formDemandSeller     = "USER-333"
+  , formDemandClient     = Nothing
+  }
+
+form1 = FormDemand
+  { formDemandAuthor     = "USER-111"
+  , formDemandBuyer      = "ENT-222"
+  , formDemandBuyerAgent = Nothing
+  , formDemandSeller     = "USER-111"
+  , formDemandClient     = Nothing
+  }
+
+form2 = FormDemand
+  { formDemandAuthor     = "USER-111"
+  , formDemandBuyer      = "ENT-222"
+  , formDemandBuyerAgent = Just "UNIT-444"
+  , formDemandSeller     = "USER-333"
+  , formDemandClient     = Nothing
+  }
+
+form2' = FormDemand
+  { formDemandAuthor     = "USER-111"
+  , formDemandBuyer      = "ENT-222"
+  , formDemandBuyerAgent = Just "UNIT-555"
+  , formDemandSeller     = "USER-333"
+  , formDemandClient     = Nothing
+  }

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{- |
+Module: Curiosity.Data.Email
+Description: Email -related data types.
+
+This module contains data types used to represent emails. Within
+`Curiosity.Data`, they are used to record atomically that an email should be
+sent during an STM operation. A separate thread should actually handle them.
+
+-}
+module Curiosity.Data.Email
+  ( -- * Main data representation
+    Email(..)
+  , EmailId(..)
+  , EmailTemplate(..)
+  , Err(..)
+  ) where
+
+import qualified Commence.Types.Wrapped        as W
+import qualified Curiosity.Data.User           as User
+import           Data.Aeson
+import qualified Text.Blaze.Html5              as H
+import           Web.FormUrlEncoded             ( FromForm(..)
+                                                )
+
+
+--------------------------------------------------------------------------------
+-- | This represents an email in database.
+data Email = Email
+  { _emailId :: EmailId
+  , _emailTemplate :: EmailTemplate
+  , _emailRecipient :: User.UserEmailAddr
+  }
+  deriving (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+-- | Record ID of the form EMAIL-xxx.
+newtype EmailId = EmailId { unEmailId :: Text }
+               deriving (Eq, Show)
+               deriving ( IsString
+                        , FromJSON
+                        , ToJSON
+                        , H.ToMarkup
+                        , H.ToValue
+                        ) via Text
+               deriving FromForm via W.Wrapped "email-id" Text
+
+data EmailTemplate = SignupConfirmationEmail | QuotationEmail | InvoiceEmail
+  deriving (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data Err = Err
+  { unErr :: Text
+  }
+  deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -46,7 +46,7 @@ newtype EmailId = EmailId { unEmailId :: Text }
                         ) via Text
                deriving FromForm via W.Wrapped "email-id" Text
 
-data EmailTemplate = SignupConfirmationEmail | QuotationEmail | InvoiceEmail
+data EmailTemplate = SignupConfirmationEmail | QuotationEmail | InvoiceEmail | InvoiceReminderEmail
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
 

--- a/src/Curiosity/Data/Invoice.hs
+++ b/src/Curiosity/Data/Invoice.hs
@@ -35,4 +35,6 @@ newtype InvoiceId = InvoiceId { unInvoiceId :: Text }
                deriving FromForm via W.Wrapped "invoice-id" Text
 
 data Err = Err
+  { unErr :: Text
+  }
   deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/Legal.hs
+++ b/src/Curiosity/Data/Legal.hs
@@ -12,6 +12,7 @@ module Curiosity.Data.Legal
   , RegistrationName(..)
   , ActingUserId(..)
   , ActingUser(..)
+  , EntityAndRole(..)
   , Err(..)
   , encodeUBL
   , toUBL
@@ -126,7 +127,12 @@ data ActingRole = Titular | Director | Administrator
   deriving (Eq, Generic, Show)
   deriving (FromJSON, ToJSON)
 
+-- | A user and their role within an entity.
 data ActingUser = ActingUser User.UserProfile ActingRole
+
+-- | The inverse of `ActingUser`: an entity in which a user acts, with the role
+-- of the user.
+data EntityAndRole = EntityAndRole Entity ActingRole
 
 data Err = Err
   deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/Legal.hs
+++ b/src/Curiosity/Data/Legal.hs
@@ -10,12 +10,15 @@ module Curiosity.Data.Legal
   , Update(..)
   , EntityId(..)
   , RegistrationName(..)
+  , ActingUserId(..)
+  , ActingUser(..)
   , Err(..)
   , encodeUBL
   , toUBL
   ) where
 
 import qualified Commence.Types.Wrapped        as W
+import qualified Curiosity.Data.User           as User
 import           Data.Aeson
 import qualified Data.ByteString.Lazy          as LB
 import qualified Text.Blaze.Html5              as H
@@ -58,12 +61,14 @@ instance FromForm Update where
 data Entity = Entity
   { _entityId          :: EntityId
   , _entitySlug        :: Text
-    -- An identifier suitable for URLs
+    -- ^ An identifier suitable for URLs (unique across entities).
   , _entityName        :: RegistrationName
   , _entityCbeNumber   :: CbeNumber
   , _entityVatNumber   :: VatNumber -- TODO Is it really useful to habe both ?
   , _entityDescription :: Maybe Text
-    -- Public description. Similar to a user profile bio.
+    -- ^ Public description. Similar to a user profile bio.
+  , _entityUsersAndRoles :: [ActingUserId]
+    -- ^ Users that can "act" within the entity, with some kind of associated rights.
   }
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
@@ -112,6 +117,16 @@ newtype VatNumber = VatNumber { unVatNumber :: Text }
                         , H.ToValue
                         ) via Text
                deriving (FromHttpApiData, FromForm) via W.Wrapped "vat-number" Text
+
+data ActingUserId = ActingUserId User.UserId ActingRole
+  deriving (Eq, Generic, Show)
+  deriving (FromJSON, ToJSON)
+
+data ActingRole = Titular | Director | Administrator
+  deriving (Eq, Generic, Show)
+  deriving (FromJSON, ToJSON)
+
+data ActingUser = ActingUser User.UserProfile ActingRole
 
 data Err = Err
   deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/Legal.hs
+++ b/src/Curiosity/Data/Legal.hs
@@ -8,7 +8,7 @@ module Curiosity.Data.Legal
   ( Entity(..)
   , Create(..)
   , Update(..)
-  , LegalId(..)
+  , EntityId(..)
   , RegistrationName(..)
   , Err(..)
   , encodeUBL
@@ -56,7 +56,7 @@ instance FromForm Update where
 
 --------------------------------------------------------------------------------
 data Entity = Entity
-  { _entityId          :: LegalId
+  { _entityId          :: EntityId
   , _entitySlug        :: Text
     -- An identifier suitable for URLs
   , _entityName        :: RegistrationName
@@ -69,7 +69,7 @@ data Entity = Entity
   deriving anyclass (ToJSON, FromJSON)
 
 -- | Record ID of the form LENT-xxx.
-newtype LegalId = LegalId { unLegalId :: Text }
+newtype EntityId = EntityId { unEntityId :: Text }
                deriving (Eq, Show)
                deriving ( IsString
                         , FromJSON

--- a/src/Curiosity/Data/Order.hs
+++ b/src/Curiosity/Data/Order.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{- |
+Module: Curiosity.Data.Order
+Description: Order -related data types.
+
+This module contains data types used to represent orders (there is no form to
+create them as they result from a signed quotation).
+
+-}
+module Curiosity.Data.Order
+  ( -- * Main data representation
+    Order(..)
+  , OrderId(..)
+  , Err(..)
+  ) where
+
+import qualified Commence.Types.Wrapped        as W
+import           Data.Aeson
+import qualified Text.Blaze.Html5              as H
+import           Web.FormUrlEncoded             ( FromForm(..)
+                                                )
+
+
+--------------------------------------------------------------------------------
+-- | This represents an order in database.
+data Order = Order
+  { _orderId :: OrderId
+  }
+  deriving (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+-- | Record ID of the form ORD-xxx.
+newtype OrderId = OrderId { unOrderId :: Text }
+               deriving (Eq, Show)
+               deriving ( IsString
+                        , FromJSON
+                        , ToJSON
+                        , H.ToMarkup
+                        , H.ToValue
+                        ) via Text
+               deriving FromForm via W.Wrapped "order-id" Text
+
+data Err = Err
+  { unErr :: Text
+  }
+  deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/Quotation.hs
+++ b/src/Curiosity/Data/Quotation.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{- |
+Module: Curiosity.Data.Quotation
+Description: Quotation -related data types.
+
+This module contains data types used to represent quotations, both as used when
+filling a form, and used as proper validated data.
+
+-}
+module Curiosity.Data.Quotation
+  ( -- * Form data representation
+    --
+    -- $formDataTypes
+    CreateQuotationAll(..)
+    -- * Empty values
+    --
+    -- $emptyValues
+  , emptyCreateQuotationAll
+    -- * Form submittal and validation
+  , SubmitQuotation(..)
+  , validateCreateQuotation
+  , validateCreateQuotation'
+    -- * Main data representation
+  , Quotation(..)
+  , QuotationId(..)
+  , Err(..)
+  ) where
+
+import qualified Commence.Types.Wrapped        as W
+import qualified Curiosity.Data.User           as User
+import           Data.Aeson
+import qualified Text.Blaze.Html5              as H
+import           Web.FormUrlEncoded             ( FromForm(..)
+                                                , parseUnique
+                                                )
+
+
+--------------------------------------------------------------------------------
+-- $formDataTypes
+--
+-- A quotation form, as displayed on a web page, is made of multiple input
+-- groups (or panels, or even of separate pages). Different data types are
+-- provided to represent those sets of input fields.
+
+-- | This represents a form being filled in. In particular, it can represent
+-- invalid inputs. As it is filled, it is kept in a Map in "Curiosity.Data",
+-- where it is identified by a key. The form data are validated when they are
+-- "submitted", using the `SubmitQuotation` data type below, and the key.
+data CreateQuotationAll = CreateQuotationAll
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm CreateQuotationAll where
+  fromForm f = pure CreateQuotationAll
+
+
+--------------------------------------------------------------------------------
+-- $emptyValues
+--
+-- Since forms are designed to be submitted after a confirmation page, it
+-- should be possible to re-display a form with pre-filled values. The initial
+-- form, when no value has been provided by a user, is actually rendering
+-- \"empty" values, defined here.
+
+emptyCreateQuotationAll :: CreateQuotationAll
+emptyCreateQuotationAll = CreateQuotationAll
+
+
+--------------------------------------------------------------------------------
+-- | This represents the submittal of a CreateQuotationAll, identified by its
+-- key.
+data SubmitQuotation = SubmitQuotation
+  { _submitQuotationKey :: Text
+  }
+  deriving (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance FromForm SubmitQuotation where
+  fromForm f = SubmitQuotation <$> parseUnique "key" f
+
+-- | Given a contract form, tries to return a proper `Quotation` value, although
+-- the ID is dummy. Maybe we should have separate data types (with or without
+-- the ID).
+-- This is a pure function: everything required to perform the validation
+-- should be provided as arguments.
+validateCreateQuotation
+  :: User.UserProfile -> CreateQuotationAll -> Either [Err] Quotation
+validateCreateQuotation profile CreateQuotationAll = if null errors
+  then Right quotation
+  else Left errors
+ where
+  quotation = Quotation { _quotationId = QuotationId "TODO-DUMMY" }
+  errors =
+    concat
+    -- No rules for now.
+           []
+
+-- | Similar to `validateCreateQuotation` but throw away the returned
+-- contract, i.e. keep only the errors.
+validateCreateQuotation' profile quotation =
+  either identity (const []) $ validateCreateQuotation profile quotation
+
+
+--------------------------------------------------------------------------------
+-- | This represents a quotation in database.
+data Quotation = Quotation
+  { _quotationId :: QuotationId
+  }
+  deriving (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+-- | Record ID of the form QUOT-xxx.
+newtype QuotationId = QuotationId { unQuotationId :: Text }
+               deriving (Eq, Show)
+               deriving ( IsString
+                        , FromJSON
+                        , ToJSON
+                        , H.ToMarkup
+                        , H.ToValue
+                        ) via Text
+               deriving FromForm via W.Wrapped "quotation-id" Text
+
+data Err = Err
+  { unErr :: Text
+  }
+  deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/RemittanceAdv.hs
+++ b/src/Curiosity/Data/RemittanceAdv.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{- |
+Module: Curiosity.Data.RemittanceAdv
+Description: RemittanceAdv -related data types.
+
+This module contains data types used to represent remittance advices.
+
+-}
+module Curiosity.Data.RemittanceAdv
+  ( -- * Main data representation
+    RemittanceAdv(..)
+  , RemittanceAdvId(..)
+  , Err(..)
+  ) where
+
+import qualified Commence.Types.Wrapped        as W
+import           Data.Aeson
+import qualified Text.Blaze.Html5              as H
+import           Web.FormUrlEncoded             ( FromForm(..)
+                                                )
+
+
+--------------------------------------------------------------------------------
+-- | This represents a remittance advice in database.
+data RemittanceAdv = RemittanceAdv
+  { _remittanceAdvId :: RemittanceAdvId
+  }
+  deriving (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+-- | Record ID of the form REM-xxx.
+newtype RemittanceAdvId = RemittanceAdvId { unRemittanceAdvId :: Text }
+               deriving (Eq, Show)
+               deriving ( IsString
+                        , FromJSON
+                        , ToJSON
+                        , H.ToMarkup
+                        , H.ToValue
+                        ) via Text
+               deriving FromForm via W.Wrapped "remittance-advice-id" Text
+
+data Err = Err
+  { unErr :: Text
+  }
+  deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/SimpleContract.hs
+++ b/src/Curiosity/Data/SimpleContract.hs
@@ -66,9 +66,7 @@ import           Web.FormUrlEncoded             ( FromForm(..)
                                                 , parseMaybe
                                                 , parseUnique
                                                 )
-import           Web.HttpApiData                ( FromHttpApiData(..)
-                                                , parseQueryParams
-                                                )
+import           Web.HttpApiData                ( parseQueryParams )
 
 --------------------------------------------------------------------------------
 -- $formDataTypes

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -42,6 +42,7 @@ module Curiosity.Data.User
   , Predicate(..)
   , applyPredicate
   , SetUserEmailAddrAsVerified(..)
+  , userIdPrefix
   -- * Export all DB ops.
   , Storage.DBUpdate(..)
   , Storage.DBSelect(..)
@@ -227,6 +228,9 @@ newtype UserId = UserId { unUserId :: Text }
                         , H.ToValue
                         ) via Text
                deriving (FromHttpApiData, FromForm) via W.Wrapped "user-id" Text
+
+userIdPrefix :: Text
+userIdPrefix = "USER-"
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Business.hs
+++ b/src/Curiosity/Html/Business.hs
@@ -19,7 +19,7 @@ import qualified Text.Blaze.Html5.Attributes   as A
 data UnitView = UnitView
   { _unitViewUser          :: Maybe User.UserProfile
     -- ^ The logged-in user, if any.
-  , _unitViewUnit          :: Business.Entity
+  , _unitViewUnit          :: Business.Unit
   , _unitViewHasEditButton :: Maybe H.AttributeValue
   }
 

--- a/src/Curiosity/Html/Legal.hs
+++ b/src/Curiosity/Html/Legal.hs
@@ -20,14 +20,16 @@ data EntityView = EntityView
   { _entityViewUser          :: Maybe User.UserProfile
     -- ^ The logged-in user, if any.
   , _entityViewEntity        :: Legal.Entity
+  , _entityViewUsersAndRoles :: [Legal.ActingUser]
+    -- ^ The resolved users for `_entityUsersAndRoles`.
   , _entityViewHasEditButton :: Maybe H.AttributeValue
   }
 
 instance H.ToMarkup EntityView where
-  toMarkup (EntityView mprofile entity hasEditButton) =
-    renderView' mprofile $ entityView entity hasEditButton
+  toMarkup (EntityView mprofile entity users hasEditButton) =
+    renderView' mprofile $ entityView entity users hasEditButton
 
-entityView entity hasEditButton = containerMedium $ do
+entityView entity users hasEditButton = containerMedium $ do
   title' "Legal entity" hasEditButton
   H.dl ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short" $ do
     keyValuePair "ID"                (Legal._entityId entity)
@@ -35,6 +37,16 @@ entityView entity hasEditButton = containerMedium $ do
     keyValuePair "CBE number"        (Legal._entityCbeNumber entity)
     keyValuePair "VAT number"        (Legal._entityVatNumber entity)
     maybe mempty (keyValuePair "Description") (Legal._entityDescription entity)
+
+  title' "Acting users" Nothing
+  H.ul $ mapM_ displayActingUser users
+
+displayActingUser (Legal.ActingUser u role) =
+  H.li $ do
+    H.a ! A.href (H.toValue $ "/" <> username) $ H.text username
+    H.code . H.text $ show role
+
+  where username = User.unUserName . User._userCredsName . User._userProfileCreds $ u
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Run.hs
+++ b/src/Curiosity/Html/Run.hs
@@ -8,21 +8,7 @@ module Curiosity.Html.Run
 
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
-import           Curiosity.Html.Navbar          ( navbar )
-import qualified Smart.Html.Dsl                as Dsl
-import           Smart.Html.Layout
-import qualified Smart.Html.Misc               as Misc
-import qualified Smart.Html.Render             as Render
-import           Smart.Html.Shared.Html.Icons   ( svgIconAdd
-                                                , svgIconArrowRight
-                                                )
-import           Smart.Html.SideMenu            ( SideMenu(..)
-                                                , SideMenuItem(..)
-                                                )
-import           Text.Blaze                     ( customAttribute )
 import qualified Text.Blaze.Html5              as H
-import           Text.Blaze.Html5               ( (!) )
-import qualified Text.Blaze.Html5.Attributes   as A
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -1,8 +1,8 @@
 {- |
-Module: Curiosity.Html.Profile
+Module: Curiosity.Html.User
 Description: Profile pages (view and edit).
 -}
-module Curiosity.Html.Profile
+module Curiosity.Html.User
   ( ProfilePage(..)
   , ProfileView(..)
   , PublicProfileView(..)

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -47,7 +47,7 @@ interpret' runtime user dir content nesting = do
     case separated of
       []               -> pure (user', acc)
       ["as", username] -> do
-        let output = [show ln <> ": " <> grouped, "Modifiying default user."]
+        let output = [show ln <> ": " <> grouped, "Modifying default user."]
         pure
           (User.UserName username, acc ++ map (nesting, ExitSuccess, ) output)
       ["quit"] -> do

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -2,7 +2,6 @@ module Curiosity.Run
   ( run
   ) where
 
-import qualified Commence.Multilogging         as ML
 import qualified Commence.Runtime.Errors       as Errs
 import qualified Curiosity.Command             as Command
 import qualified Curiosity.Data                as Data

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -550,6 +550,11 @@ handleCommand runtime@Runtime {..} user command = do
             Left err -> pure (ExitFailure 1, [Order.unErr err])
         Nothing ->
           pure (ExitFailure 1, ["Username not found: " <> User.unUserName user])
+    Command.SendReminder input ->
+      -- TODO Check this is the "system" user ?
+      liftIO . STM.atomically $ do
+        createEmail _rDb Email.InvoiceReminderEmail "TODO client email addr"
+        pure (ExitSuccess, ["Reminder for invoice sent: " <> Invoice.unInvoiceId input])
     Command.FormNewSimpleContract input -> do
       output <-
         runAppMSafe runtime

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -586,7 +586,7 @@ createBusinessFull
   -> Business.Unit
   -> STM (Either Business.Err Business.UnitId)
 createBusinessFull db new = do
-  modifyBusinessEntities db (++ [new])
+  modifyBusinessUnits db (++ [new])
   pure . Right $ Business._entityId new
 
 updateBusiness db Business.Update {..} = do
@@ -599,7 +599,7 @@ updateBusiness db Business.Update {..} = do
                 else e
             | e <- entities
             ]
-      modifyBusinessEntities db replaceOlder
+      modifyBusinessUnits db replaceOlder
       pure $ Right ()
     Nothing -> pure . Left $ User.UserNotFound _updateSlug -- TODO
 
@@ -608,13 +608,13 @@ generateBusinessId
 generateBusinessId Data.Db {..} =
   Business.UnitId <$> C.bumpCounterPrefix "BENT-" _dbNextBusinessId
 
-modifyBusinessEntities
+modifyBusinessUnits
   :: forall runtime
    . Data.StmDb runtime
   -> ([Business.Unit] -> [Business.Unit])
   -> STM ()
-modifyBusinessEntities db f =
-  let tvar = Data._dbBusinessEntities db in STM.modifyTVar tvar f
+modifyBusinessUnits db f =
+  let tvar = Data._dbBusinessUnits db in STM.modifyTVar tvar f
 
 
 --------------------------------------------------------------------------------
@@ -1228,7 +1228,7 @@ readLegalEntities db = do
 selectUnitBySlug
   :: forall runtime . Data.StmDb runtime -> Text -> STM (Maybe Business.Unit)
 selectUnitBySlug db name = do
-  let tvar = Data._dbBusinessEntities db
+  let tvar = Data._dbBusinessUnits db
   records <- STM.readTVar tvar
   pure $ find ((== name) . Business._entitySlug) records
 

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -426,7 +426,20 @@ handleCommand runtime@Runtime {..} user command = do
         runAppMSafe runtime . S.liftTxn @AppM @STM $ S.dbUpdate @AppM @STM
           _rDb
           input
-      pure (ExitSuccess, [show output])
+      case output of
+        Right mid -> do
+          case mid of
+            Right storageResult -> do
+              case storageResult of
+                Right [uid] ->
+                  pure
+                    ( ExitSuccess
+                    , ["User updated: " <> User.unUserId uid]
+                    )
+                Right _ -> pure (ExitFailure 1, ["No record updated."])
+                Left err -> pure (ExitFailure 1, [show err])
+            Left err -> pure (ExitFailure 1, [show err])
+        Left err -> pure (ExitFailure 1, [show err])
     Command.SetUserEmailAddrAsVerified username -> do
       output <-
         runAppMSafe runtime

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1863,7 +1863,7 @@ withMaybeEntityFromName name a f = do
 -- | Run a handler, ensuring a business unit can be obtained from the given
 -- ame, or throw an error.
 withUnitFromName
-  :: forall m a . ServerC m => Text -> (Business.Entity -> m a) -> m a
+  :: forall m a . ServerC m => Text -> (Business.Unit -> m a) -> m a
 withUnitFromName name f = withMaybeUnitFromName name
                                                 (noSuchUserErr . show) -- TODO unit, not user
                                                 f
@@ -1878,7 +1878,7 @@ withMaybeUnitFromName
    . ServerC m
   => Text
   -> (Text -> m a)
-  -> (Business.Entity -> m a)
+  -> (Business.Unit -> m a)
   -> m a
 withMaybeUnitFromName name a f = do
   munit <- Rt.withRuntimeAtomically (Rt.selectUnitBySlug . Rt._rDb) name

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -48,9 +48,9 @@ import qualified Curiosity.Html.Homepage       as Pages
 import qualified Curiosity.Html.Invoice        as Pages
 import qualified Curiosity.Html.LandingPage    as Pages
 import qualified Curiosity.Html.Legal          as Pages
-import qualified Curiosity.Html.Profile        as Pages
 import qualified Curiosity.Html.Run            as Pages
 import qualified Curiosity.Html.SimpleContract as Pages
+import qualified Curiosity.Html.User           as Pages
 import qualified Curiosity.Interpret           as Inter
 import qualified Curiosity.Parse               as Command
 import qualified Curiosity.Runtime             as Rt

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -52,7 +52,7 @@ spec = do
   -- Same here.
   describe "Business unit JSON parser" $ do
     let go (filename, slug) = it ("Parses " <> filename) $ do
-          Right (result :: Business.Entity) <- parseFile $ "data/" </> filename
+          Right (result :: Business.Unit) <- parseFile $ "data/" </> filename
           Business._entitySlug result
             `shouldBe` slug
     mapM_


### PR DESCRIPTION
The main point of this PR is to implement https://github.com/hypered/curiosity/blob/2ab9c94b040e9e39e3a5586b4026d062e552fbcb/scenarios/quotation-flow.golden

This means this add the following commands:

- forms quotation new
- forms quotation validate
- forms quotation submit
- quotation sign
- invoice emit --from
- reminder send
- payment match

And the follow new data types:

- `Quotation`
- `Order`
- `RemittanceAdv`
- `Email`

Unrelated to the above scenario, there is also a new `Demand` data type (see its module description) and the simple contract form has been augmented.