### PR TITLE
Add logging to the reset operation

### DIFF
--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -118,6 +118,7 @@ library
     Curiosity.Html.Legal
     Curiosity.Html.Misc
     Curiosity.Html.Navbar
+    Curiosity.Html.Quotation
     Curiosity.Html.Run
     Curiosity.Html.SimpleContract
     Curiosity.Html.User

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -187,6 +187,7 @@ test-suite curiosity-tests
     , QuickCheck
   other-modules:
       CuriositySpec
+    , Curiosity.CoreSpec
     , Curiosity.DataSpec
     , Curiosity.RunSpec
     , Curiosity.RuntimeSpec

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -90,6 +90,7 @@ library
   hs-source-dirs: src
   exposed-modules:
     Curiosity.Command
+    Curiosity.Core
     Curiosity.Data
     Curiosity.Data.Business
     Curiosity.Data.Command

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -30,7 +30,7 @@ module Curiosity.Core
 
 import qualified Control.Concurrent.STM        as STM
 import           Control.Lens
-import qualified Curiosity.Data                as Data
+import           Curiosity.Data
 import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Counter        as C
 import qualified Curiosity.Data.Email          as Email
@@ -45,58 +45,108 @@ import qualified Language.Haskell.TH.Syntax    as Syntax
 
 
 --------------------------------------------------------------------------------
-type StmDb runtime = Data.Db STM.TVar runtime
-
+-- brittany-disable-next-binding
 reset :: StmDb runtime -> STM ()
-reset = Data.resetStmDb'
+reset stmDb = do
+  C.writeCounter (_dbNextBusinessId stmDb) seedNextBusinessId
+  STM.writeTVar (_dbBusinessUnits stmDb) seedBusinessUnits
+  C.writeCounter (_dbNextLegalId stmDb) seedNextLegalId
+  STM.writeTVar (_dbLegalEntities stmDb) seedLegalEntities
+  C.writeCounter (_dbNextUserId stmDb) seedNextUserId
+  STM.writeTVar (_dbUserProfiles stmDb) seedProfiles
+  C.writeCounter (_dbNextQuotationId stmDb) seedNextQuotationId
+  STM.writeTVar (_dbQuotations stmDb) seedQuotations
+  C.writeCounter (_dbNextOrderId stmDb) seedNextOrderId
+  STM.writeTVar (_dbOrders stmDb) seedOrders
+  C.writeCounter (_dbNextInvoiceId stmDb) seedNextInvoiceId
+  STM.writeTVar (_dbInvoices stmDb) seedInvoices
+  C.writeCounter (_dbNextRemittanceAdvId stmDb) seedNextRemittanceAdvId
+  STM.writeTVar (_dbRemittanceAdvs stmDb) seedRemittanceAdvs
+  C.writeCounter (_dbNextEmploymentId stmDb) seedNextEmploymentId
+  STM.writeTVar (_dbEmployments stmDb) seedEmployments
+
+  STM.writeTVar (_dbRandomGenState stmDb) seedRandomGenState
+  STM.writeTVar (_dbFormCreateQuotationAll stmDb) seedFormCreateQuotationAll
+  STM.writeTVar (_dbFormCreateContractAll stmDb) seedFormCreateContractAll
+  STM.writeTVar (_dbFormCreateSimpleContractAll stmDb)
+                seedFormCreateSimpleContractAll
+
+  C.writeCounter (_dbNextEmailId stmDb) seedNextEmailId
+  STM.writeTVar (_dbEmails stmDb) seedEmails
+ where
+  Db
+    { _dbNextBusinessId = C.CounterValue (Identity seedNextBusinessId)
+    , _dbBusinessUnits = Identity seedBusinessUnits
+    , _dbNextLegalId = C.CounterValue (Identity seedNextLegalId)
+    , _dbLegalEntities = Identity seedLegalEntities
+    , _dbNextUserId = C.CounterValue (Identity seedNextUserId)
+    , _dbUserProfiles = Identity seedProfiles
+    , _dbNextQuotationId = C.CounterValue (Identity seedNextQuotationId)
+    , _dbQuotations = Identity seedQuotations
+    , _dbNextOrderId = C.CounterValue (Identity seedNextOrderId)
+    , _dbOrders = Identity seedOrders
+    , _dbNextInvoiceId = C.CounterValue (Identity seedNextInvoiceId)
+    , _dbInvoices = Identity seedInvoices
+    , _dbNextRemittanceAdvId = C.CounterValue (Identity seedNextRemittanceAdvId)
+    , _dbRemittanceAdvs = Identity seedRemittanceAdvs
+    , _dbNextEmploymentId = C.CounterValue (Identity seedNextEmploymentId)
+    , _dbEmployments = Identity seedEmployments
+    , _dbRandomGenState = Identity seedRandomGenState
+    , _dbFormCreateQuotationAll = Identity seedFormCreateQuotationAll
+    , _dbFormCreateContractAll = Identity seedFormCreateContractAll
+    , _dbFormCreateSimpleContractAll = Identity seedFormCreateSimpleContractAll
+    , _dbNextEmailId = C.CounterValue (Identity seedNextEmailId)
+    , _dbEmails = Identity seedEmails
+    }
+    = emptyHask
 
 
 --------------------------------------------------------------------------------
-generateUserId :: forall runtime . Data.StmDb runtime -> STM User.UserId
-generateUserId Data.Db {..} =
+generateUserId :: forall runtime . StmDb runtime -> STM User.UserId
+generateUserId Db {..} =
   User.UserId <$> C.bumpCounterPrefix User.userIdPrefix _dbNextUserId
 
 generateBusinessId
-  :: forall runtime . Data.StmDb runtime -> STM Business.UnitId
-generateBusinessId Data.Db {..} =
+  :: forall runtime . StmDb runtime -> STM Business.UnitId
+generateBusinessId Db {..} =
   Business.UnitId
     <$> C.bumpCounterPrefix Business.unitIdPrefix _dbNextBusinessId
 
-generateLegalId :: forall runtime . Data.StmDb runtime -> STM Legal.EntityId
-generateLegalId Data.Db {..} =
+generateLegalId :: forall runtime . StmDb runtime -> STM Legal.EntityId
+generateLegalId Db {..} =
   Legal.EntityId <$> C.bumpCounterPrefix Legal.entityIdPrefix _dbNextLegalId
 
 generateQuotationId
-  :: forall runtime . Data.StmDb runtime -> STM Quotation.QuotationId
-generateQuotationId Data.Db {..} =
+  :: forall runtime . StmDb runtime -> STM Quotation.QuotationId
+generateQuotationId Db {..} =
   Quotation.QuotationId
     <$> C.bumpCounterPrefix Quotation.quotationIdPrefix _dbNextQuotationId
 
-generateOrderId :: forall runtime . Data.StmDb runtime -> STM Order.OrderId
-generateOrderId Data.Db {..} =
+generateOrderId :: forall runtime . StmDb runtime -> STM Order.OrderId
+generateOrderId Db {..} =
   Order.OrderId <$> C.bumpCounterPrefix Order.orderIdPrefix _dbNextOrderId
 
 generateRemittanceAdvId
-  :: forall runtime . Data.StmDb runtime -> STM RemittanceAdv.RemittanceAdvId
-generateRemittanceAdvId Data.Db {..} =
+  :: forall runtime . StmDb runtime -> STM RemittanceAdv.RemittanceAdvId
+generateRemittanceAdvId Db {..} =
   RemittanceAdv.RemittanceAdvId
     <$> C.bumpCounterPrefix RemittanceAdv.remittanceAdvIdPrefix
                             _dbNextRemittanceAdvId
 
 generateEmploymentId
-  :: forall runtime . Data.StmDb runtime -> STM Employment.ContractId
-generateEmploymentId Data.Db {..} =
+  :: forall runtime . StmDb runtime -> STM Employment.ContractId
+generateEmploymentId Db {..} =
   Employment.ContractId
     <$> C.bumpCounterPrefix Employment.contractIdPrefix _dbNextEmploymentId
 
 generateInvoiceId
-  :: forall runtime . Data.StmDb runtime -> STM Invoice.InvoiceId
-generateInvoiceId Data.Db {..} =
+  :: forall runtime . StmDb runtime -> STM Invoice.InvoiceId
+generateInvoiceId Db {..} =
   Invoice.InvoiceId
     <$> C.bumpCounterPrefix Invoice.invoiceIdPrefix _dbNextInvoiceId
 
-generateEmailId :: forall runtime . Data.StmDb runtime -> STM Email.EmailId
-generateEmailId Data.Db {..} =
+generateEmailId :: forall runtime . StmDb runtime -> STM Email.EmailId
+generateEmailId Db {..} =
   Email.EmailId <$> C.bumpCounterPrefix Email.emailIdPrefix _dbNextEmailId
 
 
@@ -111,7 +161,7 @@ firstUserRights = [User.CanCreateContracts, User.CanVerifyEmailAddr]
 --------------------------------------------------------------------------------
 createUser
   :: forall runtime
-   . Data.StmDb runtime
+   . StmDb runtime
   -> User.Signup
   -> STM (Either User.UserErr User.UserId)
 createUser db User.Signup {..} = do
@@ -137,7 +187,7 @@ createUser db User.Signup {..} = do
 
 createUserFull
   :: forall runtime
