### PR TITLE
Clean Conf data type

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -6,9 +6,9 @@
         "type": "git"
     },
     "commence": {
-        "branch": "main",
+        "branch": "noteed/feature/conf",
         "repo": "git@github.com:hypered/commence.git",
-        "rev": "660595245e76db6b6d5bae971525ea77224b1162",
+        "rev": "19b1f32b2b68f246a2488f91a26ee1072d0dd318",
         "type": "git"
     },
     "design-hs": {

--- a/src/Curiosity/Parse.hs
+++ b/src/Curiosity/Parse.hs
@@ -43,25 +43,8 @@ data ServerConf = ServerConf
   , _serverScenariosDir  :: FilePath
   , _serverCookie        :: SAuth.CookieSettings
     -- ^ Settings for setting cookies as a server (for authentication etc.).
-  , _serverMkJwtSettings :: JWK.JWK -> SAuth.JWTSettings
-    -- ^ JWK settings to use, depending on the key employed.
   }
-
-instance Eq ServerConf where
-  -- TODO This should be automatically derived: see to fix _serverMkJwtSettings.
-  a == b =
-    _serverPort b
-      == _serverPort b
-      && _serverStaticDir a
-      == _serverStaticDir b
-      && _serverDataDir a
-      == _serverDataDir b
-      && _serverScenariosDir a
-      == _serverScenariosDir b
-      && _serverCookie a
-      == _serverCookie b
-
-instance Show ServerConf
+  deriving (Eq, Show)
 
 
 --------------------------------------------------------------------------------
@@ -121,8 +104,6 @@ serverParser = do
                                , SAuth.cookieXsrfSetting = Nothing -- XSRF disabled to simplify curl calls (same as start-servant)
                                , SAuth.cookieSameSite    = SAuth.SameSiteStrict
                                }
-      -- FIXME: See if this can be customized via parsing.
-    , _serverMkJwtSettings = SAuth.defaultJWTSettings
     , ..
     }
 
@@ -133,7 +114,6 @@ defaultServerConf = ServerConf
                              , SAuth.cookieXsrfSetting = Nothing
                              , SAuth.cookieSameSite    = SAuth.SameSiteStrict
                              }
-  , _serverMkJwtSettings = SAuth.defaultJWTSettings
   , _serverPort          = 9000
   , _serverStaticDir     = "./_site/"
   , _serverDataDir       = "./data/"

--- a/src/Curiosity/Process.hs
+++ b/src/Curiosity/Process.hs
@@ -19,7 +19,7 @@ import qualified Curiosity.Server              as Srv
 --------------------------------------------------------------------------------
 startServer :: Command.ServerConf -> Rt.Runtime -> IO Errs.RuntimeErr
 startServer conf runtime@Rt.Runtime {..} = do
-  let Command.ServerConf port _ _ _ _ _ = conf
+  let Command.ServerConf port _ _ _ _ = conf
   startupLogInfo _rLoggers $ "Starting up server on port " <> show port <> "..."
   try @SomeException (Srv.run conf runtime) >>= pure . either
     Errs.RuntimeException

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -586,7 +586,8 @@ run
   -> m ()
 run conf@Command.ServerConf {..} runtime = liftIO $ do
   jwk <- SAuth.generateKey
-  let jwtSettings = _serverMkJwtSettings jwk
+  -- FIXME: See if this can be customized via parsing.
+  let jwtSettings = SAuth.defaultJWTSettings jwk
   Warp.run _serverPort $ waiApp jwtSettings
  where
   waiApp jwtS = serve @Rt.AppM (Rt.appMHandlerNatTrans runtime)
@@ -628,7 +629,8 @@ routingLayout :: forall m . MonadIO m => m Text
 routingLayout = do
   let Command.ServerConf {..} = Command.defaultServerConf
   jwk <- liftIO SAuth.generateKey
-  let jwtSettings = _serverMkJwtSettings jwk
+  -- FIXME: See if this can be customized via parsing.
+  let jwtSettings = SAuth.defaultJWTSettings jwk
   let ctx =
         _serverCookie
           Server.:. jwtSettings


### PR DESCRIPTION
This removes a function from the `Conf` data type, and also bump the Commence dependency for similar reason.