### PR TITLE
[nix] Filtering sources using a whitelist approach

### DIFF
--- a/content/default.nix
+++ b/content/default.nix
@@ -3,13 +3,21 @@
 
 let
   pkgs = import nixpkgs {};
+  sources = import ../nix/sources.nix {};
+  nix-filter = import sources.nix-filter;
 
 in
 {
   html.all = pkgs.stdenv.mkDerivation {
     name = "content";
-    # TODO We only need content/, man/, scripts/
-    src = ../.;
+    src = nix-filter {
+      root = ../.;
+      include = [
+        "content"
+        "man"
+        "scripts"
+      ];
+    };
     nativeBuildInputs = [ pkgs.mandoc pkgs.pandoc ];
     installPhase = ''
       # Make sure we don't use an already built _site/.
@@ -25,8 +33,12 @@ in
   # Define this here, instead of creating a .nix file in data/.
   data = pkgs.stdenv.mkDerivation {
     name = "data";
-    # TODO We only need data/
-    src = ../.;
+    src = nix-filter {
+      root = ../.;
+      include = [
+        "data"
+      ];
+    };
     installPhase = ''
       cp -r data $out
     '';
@@ -35,8 +47,12 @@ in
   # Define this here, instead of creating a .nix file in scenarios/.
   scenarios = pkgs.stdenv.mkDerivation {
     name = "scenarios";
-    # TODO We only need scenarios/
-    src = ../.;
+    src = nix-filter {
+      root = ../.;
+      include = [
+        "scenarios"
+      ];
+    };
     installPhase = ''
       cp -r scenarios $out
     '';

--- a/man/default.nix
+++ b/man/default.nix
@@ -3,13 +3,20 @@
 
 let
   pkgs = import nixpkgs {};
+  sources = import ../nix/sources.nix {};
+  nix-filter = import sources.nix-filter;
 
 in
 {
   man-pages = pkgs.stdenv.mkDerivation {
     name = "man";
-    # TODO We only need man/, scripts/
-    src = ../.;
+    src = nix-filter {
+      root = ../.;
+      include = with nix-filter; [
+        "man"
+        "scripts"
+      ];
+    };
     nativeBuildInputs = [ pkgs.pandoc ];
     installPhase = ''
       # Make sure we don't use an already built _site/.

--- a/nix/contents.nix
+++ b/nix/contents.nix
@@ -2,6 +2,7 @@ let
 
   sources = import ./sources.nix;
   defNixpkgs = import sources.nixpkgs { };
+  nix-filter = import sources.nix-filter;
 
 in { nixpkgs ? defNixpkgs }:
 
@@ -11,10 +12,20 @@ in {
   # The format is `{ <pkgName> : <pkgDir> }` (we refer to this as pInfo).
   # The used directory should be the path of the directory relative to the root
   # of the project.
-  pkgList = { curiosity = ../.;
-            };
+  pkgList = {
+    curiosity = nix-filter {
+      root = ../.;
+      include = with nix-filter; [
+        (and "src" (or_ (matchExt "hs") isDirectory))
+        (and "tests" (or_ (matchExt "hs") isDirectory))
+        (and "bin" (or_ (matchExt "hs") isDirectory))
+        # Required for the curiosity-scenarios test suite.
+        (and "data" (or_ (matchExt "json") isDirectory))
+        "curiosity.cabal"
+      ];
+    };
+  };
 
   # Get an attribute from a string path from a larger attrSet
   getPkg = pkgs: pPath: getAttrFromPath [pPath] pkgs;
 }
-

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -4,33 +4,13 @@ let
   lib = super.lib;
   sources = import ./sources.nix;
   contents = import ./contents.nix { nixpkgs = super; };
-
   inherit (super.lib.attrsets) mapAttrs;
   inherit (import sources.gitignore { inherit lib; }) gitignoreFilter;
 
   ourOverrides = selfh: superh:
     let
-
-      customFilter = src:
-        let
-          # IMPORTANT: use the following let binding to memoize info about the
-          # Git directories.
-          # (The comment is from the original example at
-          # https://github.com/hercules-ci/gitignore.nix/blob/master/docs/gitignoreFilter.md)
-          gitIgnoredSrc = gitignoreFilter src;
-        in
-          path: type: gitIgnoredSrc path type;
-
-      cleanedSrc = src: lib.sources.sourceFilesBySuffices
-        ( lib.cleanSourceWith {
-            filter = customFilter src;
-            src = src;
-            name = "source";
-          })
-        [".cabal" ".hs" ".json"]; # Keep JSON files for the test suite.
-
       callCabalOn = name: dir:
-        selfh.callCabal2nix "${name}" (cleanedSrc dir) { };
+        selfh.callCabal2nix "${name}" dir { };
 
     in mapAttrs callCabalOn contents.pkgList;
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,6 +41,18 @@
         "url": "https://github.com/nmattia/niv/archive/82e5cd1ad3c387863f0545d7591512e76ab0fc41.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "nix-filter": {
+        "branch": "master",
+        "description": "a small self-container source filtering lib",
+        "homepage": "",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3b821578685d661a10b563cba30b1861eec05748",
+        "sha256": "0gzx750j06f0j1wi006rhb1xhxaszlbqi7vg0cysrffvgwjccb26",
+        "type": "tarball",
+        "url": "https://github.com/numtide/nix-filter/archive/3b821578685d661a10b563cba30b1861eec05748.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "nixpkgs": {
         "branch": "nixos-22.05",
         "description": "Nix Packages collection",


### PR DESCRIPTION
The Haskell build is quite expensive, we aggressively filter its src input to make sure we that the editor artifacts and other mutable state files don't end up triggering a rebuild.

We take advantage of this filtering rework to move back the haskell sources filtering to the edge: we clean the derivation src before sending it to cabal2nix projects list. Doing this allow us to apply a package-specific filter instead of a generic one.

After applying this PR, altering the `state.json` file does not lead to a curiosity rebuild anymore.