-   . Data.StmDb runtime
+   . StmDb runtime
   -> User.UserProfile
   -> STM (Either User.UserErr User.UserId)
 createUserFull db newProfile = if username `elem` User.usernameBlocklist
@@ -161,14 +211,14 @@ createUserFull db newProfile = if username `elem` User.usernameBlocklist
 
 modifyUsers
   :: forall runtime
-   . Data.StmDb runtime
+   . StmDb runtime
   -> ([User.UserProfile] -> [User.UserProfile])
   -> STM ()
 modifyUsers db f =
-  let usersTVar = Data._dbUserProfiles db in STM.modifyTVar usersTVar f
+  let usersTVar = _dbUserProfiles db in STM.modifyTVar usersTVar f
 
 selectUserById db id = do
-  let usersTVar = Data._dbUserProfiles db
+  let usersTVar = _dbUserProfiles db
   STM.readTVar usersTVar <&> find ((== id) . User._userProfileId)
 
 selectUserByUsername
@@ -177,7 +227,7 @@ selectUserByUsername
   -> User.UserName
   -> STM (Maybe User.UserProfile)
 selectUserByUsername db username = do
-  let usersTVar = Data._dbUserProfiles db
+  let usersTVar = _dbUserProfiles db
   users' <- STM.readTVar usersTVar
   pure $ find ((== username) . User._userCredsName . User._userProfileCreds)
               users'
@@ -186,7 +236,7 @@ selectUserByUsername db username = do
 --------------------------------------------------------------------------------
 createBusiness
   :: forall runtime
-   . Data.StmDb runtime
+   . StmDb runtime
   -> Business.Create
   -> STM (Either Business.Err Business.UnitId)
 createBusiness db Business.Create {..} = do
@@ -199,7 +249,7 @@ createBusiness db Business.Create {..} = do
 
 createBusinessFull
   :: forall runtime
-   . Data.StmDb runtime
+   . StmDb runtime
   -> Business.Unit
   -> STM (Either Business.Err Business.UnitId)
 createBusinessFull db new = do
@@ -208,7 +258,7 @@ createBusinessFull db new = do
 
 updateBusiness
   :: forall runtime
-   . Data.StmDb runtime
+   . StmDb runtime
   -> Business.Update
   -> STM (Either Business.Err ())
 updateBusiness db Business.Update {..} = do
@@ -228,22 +278,22 @@ updateBusiness db Business.Update {..} = do
 
 modifyBusinessUnits
   :: forall runtime
-   . Data.StmDb runtime
+   . StmDb runtime
   -> ([Business.Unit] -> [Business.Unit])
   -> STM ()
 modifyBusinessUnits db f =
-  let tvar = Data._dbBusinessUnits db in STM.modifyTVar tvar f
+  let tvar = _dbBusinessUnits db in STM.modifyTVar tvar f
 
 selectUnitBySlug
-  :: forall runtime . Data.StmDb runtime -> Text -> STM (Maybe Business.Unit)
+  :: forall runtime . StmDb runtime -> Text -> STM (Maybe Business.Unit)
 selectUnitBySlug db name = do
-  let tvar = Data._dbBusinessUnits db
+  let tvar = _dbBusinessUnits db
   records <- STM.readTVar tvar
   pure $ find ((== name) . Business._entitySlug) records
 
 
 --------------------------------------------------------------------------------
-canPerform :: Syntax.Name -> Data.StmDb runtime -> User.UserProfile -> STM Bool
+canPerform :: Syntax.Name -> StmDb runtime -> User.UserProfile -> STM Bool
 canPerform action _ User.UserProfile {..}
   | action == 'User.SetUserEmailAddrAsVerified
   = pure $ User.CanVerifyEmailAddr `elem` _userProfileRights

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -8,6 +8,7 @@ module Curiosity.Core
     instantiateEmptyStmDb
   , instantiateStmDb
   , reset
+  , readFullStmDbInHask'
   , createUser
   , createUserFull
   , modifyUsers
@@ -163,6 +164,38 @@ reset stmDb = do
     , _dbEmails = Identity seedEmails
     }
     = emptyHask
+
+-- | Reads all values of the `Db` product type from `STM.STM` to @Hask@.
+readFullStmDbInHask' :: StmDb runtime -> STM (HaskDb runtime)
+readFullStmDbInHask' stmDb = do
+  _dbNextBusinessId         <- pure <$> C.readCounter (_dbNextBusinessId stmDb)
+  _dbBusinessUnits          <- pure <$> STM.readTVar (_dbBusinessUnits stmDb)
+  _dbNextLegalId            <- pure <$> C.readCounter (_dbNextLegalId stmDb)
+  _dbLegalEntities          <- pure <$> STM.readTVar (_dbLegalEntities stmDb)
+  _dbNextUserId             <- pure <$> C.readCounter (_dbNextUserId stmDb)
+  _dbUserProfiles           <- pure <$> STM.readTVar (_dbUserProfiles stmDb)
+  _dbNextQuotationId        <- pure <$> C.readCounter (_dbNextQuotationId stmDb)
+  _dbQuotations             <- pure <$> STM.readTVar (_dbQuotations stmDb)
+  _dbNextOrderId            <- pure <$> C.readCounter (_dbNextOrderId stmDb)
+  _dbOrders                 <- pure <$> STM.readTVar (_dbOrders stmDb)
+  _dbNextInvoiceId          <- pure <$> C.readCounter (_dbNextInvoiceId stmDb)
+  _dbInvoices               <- pure <$> STM.readTVar (_dbInvoices stmDb)
+  _dbNextRemittanceAdvId    <- pure <$> C.readCounter (_dbNextRemittanceAdvId stmDb)
+  _dbRemittanceAdvs         <- pure <$> STM.readTVar (_dbRemittanceAdvs stmDb)
+  _dbNextEmploymentId       <- pure <$> C.readCounter (_dbNextEmploymentId stmDb)
+  _dbEmployments            <- pure <$> STM.readTVar (_dbEmployments stmDb)
+
+  _dbRandomGenState         <- pure <$> STM.readTVar (_dbRandomGenState stmDb)
+  _dbFormCreateQuotationAll <- pure
+    <$> STM.readTVar (_dbFormCreateQuotationAll stmDb)
+  _dbFormCreateContractAll  <- pure
+    <$> STM.readTVar (_dbFormCreateContractAll stmDb)
+  _dbFormCreateSimpleContractAll <- pure
+    <$> STM.readTVar (_dbFormCreateSimpleContractAll stmDb)
+
+  _dbNextEmailId            <- pure <$> C.readCounter (_dbNextEmailId stmDb)
+  _dbEmails                 <- pure <$> STM.readTVar (_dbEmails stmDb)
+  pure Db { .. }
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -10,13 +10,29 @@ module Curiosity.Core
   , canPerform
   -- * ID generation
   , generateUserId
+  , generateBusinessId
+  , generateLegalId
+  , generateQuotationId
+  , generateOrderId
+  , generateRemittanceAdvId
+  , generateEmploymentId
+  , generateInvoiceId
+  , generateEmailId
   , firstUserId
   ) where
 
 import qualified Control.Concurrent.STM        as STM
 import           Control.Lens
 import qualified Curiosity.Data                as Data
+import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Counter        as C
+import qualified Curiosity.Data.Email          as Email
+import qualified Curiosity.Data.Employment     as Employment
+import qualified Curiosity.Data.Invoice        as Invoice
+import qualified Curiosity.Data.Legal          as Legal
+import qualified Curiosity.Data.Order          as Order
+import qualified Curiosity.Data.Quotation      as Quotation
+import qualified Curiosity.Data.RemittanceAdv  as RemittanceAdv
 import qualified Curiosity.Data.User           as User
 import qualified Language.Haskell.TH.Syntax    as Syntax
 
@@ -33,6 +49,46 @@ generateUserId :: forall runtime . Data.StmDb runtime -> STM User.UserId
 generateUserId Data.Db {..} =
   User.UserId <$> C.bumpCounterPrefix User.userIdPrefix _dbNextUserId
 
+generateBusinessId
+  :: forall runtime . Data.StmDb runtime -> STM Business.UnitId
+generateBusinessId Data.Db {..} =
+  Business.UnitId <$> C.bumpCounterPrefix "BENT-" _dbNextBusinessId
+
+generateLegalId :: forall runtime . Data.StmDb runtime -> STM Legal.EntityId
+generateLegalId Data.Db {..} =
+  Legal.EntityId <$> C.bumpCounterPrefix "LENT-" _dbNextLegalId
+
+generateQuotationId
+  :: forall runtime . Data.StmDb runtime -> STM Quotation.QuotationId
+generateQuotationId Data.Db {..} =
+  Quotation.QuotationId <$> C.bumpCounterPrefix "QUOT-" _dbNextQuotationId
+
+generateOrderId :: forall runtime . Data.StmDb runtime -> STM Order.OrderId
+generateOrderId Data.Db {..} =
+  Order.OrderId <$> C.bumpCounterPrefix "ORD-" _dbNextOrderId
+
+generateRemittanceAdvId
+  :: forall runtime . Data.StmDb runtime -> STM RemittanceAdv.RemittanceAdvId
+generateRemittanceAdvId Data.Db {..} =
+  RemittanceAdv.RemittanceAdvId
+    <$> C.bumpCounterPrefix "REM-" _dbNextRemittanceAdvId
+
+generateEmploymentId
+  :: forall runtime . Data.StmDb runtime -> STM Employment.ContractId
+generateEmploymentId Data.Db {..} =
+  Employment.ContractId <$> C.bumpCounterPrefix "EMP-" _dbNextEmploymentId
+
+generateInvoiceId
+  :: forall runtime . Data.StmDb runtime -> STM Invoice.InvoiceId
+generateInvoiceId Data.Db {..} =
+  Invoice.InvoiceId <$> C.bumpCounterPrefix "INV-" _dbNextInvoiceId
+
+generateEmailId :: forall runtime . Data.StmDb runtime -> STM Email.EmailId
+generateEmailId Data.Db {..} =
+  Email.EmailId <$> C.bumpCounterPrefix "EMAIL-" _dbNextEmailId
+
+
+--------------------------------------------------------------------------------
 firstUserId :: User.UserId
 firstUserId = User.UserId $ User.userIdPrefix <> "1"
 

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -52,40 +52,45 @@ generateUserId Data.Db {..} =
 generateBusinessId
   :: forall runtime . Data.StmDb runtime -> STM Business.UnitId
 generateBusinessId Data.Db {..} =
