### PR TITLE
[nix] Integration test: introduce testbench env

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,23 @@ $ cabal build curiosity
 $ ./dist-newstyle/build/x86_64-linux/ghc-8.6.5/curiosity-0.1.0.0/x/curiosity/build/curiosity/cty serve
 ```
 
-And finally, we can build a binary with Nix:
+We can build a binary with Nix:
 
 ```
 $ nix-build -A curiosity
 $ ./result/bin/cty serve
 ```
+
+And finally, we can run a local dev environment containing curiosity and a Nginx reverse proxy using:
+
+```
+$ nix-build -A integration-tests.local-dev-environment
+$ ./result/bin/run-interactive-integration-env
+$ # Or alternatively from a nix-shell via an injected alias
+$ nix-shell
+$ interactive-integration-env
+```
+
 
 # Example REPL commands
 

--- a/default.nix
+++ b/default.nix
@@ -20,13 +20,17 @@ let
       ./machine/no-gui.nix
     ];
   };
-in rec
-  {
     # Build with nix-build -A <attr>
     # binaries + haddock are also available as binaries.all.
     binaries = nixpkgs.haskellPackages.curiosity;
-    haddock = nixpkgs.haskellPackages.curiosity.doc;
     content = (import ./content {}).html.all;
+    haddock = nixpkgs.haskellPackages.curiosity.doc;
+    run = import ./scripts/integration-tests {
+      inherit nixpkgs binaries haddock content;
+    };
+in rec
+  {
+    inherit nixpkgs binaries content haddock run;
     data = (import ./content {}).data;
     scenarios = (import ./content {}).scenarios;
     static = (import "${sources.design-hs}").static;

--- a/scripts/integration-tests/default.nix
+++ b/scripts/integration-tests/default.nix
@@ -1,0 +1,42 @@
+{
+  nixpkgs ? (import ../../.).nixpkgs,
+  binaries ? (import ../../.).binaries,
+  haddock ? (import ../../.).haddock,
+  content ? (import ../../.).content,
+  data ? (import ../../.).data,
+  system ? builtins.currentSystem,
+  lib ? nixpkgs.lib
+}:
+
+let
+  runCuriosity = nixpkgs.writers.writeBashBin "run-curiosity" ''
+    set -euo pipefail
+    PATH=${lib.strings.makeBinPath [ binaries ]}:$PATH
+    export CURIOSITY_STATIC_DIR=${content}
+    export CURIOSITY_DATA_DIR=${data}
+    ${builtins.readFile ./run-curiosity.sh}
+  '';
+  nginxConf = nixpkgs.substituteAll {
+    src = ./nginx.conf;
+    curiosityaddr = "http://127.0.0.1:9100";
+    # TODO: find a way to reference this folder without the explicit
+    #       0.1.0.0 version
+    curiosityhaddock = "${haddock.doc}/share/doc/curiosity-0.1.0.0/html";
+  };
+  runNginx = nixpkgs.writers.writeBashBin "run-nginx" ''
+    set -euo pipefail
+    PATH=${lib.strings.makeBinPath [ nixpkgs.nginx ]}:$PATH
+    NGINX_CONF="${nginxConf}"
+    ${builtins.readFile ./run-nginx.sh}
+  '';
+  procFile = nixpkgs.writeText "Procfile" ''
+    curiosity: ${runCuriosity}/bin/run-curiosity
+    nginx: ${runNginx}/bin/run-nginx
+  '';
+  run-full-environment = nixpkgs.writers.writeBashBin "run-full-environment" ''
+    set -euo pipefail
+    ${nixpkgs.hivemind}/bin/hivemind ${procFile}
+  '';
+in {
+  inherit run-full-environment;
+}

--- a/scripts/integration-tests/nginx.conf
+++ b/scripts/integration-tests/nginx.conf
@@ -1,0 +1,50 @@
+daemon off;
+error_log stderr warn;
+pid @tmpdir@/nginx.pid;
+events {
+  worker_connections  1024;
+}
+http {
+        types_hash_max_size 4096;
+        default_type application/octet-stream;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        gzip on;
+        gzip_proxied any;
+        gzip_comp_level 5;
+        gzip_types
+        application/atom+xml
+        application/javascript
+        application/json
+        application/xml
+        application/xml+rss
+        image/svg+xml
+        text/css
+        text/javascript
+        text/plain
+        text/xml;
+        gzip_vary on;
+        client_max_body_size 10m;
+        server_tokens off;
+        server {
+                client_body_temp_path @tmpdir@;
+                proxy_temp_path @tmpdir@;
+                fastcgi_temp_path @tmpdir@;
+                uwsgi_temp_path @tmpdir@;
+                scgi_temp_path @tmpdir@;
+                access_log @tmpdir@/access.log;
+        	listen 0.0.0.0:8888;
+        	server_name localhost;
+        	location / {
+        		proxy_pass @curiosityaddr@;
+        	}
+        	location /documentation {
+        		proxy_pass @curiosityaddr@;
+        		ssi on;
+        	}
+        	location /haddock/ {
+                        alias @curiosityhaddock@/;
+#        		alias /nix/store/mmhksfkznr3b9rwb7zkllnn11qxzxpc1-curiosity-0.1.0.0-doc/share/doc/curiosity-0.1.0.0/html/;
+        	}
+        }
+}

--- a/scripts/integration-tests/readme.md
+++ b/scripts/integration-tests/readme.md
@@ -1,0 +1,9 @@
+# Integration Tests Scripts
+
+This integration test suite is meant to be used to generate an interactive integration test environment and to perform some integration tests on the CI.
+
+You can locally setup an interactive integration env using the `./interactive-integration-env` script. This script build and start a curiosity server and an Nginx reverse proxy.
+
+> ⚠️ Warning
+>
+> The `.sh` scripts living in this directory are not meant to be executed in isolation. These scripts need to be glued to their dependencies via Nix. They are living outside of `default.nix` for convenience reasons: it improves the editor syntax color highlighting and linting support.

--- a/scripts/integration-tests/run-curiosity.sh
+++ b/scripts/integration-tests/run-curiosity.sh
@@ -1,0 +1,19 @@
+if ! command -v cty; then
+    scriptdir=$(realpath -s "$0" | xargs dirname)
+    echo "Missing cty."
+    echo "Did you read $scriptdir/readme.md ?"
+    exit 1
+fi
+
+echo "[+] Setting up the curiosity runtime env"
+rundir=$(mktemp -d -t "curiosity.XXXXXXXXXX")
+echo "[+] Curiosity runtime dir: $rundir"
+trap 'rm -rf -- "$rundir"' EXIT
+cd "$rundir"
+
+# Init curiosity env
+cty init
+
+# Start server
+echo "[+] Starting the curiosity server"
+cty serve --server-port 9100

--- a/scripts/integration-tests/run-nginx.sh
+++ b/scripts/integration-tests/run-nginx.sh
@@ -1,0 +1,16 @@
+if [[ -z $NGINX_CONF ]]; then
+    scriptdir=$(realpath -s "$0" | xargs dirname)
+    echo "Missing static files."
+    echo "Did you read $scriptdir/readme.md ?"
+    exit 1
+fi
+rundir=$(mktemp -d -t "curiosity-nginx.XXXXXXXXXX")
+echo "[+] Nginx runtime dir: $rundir"
+trap 'rm -rf -- "$rundir"' EXIT
+cd "$rundir"
+cp "$NGINX_CONF" nginx.conf
+mkdir -p nginx-cache
+sed -i "s~@tmpdir@~$rundir/nginx-cache~g" nginx.conf
+echo "[+] Starting nginx on port 8888"
+echo "[+] Home page: http://127.0.0.1:8888"
+nginx -c "$rundir"/nginx.conf

--- a/scripts/run-full-environment.sh
+++ b/scripts/run-full-environment.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+scriptdir=$(dirname $0)
+$(nix-build "$scriptdir"/integration-tests --no-out-link -A run-full-environment)/bin/run-full-environment


### PR DESCRIPTION
This is a first step towards writing an integration test suite.

We set up an environment running the curiosity server behind a Nginx proxy. This environment is mostly provisioned using the various nix build artifacts.

While this setup do not provides an isolation level comparable to a VM-based one, it's much more lightweight.

We had to cut some corners on the Nginx side. We did not find a satisfactory solution to extract the configuration file from a NixOS machine description. We're instead using a template text file.

We expose this script via a new target in the top-level default.nix, via a script file living in `/scripts/integration-tests/` and via a `nix-shell` bash alias.