### PR TITLE
Expose scenario's intermediate states

### DIFF
--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -9,10 +9,11 @@ of test scenarios. To do so, Curiosity supports running scripts: they are
 textual sequences of commands that mimic closely what can be done through the
 web interface.
 
-As part of Curiosity's test suite, a collection of scenarios are run and their
-results are compared to known sources of truth, called "golden files". This
-makes sure that, as scenarios are created, and as Curiosity evolves, the system
-continues to work as expected, and few bugs can be introduced inadvertantly.
+As part of Curiosity's test suite, a [collection of scenarios](#scenarios) are
+run and their results are compared to known sources of truth, called "golden
+files". This makes sure that, as scenarios are created, and as Curiosity
+evolves, the system continues to work as expected, and few bugs can be
+introduced inadvertantly.
 
 # Example data
 
@@ -50,6 +51,10 @@ This kind of live data have their own [documentation
 page](/documentation/live-data).
 
 # Scenarios
+
+The test suite of Curiosity contains the following scenarios (those are
+clickable links). For each scenario, it is possible to view all the states
+resulting of each of the commands the execute.
 
 <!--# include virtual="/partials/scenarios" -->
 

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -48,3 +48,9 @@ dynamically add, edit, and remove them in specific test scenarios.
 
 This kind of live data have their own [documentation
 page](/documentation/live-data).
+
+# Scenarios
+
+<!--# include virtual="/partials/scenarios" -->
+
+The list [as JSON](/partials/scenarios.json).

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -136,6 +136,7 @@ library
     , directory
     , fast-logger
     , filepath
+    , Glob
     , haskeline
     , memory
     , network
@@ -198,7 +199,6 @@ test-suite curiosity-scenarios
       bytestring
     , curiosity
     , filepath
-    , Glob
     , lens
     , tasty
     , tasty-silver

--- a/modules/curiosity.nix
+++ b/modules/curiosity.nix
@@ -22,6 +22,7 @@
         --server-port 9100 \
         --static-dir ${(import ../.).content} \
         --data-dir ${(import ../.).data} \
+        --scenarios-dir ${(import ../.).scenarios} \
         --log /tmp/curiosity.log
     '';
   };

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -1,34 +1,34 @@
 1: reset
 Resetting to the empty state.
 2: run init-users.txt
-2: user create alice a alice@example.com --accept-tos
-User created: USER-1
-3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
-User updated: USER-1
-5: user create bob b bob@example.com --accept-tos
-User created: USER-2
-6: user create charlie c charlie@example.com --accept-tos
-User created: USER-3
-8: user create mila m mila@example.com --accept-tos
-User created: USER-4
-9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
-User updated: USER-4
+> 2: user create alice a alice@example.com --accept-tos
+> User created: USER-1
+> 3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
+> User updated: USER-1
+> 5: user create bob b bob@example.com --accept-tos
+> User created: USER-2
+> 6: user create charlie c charlie@example.com --accept-tos
+> User created: USER-3
+> 8: user create mila m mila@example.com --accept-tos
+> User created: USER-4
+> 9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
+> User updated: USER-4
 3: run init-entities.txt
-1: legal create one One S.A. 100200300 BE0100200300
-Legal entity created: LENT-1
-2: legal update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
-Legal entity updated: one
+> 1: legal create one One S.A. 100200300 BE0100200300
+> Legal entity created: LENT-1
+> 2: legal update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
+> Legal entity updated: one
 4: run init-units.txt
-1: business create alpha Alpha
-Business entity created: BENT-1
-2: business update alpha The first business unit of the prototype, Alpha is run by @mila.
-Business unit updated: alpha
+> 1: business create alpha Alpha
+> Business entity created: BENT-1
+> 2: business update alpha The first business unit of the prototype, Alpha is run by @mila.
+> Business unit updated: alpha
 5: run init-form-simple-contracts.txt
-1: as mila
-Modifying default user.
-2: forms simple-contract new --amount -100
-Simple contract form created: TBPJLIUG
-3: forms simple-contract new
-Simple contract form created: HNONWPTG
-4: forms simple-contract new --amount 100
-Simple contract form created: RZEMQMNF
+> 1: as mila
+> Modifying default user.
+> 2: forms simple-contract new --amount -100
+> Simple contract form created: TBPJLIUG
+> 3: forms simple-contract new
+> Simple contract form created: HNONWPTG
+> 4: forms simple-contract new --amount 100
+> Simple contract form created: RZEMQMNF

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -3,6 +3,7 @@ module Curiosity.Interpret
   ( interpretFile
   , interpret'
   , formatOutput
+  , listScenarios
   , wordsq
   ) where
 