-  Business.UnitId <$> C.bumpCounterPrefix "BENT-" _dbNextBusinessId
+  Business.UnitId
+    <$> C.bumpCounterPrefix Business.unitIdPrefix _dbNextBusinessId
 
 generateLegalId :: forall runtime . Data.StmDb runtime -> STM Legal.EntityId
 generateLegalId Data.Db {..} =
-  Legal.EntityId <$> C.bumpCounterPrefix "LENT-" _dbNextLegalId
+  Legal.EntityId <$> C.bumpCounterPrefix Legal.entityIdPrefix _dbNextLegalId
 
 generateQuotationId
   :: forall runtime . Data.StmDb runtime -> STM Quotation.QuotationId
 generateQuotationId Data.Db {..} =
-  Quotation.QuotationId <$> C.bumpCounterPrefix "QUOT-" _dbNextQuotationId
+  Quotation.QuotationId
+    <$> C.bumpCounterPrefix Quotation.quotationIdPrefix _dbNextQuotationId
 
 generateOrderId :: forall runtime . Data.StmDb runtime -> STM Order.OrderId
 generateOrderId Data.Db {..} =
-  Order.OrderId <$> C.bumpCounterPrefix "ORD-" _dbNextOrderId
+  Order.OrderId <$> C.bumpCounterPrefix Order.orderIdPrefix _dbNextOrderId
 
 generateRemittanceAdvId
   :: forall runtime . Data.StmDb runtime -> STM RemittanceAdv.RemittanceAdvId
 generateRemittanceAdvId Data.Db {..} =
   RemittanceAdv.RemittanceAdvId
-    <$> C.bumpCounterPrefix "REM-" _dbNextRemittanceAdvId
+    <$> C.bumpCounterPrefix RemittanceAdv.remittanceAdvIdPrefix
+                            _dbNextRemittanceAdvId
 
 generateEmploymentId
   :: forall runtime . Data.StmDb runtime -> STM Employment.ContractId
 generateEmploymentId Data.Db {..} =
-  Employment.ContractId <$> C.bumpCounterPrefix "EMP-" _dbNextEmploymentId
+  Employment.ContractId
+    <$> C.bumpCounterPrefix Employment.contractIdPrefix _dbNextEmploymentId
 
 generateInvoiceId
   :: forall runtime . Data.StmDb runtime -> STM Invoice.InvoiceId
 generateInvoiceId Data.Db {..} =
-  Invoice.InvoiceId <$> C.bumpCounterPrefix "INV-" _dbNextInvoiceId
+  Invoice.InvoiceId
+    <$> C.bumpCounterPrefix Invoice.invoiceIdPrefix _dbNextInvoiceId
 
 generateEmailId :: forall runtime . Data.StmDb runtime -> STM Email.EmailId
 generateEmailId Data.Db {..} =
-  Email.EmailId <$> C.bumpCounterPrefix "EMAIL-" _dbNextEmailId
+  Email.EmailId <$> C.bumpCounterPrefix Email.emailIdPrefix _dbNextEmailId
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE TemplateHaskell #-}
+-- | STM operations around `Curiosity.Data`.
+module Curiosity.Core
+  ( reset
+  , createUser
+  , createUserFull
+  , modifyUsers
+  , selectUserById
+  , selectUserByUsername
+  , canPerform
+  -- * ID generation
+  , generateUserId
+  , firstUserId
+  ) where
+
+import qualified Control.Concurrent.STM        as STM
+import           Control.Lens
+import qualified Curiosity.Data                as Data
+import qualified Curiosity.Data.Counter        as C
+import qualified Curiosity.Data.User           as User
+import qualified Language.Haskell.TH.Syntax    as Syntax
+
+
+--------------------------------------------------------------------------------
+type StmDb runtime = Data.Db STM.TVar runtime
+
+reset :: StmDb runtime -> STM ()
+reset = Data.resetStmDb'
+
+
+--------------------------------------------------------------------------------
+generateUserId :: forall runtime . Data.StmDb runtime -> STM User.UserId
+generateUserId Data.Db {..} =
+  User.UserId <$> C.bumpCounterPrefix User.userIdPrefix _dbNextUserId
+
+firstUserId :: User.UserId
+firstUserId = User.UserId $ User.userIdPrefix <> "1"
+
+firstUserRights :: [User.AccessRight]
+firstUserRights = [User.CanCreateContracts, User.CanVerifyEmailAddr]
+
+
+--------------------------------------------------------------------------------
+createUser
+  :: forall runtime
+   . Data.StmDb runtime
+  -> User.Signup
+  -> STM (Either User.UserErr User.UserId)
+createUser db User.Signup {..} = do
+  STM.catchSTM (Right <$> transaction) (pure . Left)
+ where
+  transaction = do
+    newId <- generateUserId db
+    let newProfile = User.UserProfile
+          newId
+          (User.Credentials username password)
+          Nothing
+          Nothing
+          email
+          Nothing
+          tosConsent
+          (User.UserCompletion1 Nothing Nothing Nothing)
+          (User.UserCompletion2 Nothing Nothing)
+          -- The very first user has plenty of rights:
+          (if newId == firstUserId then firstUserRights else [])
+    -- We fail the transaction if createUserFull returns an error,
+    -- so that we don't increment _dbNextUserId.
+    createUserFull db newProfile >>= either STM.throwSTM pure
+
+createUserFull
+  :: forall runtime
+   . Data.StmDb runtime
+  -> User.UserProfile
+  -> STM (Either User.UserErr User.UserId)
+createUserFull db newProfile = if username `elem` User.usernameBlocklist
+  then pure . Left $ User.UsernameBlocked
+  else do
+    mprofile <- selectUserById db newProfileId
+    case mprofile of
+      Just _  -> existsErr
+      Nothing -> createNew
+ where
+  username     = newProfile ^. User.userProfileCreds . User.userCredsName
+  newProfileId = User._userProfileId newProfile
+  createNew    = do
+    mprofile <- selectUserByUsername db username
+    case mprofile of
+      Just _  -> existsErr
+      Nothing -> do
+        modifyUsers db (++ [newProfile])
+        pure $ Right newProfileId
+  existsErr = pure . Left $ User.UserExists
+
+modifyUsers
+  :: forall runtime
+   . Data.StmDb runtime
+  -> ([User.UserProfile] -> [User.UserProfile])
+  -> STM ()
+modifyUsers db f =
+  let usersTVar = Data._dbUserProfiles db in STM.modifyTVar usersTVar f
+
+selectUserById db id = do
+  let usersTVar = Data._dbUserProfiles db
+  STM.readTVar usersTVar <&> find ((== id) . User._userProfileId)
+
+selectUserByUsername
+  :: forall runtime
+   . StmDb runtime
+  -> User.UserName
+  -> STM (Maybe User.UserProfile)
+selectUserByUsername db username = do
+  let usersTVar = Data._dbUserProfiles db
+  users' <- STM.readTVar usersTVar
+  pure $ find ((== username) . User._userCredsName . User._userProfileCreds)
+              users'
+
+
+--------------------------------------------------------------------------------
+canPerform :: Syntax.Name -> Data.StmDb runtime -> User.UserProfile -> STM Bool
+canPerform action _ User.UserProfile {..}
+  | action == 'User.SetUserEmailAddrAsVerified
+  = pure $ User.CanVerifyEmailAddr `elem` _userProfileRights
+  | otherwise
+  = pure False

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -10,10 +10,6 @@ module Curiosity.Data
   , RuntimeHasStmDb(..)
   -- * Instantiating databases.
   , emptyHask
-  -- * Reading values from the database.
-  , readFullStmDbInHaskFromRuntime
-  , readFullStmDbInHask
-  , readFullStmDbInHask'
   -- * Serialising and deseralising DB to bytes.
   , serialiseDb
   , deserialiseDb
@@ -133,50 +129,6 @@ emptyHask = Db (pure 1)
                (pure mempty)
 
 initialGenState = randomGenState 42 -- Deterministic initial seed.
-
--- | Reads all values of the `Db` product type from `STM.STM` to @Hask@.
-readFullStmDbInHaskFromRuntime
-  :: forall runtime m
-   . (MonadIO m, RuntimeHasStmDb runtime)
-  => runtime
-  -> m (HaskDb runtime)
-readFullStmDbInHaskFromRuntime = readFullStmDbInHask . stmDbFromRuntime
-{-# INLINE readFullStmDbInHaskFromRuntime #-}
-
--- | Reads all values of the `Db` product type from `STM.STM` to @Hask@.
-readFullStmDbInHask
-  :: forall runtime m . MonadIO m => StmDb runtime -> m (HaskDb runtime)
-readFullStmDbInHask = liftIO . STM.atomically . readFullStmDbInHask'
-
-readFullStmDbInHask' stmDb = do
-  _dbNextBusinessId         <- pure <$> C.readCounter (_dbNextBusinessId stmDb)
-  _dbBusinessUnits          <- pure <$> STM.readTVar (_dbBusinessUnits stmDb)
-  _dbNextLegalId            <- pure <$> C.readCounter (_dbNextLegalId stmDb)
-  _dbLegalEntities          <- pure <$> STM.readTVar (_dbLegalEntities stmDb)
-  _dbNextUserId             <- pure <$> C.readCounter (_dbNextUserId stmDb)
-  _dbUserProfiles           <- pure <$> STM.readTVar (_dbUserProfiles stmDb)
-  _dbNextQuotationId        <- pure <$> C.readCounter (_dbNextQuotationId stmDb)
-  _dbQuotations             <- pure <$> STM.readTVar (_dbQuotations stmDb)
-  _dbNextOrderId            <- pure <$> C.readCounter (_dbNextOrderId stmDb)
-  _dbOrders                 <- pure <$> STM.readTVar (_dbOrders stmDb)
-  _dbNextInvoiceId          <- pure <$> C.readCounter (_dbNextInvoiceId stmDb)
-  _dbInvoices               <- pure <$> STM.readTVar (_dbInvoices stmDb)
-  _dbNextRemittanceAdvId    <- pure <$> C.readCounter (_dbNextRemittanceAdvId stmDb)
-  _dbRemittanceAdvs         <- pure <$> STM.readTVar (_dbRemittanceAdvs stmDb)
-  _dbNextEmploymentId       <- pure <$> C.readCounter (_dbNextEmploymentId stmDb)
-  _dbEmployments            <- pure <$> STM.readTVar (_dbEmployments stmDb)
-
-  _dbRandomGenState         <- pure <$> STM.readTVar (_dbRandomGenState stmDb)
-  _dbFormCreateQuotationAll <- pure
-    <$> STM.readTVar (_dbFormCreateQuotationAll stmDb)
-  _dbFormCreateContractAll  <- pure
-    <$> STM.readTVar (_dbFormCreateContractAll stmDb)
-  _dbFormCreateSimpleContractAll <- pure
-    <$> STM.readTVar (_dbFormCreateSimpleContractAll stmDb)
-
-  _dbNextEmailId            <- pure <$> C.readCounter (_dbNextEmailId stmDb)
-  _dbEmails                 <- pure <$> STM.readTVar (_dbEmails stmDb)
-  pure Db { .. }
 
 {- | Provides us with the ability to constrain on a larger product-type (the
 @runtime@) to contain, in some form or another, a value of the `StmDb`, which

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -10,8 +10,6 @@ module Curiosity.Data
   , RuntimeHasStmDb(..)
   -- * Instantiating databases.
   , emptyHask
-  , instantiateStmDb
-  , instantiateEmptyStmDb
   -- * Reading values from the database.
   , readFullStmDbInHaskFromRuntime
   , readFullStmDbInHask
@@ -135,43 +133,6 @@ emptyHask = Db (pure 1)
                (pure mempty)
 
 initialGenState = randomGenState 42 -- Deterministic initial seed.
-
-instantiateStmDb
-  :: forall runtime m . MonadIO m => HaskDb runtime -> m (StmDb runtime)
-instantiateStmDb Db { _dbNextBusinessId = C.CounterValue (Identity seedNextBusinessId), _dbBusinessUnits = Identity seedBusinessUnits, _dbNextLegalId = C.CounterValue (Identity seedNextLegalId), _dbLegalEntities = Identity seedLegalEntities, _dbNextUserId = C.CounterValue (Identity seedNextUserId), _dbUserProfiles = Identity seedProfiles, _dbNextQuotationId = C.CounterValue (Identity seedNextQuotationId), _dbQuotations = Identity seedQuotations, _dbNextOrderId = C.CounterValue (Identity seedNextOrderId), _dbOrders = Identity seedOrders, _dbNextInvoiceId = C.CounterValue (Identity seedNextInvoiceId), _dbInvoices = Identity seedInvoices, _dbNextRemittanceAdvId = C.CounterValue (Identity seedNextRemittanceAdvId), _dbRemittanceAdvs = Identity seedRemittanceAdvs, _dbNextEmploymentId = C.CounterValue (Identity seedNextEmploymentId), _dbEmployments = Identity seedEmployments, _dbRandomGenState = Identity seedRandomGenState, _dbFormCreateQuotationAll = Identity seedFormCreateQuotationAll, _dbFormCreateContractAll = Identity seedFormCreateContractAll, _dbFormCreateSimpleContractAll = Identity seedFormCreateSimpleContractAll, _dbNextEmailId = C.CounterValue (Identity seedNextEmailId), _dbEmails = Identity seedEmails }
-  =
-  -- We don't use `newTVarIO` repeatedly under here and instead wrap the whole
-  -- instantiation under a single STM transaction (@atomically@).
-    liftIO . STM.atomically $ do
-    _dbNextBusinessId              <- C.newCounter seedNextBusinessId
-    _dbBusinessUnits               <- STM.newTVar seedBusinessUnits
-    _dbNextLegalId                 <- C.newCounter seedNextLegalId
-    _dbLegalEntities               <- STM.newTVar seedLegalEntities
-    _dbNextUserId                  <- C.newCounter seedNextUserId
-    _dbUserProfiles                <- STM.newTVar seedProfiles
-    _dbNextQuotationId             <- C.newCounter seedNextQuotationId
-    _dbQuotations                  <- STM.newTVar seedQuotations
-    _dbNextOrderId                 <- C.newCounter seedNextOrderId
-    _dbOrders                      <- STM.newTVar seedOrders
-    _dbNextInvoiceId               <- C.newCounter seedNextInvoiceId
-    _dbInvoices                    <- STM.newTVar seedInvoices
-    _dbNextRemittanceAdvId         <- C.newCounter seedNextRemittanceAdvId
-    _dbRemittanceAdvs              <- STM.newTVar seedRemittanceAdvs
-    _dbNextEmploymentId            <- C.newCounter seedNextEmploymentId
-    _dbEmployments                 <- STM.newTVar seedEmployments
-
-    _dbRandomGenState              <- STM.newTVar seedRandomGenState
-    _dbFormCreateQuotationAll      <- STM.newTVar seedFormCreateQuotationAll
-    _dbFormCreateContractAll       <- STM.newTVar seedFormCreateContractAll
-    _dbFormCreateSimpleContractAll <- STM.newTVar
-      seedFormCreateSimpleContractAll
-
-    _dbNextEmailId                 <- C.newCounter seedNextEmailId
-    _dbEmails                      <- STM.newTVar seedEmails
-    pure Db { .. }
-
-instantiateEmptyStmDb :: forall runtime m . MonadIO m => m (StmDb runtime)
-instantiateEmptyStmDb = instantiateStmDb emptyHask
 
 -- | Reads all values of the `Db` product type from `STM.STM` to @Hask@.
 readFullStmDbInHaskFromRuntime

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -12,7 +12,6 @@ module Curiosity.Data
   , emptyHask
   , instantiateStmDb
   , instantiateEmptyStmDb
-  , resetStmDb'
   -- * Reading values from the database.
   , readFullStmDbInHaskFromRuntime
   , readFullStmDbInHask
@@ -173,36 +172,6 @@ instantiateStmDb Db { _dbNextBusinessId = C.CounterValue (Identity seedNextBusin
 
 instantiateEmptyStmDb :: forall runtime m . MonadIO m => m (StmDb runtime)
 instantiateEmptyStmDb = instantiateStmDb emptyHask
-
-resetStmDb' stmDb = do
-  C.writeCounter (_dbNextBusinessId stmDb) seedNextBusinessId
-  STM.writeTVar (_dbBusinessUnits stmDb) seedBusinessUnits
-  C.writeCounter (_dbNextLegalId stmDb) seedNextLegalId
-  STM.writeTVar (_dbLegalEntities stmDb) seedLegalEntities
-  C.writeCounter (_dbNextUserId stmDb) seedNextUserId
-  STM.writeTVar (_dbUserProfiles stmDb) seedProfiles
-  C.writeCounter (_dbNextQuotationId stmDb) seedNextQuotationId
-  STM.writeTVar (_dbQuotations stmDb) seedQuotations
-  C.writeCounter (_dbNextOrderId stmDb) seedNextOrderId
-  STM.writeTVar (_dbOrders stmDb) seedOrders
-  C.writeCounter (_dbNextInvoiceId stmDb) seedNextInvoiceId
-  STM.writeTVar (_dbInvoices stmDb) seedInvoices
-  C.writeCounter (_dbNextRemittanceAdvId stmDb) seedNextRemittanceAdvId
-  STM.writeTVar (_dbRemittanceAdvs stmDb) seedRemittanceAdvs
-  C.writeCounter (_dbNextEmploymentId stmDb) seedNextEmploymentId
-  STM.writeTVar (_dbEmployments stmDb) seedEmployments
-
-  STM.writeTVar (_dbRandomGenState stmDb) seedRandomGenState
-  STM.writeTVar (_dbFormCreateQuotationAll stmDb) seedFormCreateQuotationAll
-  STM.writeTVar (_dbFormCreateContractAll stmDb) seedFormCreateContractAll
-  STM.writeTVar (_dbFormCreateSimpleContractAll stmDb)
-                seedFormCreateSimpleContractAll
-
-  C.writeCounter (_dbNextEmailId stmDb) seedNextEmailId
-  STM.writeTVar (_dbEmails stmDb) seedEmails
- where
-  Db { _dbNextBusinessId = C.CounterValue (Identity seedNextBusinessId), _dbBusinessUnits = Identity seedBusinessUnits, _dbNextLegalId = C.CounterValue (Identity seedNextLegalId), _dbLegalEntities = Identity seedLegalEntities, _dbNextUserId = C.CounterValue (Identity seedNextUserId), _dbUserProfiles = Identity seedProfiles, _dbNextQuotationId = C.CounterValue (Identity seedNextQuotationId), _dbQuotations = Identity seedQuotations, _dbNextOrderId = C.CounterValue (Identity seedNextOrderId), _dbOrders = Identity seedOrders, _dbNextInvoiceId = C.CounterValue (Identity seedNextInvoiceId), _dbInvoices = Identity seedInvoices, _dbNextRemittanceAdvId = C.CounterValue (Identity seedNextRemittanceAdvId), _dbRemittanceAdvs = Identity seedRemittanceAdvs, _dbNextEmploymentId = C.CounterValue (Identity seedNextEmploymentId), _dbEmployments = Identity seedEmployments, _dbRandomGenState = Identity seedRandomGenState, _dbFormCreateQuotationAll = Identity seedFormCreateQuotationAll, _dbFormCreateContractAll = Identity seedFormCreateContractAll, _dbFormCreateSimpleContractAll = Identity seedFormCreateSimpleContractAll, _dbNextEmailId = C.CounterValue (Identity seedNextEmailId), _dbEmails = Identity seedEmails }
-    = emptyHask
 
 -- | Reads all values of the `Db` product type from `STM.STM` to @Hask@.
 readFullStmDbInHaskFromRuntime

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -12,7 +12,6 @@ module Curiosity.Data
   , emptyHask
   , instantiateStmDb
   , instantiateEmptyStmDb
-  , resetStmDb
   , resetStmDb'
   -- * Reading values from the database.
   , readFullStmDbInHaskFromRuntime
@@ -174,11 +173,6 @@ instantiateStmDb Db { _dbNextBusinessId = C.CounterValue (Identity seedNextBusin
 
 instantiateEmptyStmDb :: forall runtime m . MonadIO m => m (StmDb runtime)
 instantiateEmptyStmDb = instantiateStmDb emptyHask
-
--- | Reset all values of the `Db` product type from `STM.STM` to the empty
--- state.
-resetStmDb :: forall runtime m . MonadIO m => StmDb runtime -> m ()
-resetStmDb = liftIO . STM.atomically . resetStmDb'
 
 resetStmDb' stmDb = do
   C.writeCounter (_dbNextBusinessId stmDb) seedNextBusinessId

--- a/src/Curiosity/Data/Business.hs
+++ b/src/Curiosity/Data/Business.hs
@@ -69,4 +69,6 @@ unitIdPrefix :: Text
 unitIdPrefix = "BENT-"
 
 data Err = Err
+  { unErr :: Text
+  }
   deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/Business.hs
+++ b/src/Curiosity/Data/Business.hs
@@ -9,6 +9,7 @@ module Curiosity.Data.Business
   , Create(..)
   , Update(..)
   , UnitId(..)
+  , unitIdPrefix
   , Err(..)
   ) where
 
@@ -63,6 +64,9 @@ newtype UnitId = UnitId { unUnitId :: Text }
                         , H.ToValue
                         ) via Text
                deriving FromForm via W.Wrapped "unit-id" Text
+
+unitIdPrefix :: Text
+unitIdPrefix = "BENT-"
 
 data Err = Err
   deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -13,6 +13,7 @@ module Curiosity.Data.Email
   ( -- * Main data representation
     Email(..)
   , EmailId(..)
+  , emailIdPrefix
   , EmailTemplate(..)
   , Err(..)
   ) where
@@ -45,6 +46,9 @@ newtype EmailId = EmailId { unEmailId :: Text }
                         , H.ToValue
                         ) via Text
                deriving FromForm via W.Wrapped "email-id" Text
+
+emailIdPrefix :: Text
+emailIdPrefix = "EMAIL-"
 
 data EmailTemplate = SignupConfirmationEmail | QuotationEmail | InvoiceEmail | InvoiceReminderEmail
   deriving (Show, Eq, Generic)

--- a/src/Curiosity/Data/Employment.hs
+++ b/src/Curiosity/Data/Employment.hs
@@ -38,6 +38,7 @@ module Curiosity.Data.Employment
     -- * Main data representation
   , Contract(..)
   , ContractId(..)
+  , contractIdPrefix
   , Err(..)
   ) where
 
@@ -232,6 +233,9 @@ newtype ContractId = ContractId { unContractId :: Text }
                         , H.ToValue
                         ) via Text
                deriving FromForm via W.Wrapped "contract-id" Text
+
+contractIdPrefix :: Text
+contractIdPrefix = "EMP-"
 
 data Err = Err Text
   deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/Invoice.hs
+++ b/src/Curiosity/Data/Invoice.hs
@@ -7,6 +7,7 @@ Description: Invoice related datatypes
 module Curiosity.Data.Invoice
   ( Invoice(..)
   , InvoiceId(..)
+  , invoiceIdPrefix
   , Err(..)
   ) where
 
@@ -33,6 +34,9 @@ newtype InvoiceId = InvoiceId { unInvoiceId :: Text }
                         , H.ToValue
                         ) via Text
                deriving FromForm via W.Wrapped "invoice-id" Text