@@ -15,6 +16,7 @@ import qualified Options.Applicative           as A
 import           System.FilePath                ( (</>)
                                                 , takeDirectory
                                                 )
+import qualified System.FilePath.Glob          as Glob
 
 
 --------------------------------------------------------------------------------
@@ -99,6 +101,12 @@ formatOutput output =
   in (snd3 . last $ (0, ExitSuccess, "") : output', ls)
 
 snd3 (_, b, _) = b
+
+
+--------------------------------------------------------------------------------
+listScenarios :: FilePath -> IO [FilePath]
+listScenarios scenariosDir = sort <$> Glob.globDir1 pat scenariosDir
+  where pat = Glob.compile "*.txt"
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -36,13 +36,13 @@ handleRun conf user scriptPath = do
 handleRun' :: FilePath -> IO [Text]
 handleRun' scriptPath = do
   let conf = P.Conf
-               { P._confLogging = P.mkLoggingConf "/tmp/cty-serve-explore.log"
-               , P._confDbFile = Nothing
-               }
+        { P._confLogging = P.mkLoggingConf "/tmp/cty-serve-explore.log"
+        , P._confDbFile  = Nothing
+        }
   runtime <- Rt.boot conf >>= either throwIO pure
   output  <- interpretFile runtime "system" scriptPath 0
   Rt.powerdown runtime
-  pure $ map (\(_ ,_ , c) -> c)  output
+  pure $ concatMap showTrace output
 
 interpret :: Rt.Runtime -> User.UserName -> FilePath -> IO ExitCode
 interpret runtime user path = do
@@ -53,12 +53,18 @@ interpret runtime user path = do
 
 
 --------------------------------------------------------------------------------
-interpretFile
-  :: Rt.Runtime
-  -> User.UserName
-  -> FilePath
-  -> Int
-  -> IO [(Int, ExitCode, Text)]
+data Trace = Trace
+  { traceLineNbr  :: Int
+  , traceCommand  :: Text
+  , traceComment  :: Maybe Text
+  , traceNesting  :: Int
+  , traceUser     :: User.UserName
+  , traceOutput   :: [Text]
+  , traceExitCode :: ExitCode
+  , traceNested   :: [Trace]
+  }
+
+interpretFile :: Rt.Runtime -> User.UserName -> FilePath -> Int -> IO [Trace]
 interpretFile runtime user path nesting = do
   let dir = takeDirectory path
   content <- T.lines <$> readFile path
@@ -70,24 +76,31 @@ interpret'
   -> FilePath
   -> [Text]
   -> Int
-  -> IO [(Int, ExitCode, Text)]
-interpret' runtime user dir content nesting = do
-  (_, output) <- foldlM loop (user, []) $ zip [1 :: Int ..] content
-  pure output
+  -- -> IO [(Int, ExitCode, Text)]
+  -> IO [Trace]
+interpret' runtime user dir content nesting = go user []
+  $ zip [1 :: Int ..] content
  where
-  loop (user', acc) (ln, line) = do
-    let (prefix, _) = T.breakOn "#" line
-        separated   = map T.pack . wordsq $ T.unpack prefix
-        grouped     = T.unwords separated
+  go user' acc []                  = pure acc
+  go user' acc ((ln, line) : rest) = do
+    let (prefix, comment) = T.breakOn "#" line
+        separated         = map T.pack . wordsq $ T.unpack prefix
+        grouped           = T.unwords separated
+        trace = Trace ln
+                      grouped
+                      (if T.null comment then Nothing else Just comment)
+                      nesting
+                      user'
     case separated of
-      []               -> pure (user', acc)
+      []               -> go user' acc rest
       ["as", username] -> do
-        let output = [show ln <> ": " <> grouped, "Modifying default user."]
-        pure
-          (User.UserName username, acc ++ map (nesting, ExitSuccess, ) output)
+        let t    = trace ["Modifying default user."] ExitSuccess []
+            acc' = acc ++ [t]
+        go (User.UserName username) acc' rest
       ["quit"] -> do
-        let output = [show ln <> ": " <> grouped, "Exiting."]
-        pure (user', acc ++ map (nesting, ExitSuccess, ) output)
+        let t    = trace ["Exiting."] ExitSuccess []
+            acc' = acc ++ [t]
+        go user' acc' rest
       input -> do
         let output_ = [show ln <> ": " <> grouped]
             result =
@@ -98,42 +111,51 @@ interpret' runtime user dir content nesting = do
           A.Success command -> do
             case command of
               Command.Reset _ -> do
-                let output = output_ ++ ["Resetting to the empty state."]
                 Rt.reset runtime
-                pure (user', acc ++ map (nesting, ExitSuccess, ) output)
+                let t = trace ["Resetting to the empty state."] ExitSuccess []
+                    acc' = acc ++ [t]
+                go user' acc' rest
               Command.Run _ scriptPath -> do
                 output' <- liftIO $ interpretFile runtime
-                                                       user
-                                                       (dir </> scriptPath)
-                                                       (succ nesting)
-                pure
-                  ( user'
-                  , acc ++ map (nesting, ExitSuccess, ) output_ ++ output'
-                  )
+                                                  user
+                                                  (dir </> scriptPath)
+                                                  (succ nesting)
+                let t    = trace [] ExitSuccess output'
+                    acc' = acc ++ [t]
+                go user' acc' rest
               _ -> do
                 (_, output) <- Rt.handleCommand runtime user' command
-                pure
-                  ( user'
-                  , acc ++ map (nesting, ExitSuccess, ) (output_ ++ output)
-                  )
-          A.Failure err ->
-            pure (user', acc ++ [(nesting, ExitFailure 1, show err)])
-          A.CompletionInvoked _ ->
-            pure (user', acc ++ [(nesting, ExitFailure 1, "Shouldn't happen")])
+                let t    = trace output ExitSuccess []
+                    acc' = acc ++ [t]
+                go user' acc' rest
+          A.Failure err -> do
+            let t    = trace [show err] (ExitFailure 1) []
+                acc' = acc ++ [t]
+            go user' acc' rest
+          A.CompletionInvoked _ -> do
+            let t    = trace ["Shouldn't happen."] (ExitFailure 1) []
+                acc' = acc ++ [t]
+            go user' acc' rest
 
 
 --------------------------------------------------------------------------------
-formatOutput :: [(Int, ExitCode, Text)] -> (ExitCode, [Text])
+formatOutput :: [Trace] -> (ExitCode, [Text])
 formatOutput output =
-  let len     = length $ takeWhile ((== ExitSuccess) . snd3) output
-      output' = take (len + 1) output
-      pad 0 = ""
-      pad 1 = "> "
-      pad n = T.concat (replicate ((n - 1) * 2) ">") <> "> "
-      ls =  map (\(a, _, c) -> pad a <> c) output'
-  in (snd3 . last $ (0, ExitSuccess, "") : output', ls)
+  let ls = concatMap showTrace output
+      exitCode =
+        if null output then ExitSuccess else traceExitCode $ last output
+  in  (exitCode, ls)
 
-snd3 (_, b, _) = b
+showTrace :: Trace -> [Text]
+showTrace Trace {..} =
+  map (pad traceNesting <>)
+    $  (show traceLineNbr <> ": " <> traceCommand)
+    :  traceOutput
+    ++ concatMap showTrace traceNested
+ where
+  pad 0 = ""
+  pad 1 = "> "
+  pad n = T.concat (replicate ((n - 1) * 2) ">") <> "> "
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Parse.hs
+++ b/src/Curiosity/Parse.hs
@@ -45,6 +45,7 @@ data ServerConf = ServerConf
   { _serverPort          :: Int
   , _serverStaticDir     :: FilePath
   , _serverDataDir       :: FilePath
+  , _serverScenariosDir  :: FilePath
   , _serverCookie        :: SAuth.CookieSettings
     -- ^ Settings for setting cookies as a server (for authentication etc.).
   , _serverMkJwtSettings :: JWK.JWK -> SAuth.JWTSettings
@@ -60,6 +61,8 @@ instance Eq ServerConf where
       == _serverStaticDir b
       && _serverDataDir a
       == _serverDataDir b
+      && _serverScenariosDir a
+      == _serverScenariosDir b
       && _serverCookie a
       == _serverCookie b
 
@@ -115,6 +118,10 @@ serverParser = do
     (A.long "data-dir" <> A.value "./data/" <> A.metavar "DIR" <> A.help
       "A directory containing example data."
     )
+  _serverScenariosDir <- A.strOption
+    (A.long "scenarios-dir" <> A.value "./scenarios/" <> A.metavar "DIR" <> A.help
+      "A directory containing scenarios."
+    )
 
   pure ServerConf
     {
@@ -140,6 +147,7 @@ defaultServerConf = ServerConf
   , _serverPort          = 9000
   , _serverStaticDir     = "./_site/"
   , _serverDataDir       = "./data/"
+  , _serverScenariosDir  = "./scenarios/"
   }
 
 

--- a/src/Curiosity/Process.hs
+++ b/src/Curiosity/Process.hs
@@ -19,7 +19,7 @@ import qualified Curiosity.Server              as Srv
 --------------------------------------------------------------------------------
 startServer :: Command.ServerConf -> Rt.Runtime -> IO Errs.RuntimeErr
 startServer conf runtime@Rt.Runtime {..} = do
-  let Command.ServerConf port _ _ _ _ = conf
+  let Command.ServerConf port _ _ _ _ _ = conf
   startupLogInfo _rLoggers $ "Starting up server on port " <> show port <> "..."
   try @SomeException (Srv.run conf runtime) >>= pure . either
     Errs.RuntimeException

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -1,5 +1,6 @@
 module Curiosity.Run
   ( run
+  , handleRun'
   ) where
 
 import qualified Commence.Runtime.Errors       as Errs
@@ -230,6 +231,14 @@ handleRun conf user scriptPath = do
   code    <- interpret runtime user scriptPath
   Rt.powerdown runtime
   exitWith code
+
+-- | Similar to `handleRun`, but capturing the output. This is used in tests.
+handleRun' :: FilePath -> IO [Text]
+handleRun' scriptPath = do
+  runtime <- Rt.boot P.defaultConf >>= either throwIO pure
+  output  <- Inter.interpretFile runtime "system" scriptPath 0
+  Rt.powerdown runtime
+  pure $ map (\(_ ,_ , c) -> c)  output
 
 interpret :: Rt.Runtime -> User.UserName -> FilePath -> IO ExitCode
 interpret runtime user path = do

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -1,6 +1,5 @@
 module Curiosity.Run
   ( run
-  , handleRun'
   ) where
 
 import qualified Commence.Runtime.Errors       as Errs
@@ -94,9 +93,9 @@ run (Command.CommandWithTarget (Command.Serve conf serverConf) target _) = do
 run (Command.CommandWithTarget (Command.Run _ scriptPath) target (Command.User user))
   = case target of
     Command.MemoryTarget -> do
-      handleRun P.defaultConf user scriptPath
+      Inter.handleRun P.defaultConf user scriptPath
     Command.StateFileTarget path -> do
-      handleRun P.defaultConf { P._confDbFile = Just path } user scriptPath
+      Inter.handleRun P.defaultConf { P._confDbFile = Just path } user scriptPath
     Command.UnixDomainTarget _ -> do
       putStrLn @Text "TODO"
       exitFailure
@@ -225,30 +224,6 @@ handleServe conf serverConf = do
 
 
 --------------------------------------------------------------------------------
-handleRun :: P.Conf -> User.UserName -> FilePath -> IO ExitCode
-handleRun conf user scriptPath = do
-  runtime <- Rt.boot conf >>= either throwIO pure
-  code    <- interpret runtime user scriptPath
-  Rt.powerdown runtime
-  exitWith code
-
--- | Similar to `handleRun`, but capturing the output. This is used in tests.
-handleRun' :: FilePath -> IO [Text]
-handleRun' scriptPath = do
-  runtime <- Rt.boot P.defaultConf >>= either throwIO pure
-  output  <- Inter.interpretFile runtime "system" scriptPath 0
-  Rt.powerdown runtime
-  pure $ map (\(_ ,_ , c) -> c)  output
-
-interpret :: Rt.Runtime -> User.UserName -> FilePath -> IO ExitCode
-interpret runtime user path = do
-  output <- Inter.interpretFile runtime user path 0
-  let (exitCode, ls) = Inter.formatOutput output
-  mapM_ putStrLn ls
-  pure exitCode
-
-
---------------------------------------------------------------------------------
 handleViewQueue conf user name = do
   case name of
     Command.EmailAddrToVerify -> do
@@ -350,7 +325,7 @@ repl runtime user = HL.runInputT HL.defaultSettings loop
             -- to Rt.handleCommand too.
             Command.Reset _          -> Rt.reset runtime
             Command.Run _ scriptPath -> do
-              code <- liftIO $ interpret runtime user scriptPath
+              code <- liftIO $ Inter.interpret runtime user scriptPath
               case code of
                 ExitSuccess   -> pure ()
                 ExitFailure _ -> output' "Script failed."

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -14,6 +14,7 @@ module Curiosity.Runtime
   , boot
   , boot'
   , reset
+  , state
   , handleCommand
   , powerdown
   , readDb
@@ -100,6 +101,7 @@ import qualified Data.Text.IO                  as T
 import qualified Data.Text.Lazy                as LT
 import qualified Language.Haskell.TH.Syntax    as Syntax
 import qualified Network.HTTP.Types            as HTTP
+import           Prelude                 hiding ( state )
 import qualified Servant
 import           System.Directory               ( doesFileExist )
 
@@ -219,6 +221,8 @@ saveDbAs runtime fpath = do
   liftIO
       (try @SomeException (T.writeFile fpath . TE.decodeUtf8 $ BS.toStrict bs))
     <&> either (Just . Errs.RuntimeException) (const Nothing)
+
+state runtime = Data.readFullStmDbInHask $ _rDb runtime
 
 {- | Instantiate the db.
 

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -2031,7 +2031,7 @@ showScenario scenariosDir name = do
     H.text $ Inter.pad traceNesting <> show traceLineNbr <> ": " <> traceCommand <> "    "
     H.a ! A.href (H.toValue $ "/scenarios/" <> name <> "/" <> show traceNumber <> "/state.json") $ "View state"
     H.text "\n"
-    mapM_ (\o -> H.text o >> H.text "\n") traceOutput
+    mapM_ (\o -> H.text (Inter.pad traceNesting) >> H.text o >> H.text "\n") traceOutput
     mapM_ displayTrace traceNested
 
 -- | Show the state after a specific command, given as its number within the

--- a/tests/run-scenarios.hs
+++ b/tests/run-scenarios.hs
@@ -1,7 +1,6 @@
 -- | Run scripts similarly to `cty run`, ensuring their outputs are identical
 -- to "golden" (expected) results.
 import qualified Curiosity.Interpret           as Inter
-import qualified Curiosity.Run                 as Run
 import qualified Data.Text                     as T
 import           System.FilePath
 
@@ -23,6 +22,6 @@ mkGoldenTest path = do
   pure $ Silver.goldenVsAction testName goldenPath action convert
  where
   action :: IO [Text]
-  action = Run.handleRun' path
+  action = Inter.handleRun' path
 
   convert = T.unlines

--- a/tests/run-scenarios.hs
+++ b/tests/run-scenarios.hs
@@ -22,6 +22,6 @@ mkGoldenTest path = do
   pure $ Silver.goldenVsAction testName goldenPath action convert
  where
   action :: IO [Text]
-  action = Inter.handleRun' path
+  action = snd . Inter.formatOutput <$> Inter.handleRun' path
 
   convert = T.unlines

--- a/tests/run-scenarios.hs
+++ b/tests/run-scenarios.hs
@@ -1,11 +1,9 @@
 -- | Run scripts similarly to `cty run`, ensuring their outputs are identical
 -- to "golden" (expected) results.
 import qualified Curiosity.Interpret           as Inter
-import qualified Curiosity.Parse               as P
-import qualified Curiosity.Runtime             as Rt
+import qualified Curiosity.Run                 as Run
 import qualified Data.Text                     as T
 import           System.FilePath
-import qualified System.FilePath.Glob          as Glob
 
 import           Test.Tasty
 import qualified Test.Tasty.Silver             as Silver
@@ -13,15 +11,11 @@ import qualified Test.Tasty.Silver             as Silver
 --------------------------------------------------------------------------------
 main :: IO ()
 main = do
-  goldens <- listScenarios >>= mapM mkGoldenTest
+  goldens <- Inter.listScenarios "scenarios/" >>= mapM mkGoldenTest
   defaultMain $ testGroup "Tests" goldens
 
 
 --------------------------------------------------------------------------------
-listScenarios :: IO [FilePath]
-listScenarios = sort <$> Glob.globDir1 pat "scenarios/"
-  where pat = Glob.compile "*.txt"
-
 mkGoldenTest :: FilePath -> IO TestTree
 mkGoldenTest path = do
   let testName   = takeBaseName path
@@ -29,16 +23,6 @@ mkGoldenTest path = do
   pure $ Silver.goldenVsAction testName goldenPath action convert
  where
   action :: IO [Text]
-  action = do
-    actual <- run path
-    return actual
+  action = Run.handleRun' path
 
   convert = T.unlines
-
--- Similar to Run.handleRun, but capturing the output.
-run :: FilePath -> IO [Text]
-run scriptPath = do
-  runtime <- Rt.boot P.defaultConf >>= either throwIO pure
-  output  <- Inter.interpretFile runtime "system" scriptPath 0
-  Rt.powerdown runtime
-  pure $ map (\(_ ,_ , c) -> c)  output


### PR DESCRIPTION
This PRs adds the list of available test scenarios to the documentation. Scenarios are displayed as they appear in a golden file (although they are run live upon requesting the web page) and the intermediate states are linked after each command.