+
+invoiceIdPrefix :: Text
+invoiceIdPrefix = "INV-"
 
 data Err = Err
   { unErr :: Text

--- a/src/Curiosity/Data/Legal.hs
+++ b/src/Curiosity/Data/Legal.hs
@@ -9,6 +9,7 @@ module Curiosity.Data.Legal
   , Create(..)
   , Update(..)
   , EntityId(..)
+  , entityIdPrefix
   , RegistrationName(..)
   , ActingUserId(..)
   , ActingUser(..)
@@ -84,6 +85,9 @@ newtype EntityId = EntityId { unEntityId :: Text }
                         , H.ToValue
                         ) via Text
                deriving FromForm via W.Wrapped "legal-id" Text
+
+entityIdPrefix :: Text
+entityIdPrefix = "LENT-"
 
 -- | A registation name.
 newtype RegistrationName = RegistrationName { unRegistrationName :: Text }

--- a/src/Curiosity/Data/Order.hs
+++ b/src/Curiosity/Data/Order.hs
@@ -12,6 +12,7 @@ module Curiosity.Data.Order
   ( -- * Main data representation
     Order(..)
   , OrderId(..)
+  , orderIdPrefix
   , Err(..)
   ) where
 
@@ -40,6 +41,9 @@ newtype OrderId = OrderId { unOrderId :: Text }
                         , H.ToValue
                         ) via Text
                deriving FromForm via W.Wrapped "order-id" Text
+
+orderIdPrefix :: Text
+orderIdPrefix = "ORD-"
 
 data Err = Err
   { unErr :: Text

--- a/src/Curiosity/Data/Quotation.hs
+++ b/src/Curiosity/Data/Quotation.hs
@@ -24,6 +24,7 @@ module Curiosity.Data.Quotation
     -- * Main data representation
   , Quotation(..)
   , QuotationId(..)
+  , quotationIdPrefix
   , Err(..)
   ) where
 
@@ -120,6 +121,9 @@ newtype QuotationId = QuotationId { unQuotationId :: Text }
                         , H.ToValue
                         ) via Text
                deriving FromForm via W.Wrapped "quotation-id" Text
+
+quotationIdPrefix :: Text
+quotationIdPrefix = "QUOT-"
 
 data Err = Err
   { unErr :: Text

--- a/src/Curiosity/Data/RemittanceAdv.hs
+++ b/src/Curiosity/Data/RemittanceAdv.hs
@@ -11,6 +11,7 @@ module Curiosity.Data.RemittanceAdv
   ( -- * Main data representation
     RemittanceAdv(..)
   , RemittanceAdvId(..)
+  , remittanceAdvIdPrefix
   , Err(..)
   ) where
 
@@ -39,6 +40,9 @@ newtype RemittanceAdvId = RemittanceAdvId { unRemittanceAdvId :: Text }
                         , H.ToValue
                         ) via Text
                deriving FromForm via W.Wrapped "remittance-advice-id" Text
+
+remittanceAdvIdPrefix :: Text
+remittanceAdvIdPrefix = "REM-"
 
 data Err = Err
   { unErr :: Text

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -18,28 +18,28 @@ module Curiosity.Dsl
   ) where
 
 import qualified Control.Concurrent.STM        as STM
+import qualified Curiosity.Core                as Core
 import qualified Curiosity.Data                as Data
 import           Curiosity.Data                 ( HaskDb
                                                 , readFullStmDbInHask'
                                                 )
 import qualified Curiosity.Data.User           as User
-import qualified Curiosity.Runtime             as Rt
 import qualified Language.Haskell.TH.Syntax    as Syntax
 import           Prelude                 hiding ( state )
 
 
 --------------------------------------------------------------------------------
-newtype Run a = Run { runM :: ReaderT (Data.StmDb Rt.Runtime) STM a }
+newtype Run a = Run { runM :: ReaderT (Data.StmDb ()) STM a }
   deriving ( Functor
            , Applicative
            , Monad
-           , MonadReader (Data.StmDb Rt.Runtime)
+           , MonadReader (Data.StmDb ())
            )
 
 -- Is it possible to implement MonadFail only when the return type is Either ?
 -- deriving instance MonadFail (Run (Either Text a))
 
-run :: forall a . HaskDb Rt.Runtime -> Run a -> IO a
+run :: forall a . HaskDb () -> Run a -> IO a
 run db Run {..} = do
   db' <- Data.instantiateStmDb db
   STM.atomically $ runReaderT runM db'
@@ -48,14 +48,14 @@ run db Run {..} = do
 --------------------------------------------------------------------------------
 db0 = Data.emptyHask
 
-state :: Run (HaskDb Rt.Runtime)
+state :: Run (HaskDb ())
 state = ask >>= (Run . lift . readFullStmDbInHask')
 
 reset :: Run ()
 reset = ask >>= (Run . lift . Data.resetStmDb')
 
 user :: User.UserName -> Run (Maybe User.UserProfile)
-user username = ask >>= (Run . lift . flip Rt.selectUserByUsername username)
+user username = ask >>= (Run . lift . flip Core.selectUserByUsername username)
 
 signup
   :: User.UserName
@@ -63,11 +63,11 @@ signup
   -> User.UserEmailAddr
   -> Run (Either User.UserErr User.UserId)
 signup username password email =
-  ask >>= (Run . lift . flip Rt.createUser input)
+  ask >>= (Run . lift . flip Core.createUser input)
   where input = User.Signup username password email True
 
 can :: User.UserProfile -> Syntax.Name -> Run Bool
-can profile name = ask >>= (Run . lift . flip (Rt.canPerform name) profile)
+can profile name = ask >>= (Run . lift . flip (Core.canPerform name) profile)
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -28,11 +28,11 @@ import           Prelude                 hiding ( state )
 
 
 --------------------------------------------------------------------------------
-newtype Run a = Run { runM :: ReaderT (Data.StmDb ()) STM a }
+newtype Run a = Run { runM :: ReaderT (Core.StmDb ()) STM a }
   deriving ( Functor
            , Applicative
            , Monad
-           , MonadReader (Data.StmDb ())
+           , MonadReader (Core.StmDb ())
            )
 
 -- Is it possible to implement MonadFail only when the return type is Either ?

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -40,9 +40,10 @@ newtype Run a = Run { runM :: ReaderT (Data.StmDb ()) STM a }
 -- deriving instance MonadFail (Run (Either Text a))
 
 run :: forall a . HaskDb () -> Run a -> IO a
-run db Run {..} = do
-  db' <- Data.instantiateStmDb db
-  STM.atomically $ runReaderT runM db'
+run db Run {..} =
+  STM.atomically $ do
+     db' <- Core.instantiateStmDb db
+     runReaderT runM db'
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -21,7 +21,6 @@ import qualified Control.Concurrent.STM        as STM
 import qualified Curiosity.Core                as Core
 import qualified Curiosity.Data                as Data
 import           Curiosity.Data                 ( HaskDb
-                                                , readFullStmDbInHask'
                                                 )
 import qualified Curiosity.Data.User           as User
 import qualified Language.Haskell.TH.Syntax    as Syntax
@@ -50,7 +49,7 @@ run db Run {..} =
 db0 = Data.emptyHask
 
 state :: Run (HaskDb ())
-state = ask >>= (Run . lift . readFullStmDbInHask')
+state = ask >>= (Run . lift . Core.readFullStmDbInHask')
 
 reset :: Run ()
 reset = ask >>= (Run . lift . Core.reset)

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -52,7 +52,7 @@ state :: Run (HaskDb ())
 state = ask >>= (Run . lift . readFullStmDbInHask')
 
 reset :: Run ()
-reset = ask >>= (Run . lift . Data.resetStmDb')
+reset = ask >>= (Run . lift . Core.reset)
 
 user :: User.UserName -> Run (Maybe User.UserProfile)
 user username = ask >>= (Run . lift . flip Core.selectUserByUsername username)

--- a/src/Curiosity/Html/Navbar.hs
+++ b/src/Curiosity/Html/Navbar.hs
@@ -48,7 +48,8 @@ plusEntry = Navbar.IconEntry divIconAdd plusEntries
 
 plusEntries :: [Navbar.SubEntry]
 plusEntries =
-  [ Navbar.SubEntry "New invoice" "/new/invoice" False
+  [ Navbar.SubEntry "New quotation" "/new/quotation" False
+  , Navbar.SubEntry "New invoice" "/new/invoice" False
   , Navbar.SubEntry "New contract" "/new/contract" False
   , Navbar.Divider
   , Navbar.SubEntry "New business entity" "/new/unit" False

--- a/src/Curiosity/Html/Quotation.hs
+++ b/src/Curiosity/Html/Quotation.hs
@@ -1,0 +1,70 @@
+{- |
+Module: Curiosity.Html.Quotation
+Description: Quotation pages (view and edit).
+-}
+module Curiosity.Html.Quotation
+  ( QuotationView(..)
+  , CreateQuotationPage(..)
+  , ConfirmQuotationPage(..)
+  ) where
+
+import qualified Curiosity.Data.Quotation      as Quotation
+import qualified Curiosity.Data.User           as User
+import           Curiosity.Html.Misc
+import qualified Text.Blaze.Html5              as H
+import           Text.Blaze.Html5               ( (!) )
+import qualified Text.Blaze.Html5.Attributes   as A
+
+
+--------------------------------------------------------------------------------
+data QuotationView = QuotationView
+  { _quotationViewQuotation     :: Quotation.Quotation
+  , _quotationViewHasEditButton :: Maybe H.AttributeValue
+  }
+
+instance H.ToMarkup QuotationView where
+  toMarkup (QuotationView quotation hasEditButton) =
+    renderView $ quotationView quotation hasEditButton
+
+quotationView quotation hasEditButton = containerLarge $ do
+  title' "Quotation" hasEditButton
+  H.dl ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short" $ do
+    keyValuePair "ID" (Quotation._quotationId quotation)
+
+
+--------------------------------------------------------------------------------
+data CreateQuotationPage = CreateQuotationPage
+  { _createQuotationPageUserProfile :: User.UserProfile
+    -- ^ The user creating the quotation
+  , _createQuotationPageKey         :: Maybe Text
+    -- ^ The form editing session key, if the form was already saved
+  , _createQuotationQuotation       :: Quotation.CreateQuotationAll
+  , _createQuotationPageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup CreateQuotationPage where
+  toMarkup (CreateQuotationPage profile mkey quotation submitUrl) =
+    renderForm profile $ groupLayout $ do
+      title "New quotation"
+      inputText "Quotation name" "name" Nothing Nothing
+      submitButton submitUrl
+        $ maybe "Create new quotation" (const "Save quotation") mkey
+
+
+--------------------------------------------------------------------------------
+data ConfirmQuotationPage = ConfirmQuotationPage
+  { _confirmQuotationPageUserProfile :: User.UserProfile
+    -- ^ The user creating the quotation
+  , _confirmQuotationPageKey         :: Text
+  , _confirmQuotationPageQuotation   :: Quotation.CreateQuotationAll
+  , _confirmQuotationPageSubmitURL   :: H.AttributeValue
+  }
+
+instance H.ToMarkup ConfirmQuotationPage where
+  toMarkup (ConfirmQuotationPage profile key (Quotation.CreateQuotationAll{}) submitUrl)
+    = renderFormLarge profile $ do
+      title' "New quotation" . Just . H.toValue $ "/edit/quotation/" <> key
+
+      H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
+        (H.toValue key)
+      button submitUrl "Submit quotation"

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -125,7 +125,7 @@ interpret' runtime user dir content nesting = go user [] 0
           A.Success command -> do
             case command of
               Command.Reset _ -> do
-                Rt.reset runtime
+                Rt.runRunM runtime $ Rt.reset
                 st <- Rt.state runtime
                 let t = trace ["Resetting to the empty state."] ExitSuccess [] st
                     acc' = acc ++ [t]

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -116,8 +116,7 @@ interpret' runtime user dir content nesting = go user [] 0
             acc' = acc ++ [t]
         go user' acc' nbr' rest
       input -> do
-        let output_ = [show ln <> ": " <> grouped]
-            result =
+        let result =
               A.execParserPure A.defaultPrefs Command.parserInfo
                 $   T.unpack
                 <$> input

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -59,7 +59,7 @@ run (Command.CommandWithTarget (Command.Reset conf) (Command.StateFileTarget pat
   = do
     runtime <-
       Rt.boot conf { P._confDbFile = Just path } >>= either throwIO pure
-    Rt.reset runtime
+    Rt.runRunM runtime $ Rt.reset
     Rt.powerdown runtime
     exitSuccess
 
@@ -323,7 +323,7 @@ repl runtime user = HL.runInputT HL.defaultSettings loop
           case command of
             -- We ignore the Configuration here. Probably this should be moved
             -- to Rt.handleCommand too.
-            Command.Reset _          -> Rt.reset runtime
+            Command.Reset _          -> Rt.runRunM runtime $ Rt.reset
             Command.Run _ scriptPath -> do
               code <- liftIO $ Inter.interpret runtime user scriptPath
               case code of

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -686,7 +686,7 @@ createBusiness db Business.Create {..} = do
   STM.catchSTM (Right <$> transaction) (pure . Left)
  where
   transaction = do
-    newId <- generateBusinessId db
+    newId <- Core.generateBusinessId db
     let new = Business.Unit newId _createSlug _createName Nothing
     createBusinessFull db new >>= either STM.throwSTM pure
 
@@ -713,11 +713,6 @@ updateBusiness db Business.Update {..} = do
       pure $ Right ()
     Nothing -> pure . Left $ User.UserNotFound _updateSlug -- TODO
 
-generateBusinessId
-  :: forall runtime . Data.StmDb runtime -> STM Business.UnitId
-generateBusinessId Data.Db {..} =
-  Business.UnitId <$> C.bumpCounterPrefix "BENT-" _dbNextBusinessId
-
 modifyBusinessUnits
   :: forall runtime
    . Data.StmDb runtime
@@ -737,7 +732,7 @@ createLegal db Legal.Create {..} = do
   STM.catchSTM (Right <$> transaction) (pure . Left)
  where
   transaction = do
-    newId <- generateLegalId db
+    newId <- Core.generateLegalId db
     let new = Legal.Entity newId
                            _createSlug
                            _createName
@@ -770,10 +765,6 @@ updateLegal db Legal.Update {..} = do
       pure $ Right ()
     Nothing -> pure . Left $ User.UserNotFound _updateSlug -- TODO
 
-generateLegalId :: forall runtime . Data.StmDb runtime -> STM Legal.EntityId
-generateLegalId Data.Db {..} =
-  Legal.EntityId <$> C.bumpCounterPrefix "LENT-" _dbNextLegalId
-
 modifyLegalEntities
   :: forall runtime
    . Data.StmDb runtime
@@ -793,7 +784,7 @@ createQuotation db _ = do
   STM.catchSTM (Right <$> transaction) (pure . Left)
  where
   transaction = do
-    newId <- generateQuotationId db
+    newId <- Core.generateQuotationId db
     let new = Quotation.Quotation newId
     createQuotationFull db new >>= either STM.throwSTM pure
 
@@ -805,11 +796,6 @@ createQuotationFull
 createQuotationFull db new = do
   modifyQuotations db (++ [new])
   pure . Right $ Quotation._quotationId new
-
-generateQuotationId
-  :: forall runtime . Data.StmDb runtime -> STM Quotation.QuotationId
-generateQuotationId Data.Db {..} =
-  Quotation.QuotationId <$> C.bumpCounterPrefix "QUOT-" _dbNextQuotationId
 
 modifyQuotations
   :: forall runtime
@@ -839,7 +825,7 @@ createOrder db = do
   STM.catchSTM (Right <$> transaction) (pure . Left)
  where
   transaction = do
-    newId <- generateOrderId db
+    newId <- Core.generateOrderId db
     let new = Order.Order newId
     createOrderFull db new >>= either STM.throwSTM pure
 
@@ -851,10 +837,6 @@ createOrderFull
 createOrderFull db new = do
   modifyOrders db (++ [new])
   pure . Right $ Order._orderId new
-
-generateOrderId :: forall runtime . Data.StmDb runtime -> STM Order.OrderId
-generateOrderId Data.Db {..} =
-  Order.OrderId <$> C.bumpCounterPrefix "ORD-" _dbNextOrderId
 
 modifyOrders
   :: forall runtime
@@ -905,7 +887,7 @@ createRemittanceAdv db = do
   STM.catchSTM (Right <$> transaction) (pure . Left)
  where
   transaction = do
-    newId <- generateRemittanceAdvId db
+    newId <- Core.generateRemittanceAdvId db
     let new = RemittanceAdv.RemittanceAdv newId
     createRemittanceAdvFull db new >>= either STM.throwSTM pure
 
@@ -917,12 +899,6 @@ createRemittanceAdvFull
 createRemittanceAdvFull db new = do
   modifyRemittanceAdvs db (++ [new])
   pure . Right $ RemittanceAdv._remittanceAdvId new
-
-generateRemittanceAdvId
-  :: forall runtime . Data.StmDb runtime -> STM RemittanceAdv.RemittanceAdvId
-generateRemittanceAdvId Data.Db {..} =
-  RemittanceAdv.RemittanceAdvId
-    <$> C.bumpCounterPrefix "REM-" _dbNextRemittanceAdvId
 
 modifyRemittanceAdvs
   :: forall runtime
@@ -943,7 +919,7 @@ createEmployment db _ = do
   STM.catchSTM (Right <$> transaction) (pure . Left)
  where
   transaction = do
-    newId <- generateEmploymentId db
+    newId <- Core.generateEmploymentId db
     let new = Employment.Contract newId
     createEmploymentFull db new >>= either STM.throwSTM pure
 
@@ -955,11 +931,6 @@ createEmploymentFull
 createEmploymentFull db new = do
   modifyEmployments db (++ [new])
   pure . Right $ Employment._contractId new
-
-generateEmploymentId
-  :: forall runtime . Data.StmDb runtime -> STM Employment.ContractId
-generateEmploymentId Data.Db {..} =
-  Employment.ContractId <$> C.bumpCounterPrefix "EMP-" _dbNextEmploymentId
 
 modifyEmployments
   :: forall runtime
@@ -1385,7 +1356,7 @@ createInvoice db = do
   STM.catchSTM (Right <$> transaction) (pure . Left)
  where
   transaction = do
-    newId <- generateInvoiceId db
+    newId <- Core.generateInvoiceId db
     let new = Invoice.Invoice newId
     createInvoiceFull db new >>= either STM.throwSTM pure
 
@@ -1397,11 +1368,6 @@ createInvoiceFull
 createInvoiceFull db new = do
   modifyInvoices db (++ [new])
   pure . Right $ Invoice._entityId new
-
-generateInvoiceId
-  :: forall runtime . Data.StmDb runtime -> STM Invoice.InvoiceId
-generateInvoiceId Data.Db {..} =
-  Invoice.InvoiceId <$> C.bumpCounterPrefix "INV-" _dbNextInvoiceId
 
 modifyInvoices
   :: forall runtime
@@ -1441,7 +1407,7 @@ createEmail db template emailAddr = do
   STM.catchSTM (Right <$> transaction) (pure . Left)
  where
   transaction = do
-    newId <- generateEmailId db
+    newId <- Core.generateEmailId db
     let new = Email.Email newId template emailAddr
     createEmailFull db new >>= either STM.throwSTM pure
 
@@ -1453,10 +1419,6 @@ createEmailFull
 createEmailFull db new = do
   modifyEmails db (++ [new])
   pure . Right $ Email._emailId new
-
-generateEmailId :: forall runtime . Data.StmDb runtime -> STM Email.EmailId
-generateEmailId Data.Db {..} =
-  Email.EmailId <$> C.bumpCounterPrefix "EMAIL-" _dbNextEmailId
 
 modifyEmails
   :: forall runtime

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -83,7 +83,6 @@ import qualified Curiosity.Command             as Command
 import qualified Curiosity.Core                as Core
 import qualified Curiosity.Data                as Data
 import qualified Curiosity.Data.Business       as Business
-import qualified Curiosity.Data.Counter        as C
 import qualified Curiosity.Data.Email          as Email
 import qualified Curiosity.Data.Employment     as Employment
 import qualified Curiosity.Data.Invoice        as Invoice
@@ -102,7 +101,6 @@ import qualified Data.Text                     as T
 import qualified Data.Text.Encoding            as TE
 import qualified Data.Text.IO                  as T
 import qualified Data.Text.Lazy                as LT
-import qualified Language.Haskell.TH.Syntax    as Syntax
 import qualified Network.HTTP.Types            as HTTP
 import           Prelude                 hiding ( state )
 import qualified Servant

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1117,7 +1117,6 @@ handleSubmitQuotation
   -> User.UserProfile
   -> m Pages.EchoPage
 handleSubmitQuotation (Quotation.SubmitQuotation key) profile = do
-  db     <- asks Rt._rDb
   output <- withRuntime $ Rt.readCreateQuotationForm' profile key
   case output of
     Right quotation -> pure . Pages.EchoPage $ show

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -40,7 +40,6 @@ import "exceptions" Control.Monad.Catch         ( MonadMask )
 import qualified Curiosity.Core                as Core
 import qualified Curiosity.Data                as Data
 import           Curiosity.Data                 ( HaskDb
-                                                , readFullStmDbInHask
                                                 )
 import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Country        as Country
@@ -2281,8 +2280,7 @@ listScenarioNames scenariosDir = do
 --------------------------------------------------------------------------------
 showState :: ServerC m => m Pages.EchoPage
 showState = do
-  stmDb <- asks Rt._rDb
-  db    <- readFullStmDbInHask stmDb
+  db <- withRuntime Rt.state
   pure . Pages.EchoPage $ show db
 
 -- TODO The passwords are displayed in clear. Would be great to have the option
@@ -2290,8 +2288,7 @@ showState = do
 showStateAsJson
   :: ServerC m => m (JP.PrettyJSON '[ 'JP.DropNulls] (HaskDb Rt.Runtime))
 showStateAsJson = do
-  stmDb <- asks Rt._rDb
-  db    <- readFullStmDbInHask stmDb
+  db <- withRuntime Rt.state
   pure $ JP.PrettyJSON db
 
 

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -562,7 +562,7 @@ type ServerC m
     , MonadReader Rt.Runtime m
     , MonadIO m
     , Show (S.DBError m STM User.UserProfile)
-    , S.Db m STM User.UserProfile ~ Data.StmDb Rt.Runtime
+    , S.Db m STM User.UserProfile ~ Core.StmDb Rt.Runtime
     )
 
 

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -2174,9 +2174,9 @@ withMaybeUnitFromName
   -> (Text -> m a)
   -> (Business.Unit -> m a)
   -> m a
-withMaybeUnitFromName name a f = do
-  munit <- Rt.withRuntimeAtomically (Rt.selectUnitBySlug . Rt._rDb) name
-  maybe (a name) f munit
+withMaybeUnitFromName slug a f = do
+  munit <- withRuntime $ Rt.selectUnitBySlug slug
+  maybe (a slug) f munit
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -385,28 +385,7 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                                               NoContent
                                             )
 
-             -- static data
-             :<|> "partials" :> "username-blocklist" :> Get '[B.HTML] H.Html
-             :<|> "partials" :> "username-blocklist.json" :> Get '[JSON] [User.UserName]
-
-             :<|> "partials" :> "roles" :> Get '[B.HTML] H.Html
-             :<|> "partials" :> "roles.json" :> Get '[JSON] [SimpleContract.Role0]
-
-             :<|> "partials" :> "countries" :> Get '[B.HTML] H.Html
-             :<|> "partials" :> "countries.json" :> Get '[JSON] [(Text, Text)]
-
-             :<|> "partials" :> "vat-rates" :> Get '[B.HTML] H.Html
-             :<|> "partials" :> "vat-rates.json" :> Get '[JSON] [(Text, Text)]
-
-             :<|> "partials" :> "permissions" :> Get '[B.HTML] H.Html
-             :<|> "partials" :> "permissions.json" :> Get '[JSON] [User.AccessRight]
-
-             :<|> "partials" :> "scenarios" :> Get '[B.HTML] H.Html
-             :<|> "partials" :> "scenarios.json" :> Get '[JSON] [FilePath]
-
-             -- live data
-             :<|> "partials" :> "legal-entities" :> Get '[B.HTML] H.Html
-             :<|> "partials" :> "legal-entities.json" :> Get '[JSON] [Legal.Entity]
+             :<|> Partials
 
              :<|> "login" :> Get '[B.HTML] Login.Page
              :<|> "signup" :> Get '[B.HTML] Signup.Page
@@ -433,6 +412,30 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
 -- brittany-disable-next-binding
 type NamespaceAPI = Get '[B.HTML] (PageEither Pages.PublicProfileView Pages.UnitView)
 
+-- brittany-disable-next-binding
+type Partials =
+  -- static data
+       "partials" :> "username-blocklist" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "username-blocklist.json" :> Get '[JSON] [User.UserName]
+
+  :<|> "partials" :> "roles" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "roles.json" :> Get '[JSON] [SimpleContract.Role0]
+
+  :<|> "partials" :> "countries" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "countries.json" :> Get '[JSON] [(Text, Text)]
+
+  :<|> "partials" :> "vat-rates" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "vat-rates.json" :> Get '[JSON] [(Text, Text)]
+
+  :<|> "partials" :> "permissions" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "permissions.json" :> Get '[JSON] [User.AccessRight]
+
+  :<|> "partials" :> "scenarios" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "scenarios.json" :> Get '[JSON] [FilePath]
+
+  -- live data
+  :<|> "partials" :> "legal-entities" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "legal-entities.json" :> Get '[JSON] [Legal.Entity]
 
 -- | This is the main Servant server definition, corresponding to @App@.
 serverT
@@ -519,8 +522,25 @@ serverT natTrans ctx conf jwtS root dataDir scenariosDir =
     :<|> echoSimpleContractSaveExpense dataDir
     :<|> echoSimpleContractRemoveExpense dataDir
 
+    :<|> partials scenariosDir
+
+    :<|> showLoginPage
+    :<|> showSignupPage
+    :<|> showSetUserEmailAddrAsVerifiedPage
+    :<|> publicT conf jwtS
+    :<|> privateT conf
+    :<|> serveData dataDir
+    :<|> serveUBL dataDir
+    :<|> serveErrors
+    :<|> serveNamespaceDocumentation "alice"
+    :<|> serveEntity
+    :<|> websocket
+    :<|> serveNamespaceOrStatic natTrans ctx jwtS conf root
+
+partials :: ServerC m => FilePath -> ServerT Partials m
+partials scenariosDir =
     -- static data
-    :<|> partialUsernameBlocklist
+         partialUsernameBlocklist
     :<|> partialUsernameBlocklistAsJson
     :<|> partialRoles
     :<|> partialRolesAsJson
@@ -536,20 +556,6 @@ serverT natTrans ctx conf jwtS root dataDir scenariosDir =
     -- live data
     :<|> partialLegalEntities
     :<|> partialLegalEntitiesAsJson
-
-    :<|> showLoginPage
-    :<|> showSignupPage
-    :<|> showSetUserEmailAddrAsVerifiedPage
-    :<|> publicT conf jwtS
-    :<|> privateT conf
-    :<|> serveData dataDir
-    :<|> serveUBL dataDir
-    :<|> serveErrors
-    :<|> serveNamespaceDocumentation "alice"
-    :<|> serveEntity
-    :<|> websocket
-    :<|> serveNamespaceOrStatic natTrans ctx jwtS conf root
-
 
 --------------------------------------------------------------------------------
 -- | Minimal set of constraints needed on some monad @m@ to be satisfied to be

--- a/tests/Curiosity/CoreSpec.hs
+++ b/tests/Curiosity/CoreSpec.hs
@@ -1,0 +1,17 @@
+module Curiosity.CoreSpec
+  ( spec
+  ) where
+
+import           Curiosity.Core
+import           Curiosity.Data.User
+import           Test.Hspec
+
+
+--------------------------------------------------------------------------------
+spec :: Spec
+spec = do
+  describe "Core" $ do
+    it ("The first user ID is " <> show (unUserId firstUserId) <> ".") $ do
+      db <- atomically instantiateEmptyStmDb
+      id <- atomically $ generateUserId db
+      id `shouldBe` firstUserId

--- a/tests/Curiosity/RuntimeSpec.hs
+++ b/tests/Curiosity/RuntimeSpec.hs
@@ -16,7 +16,8 @@ spec = do
     it "Should boot." $ do
       -- TODO I don't like that this involves logging stuff.
       runtime <- boot' emptyHask "/tmp/curiosity-test-xxx-1.log"
-      st <- readFullStmDbInHaskFromRuntime runtime
+      let db = _rDb runtime
+      st <- atomically $ readFullStmDbInHask' db
       st `shouldBe` emptyHask
 
   describe "Runtime / Users" $ do

--- a/tests/Curiosity/RuntimeSpec.hs
+++ b/tests/Curiosity/RuntimeSpec.hs
@@ -31,13 +31,6 @@ spec = do
 
       muser `shouldBe` Nothing
 
-    it ("The first user ID is " <> show (unUserId firstUserId) <> ".") $ do
-      runtime <- boot' emptyHask "/tmp/curiosity-test-xxx-2-1.log"
-      let db = _rDb runtime
-      id <- atomically $ generateUserId db
-
-      id `shouldBe` firstUserId
-
     it "Adding a user, returns a user." $ do
       runtime <- boot' emptyHask "/tmp/curiosity-test-xxx-3.log"
       let db = _rDb runtime

--- a/tests/Curiosity/RuntimeSpec.hs
+++ b/tests/Curiosity/RuntimeSpec.hs
@@ -2,9 +2,10 @@ module Curiosity.RuntimeSpec
   ( spec
   ) where
 
+import           Curiosity.Core
 import           Curiosity.Data
 import           Curiosity.Data.User
-import           Curiosity.Runtime
+import           Curiosity.Runtime              (boot', _rDb)
 import           Test.Hspec
 
 


### PR DESCRIPTION
@asheshambasta Can you have a look here ? This shows what I was thinking to do: separate clearly three layers:

- `Curiosity.Data` should provide only pure code (no `STM`, no `IO`).
- `Curiosity.Core` adds `STM` to that. There is no call to `atomically` there.
- `Curiosity.Runtime` adds IO to that, mainly for logging, and for making atomic transactions out of the STM operations defined in `Core`.

I'm demonstrating that with the `reset` operation (but I haven't moved all the `STM` or `IO` out of `Data` yet). Are you ok with such an organization ?

Moreover, I'm have also replace a call to `runAppMSafe` to `runRunM`. As you can see, this removes one layer of `Either` case pattern matching, which I think is cool since it was obfuscating that `readFullStmDbInHaskFromRuntime` was already safe. Is this also ok or is there something I'm missing ?