### PR TITLE
Complete the quotation flow done through the web interface

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -12,6 +12,23 @@ available at [`smartcoop.sh`](//smartcoop.sh) for demonstration purpose. For
 tech savvy users, the complete system is packaged as a [virtual machine
 image](/documentation/machine), made to be easily run and explored.
 
+## Documented
+
+To achieve our goals in making Curiosity a central place to inform future
+developments, the complete documentation is part of the virtual machine image.
+The documentation is comprised of HTML pages, visible at
+[`smartcoop.sh`](//smartcoop.sh/documentation), and [man
+pages](/documentation/man-pages), available from the terminal within the
+virtual machine.
+
+The documentation part of the Curiosity project is its main goal. The running
+prototype is written and used to help us make the documentation accurate and
+live; i.e. the documentation reflects the code without reformulating manually
+its behavior, but actually runs it or directly queries it.
+
+In particular, business features are demonstrated through [executable
+scenarios](/documentation/scenarios).
+
 ## Experimental
 
 Curiosity is being developed to inform further developments, and is not
@@ -23,12 +40,3 @@ Smart Coop are.
 
 Curiosity is an open source project distributed under a 2-clause BSD license.
 It is available on [GitHub](https://github.com/hypered/curiosity).
-
-## Documented
-
-To achieve our goals in making Curiosity a central place to inform future
-developments, the complete documentation is part of the virtual machine image.
-The documentation is comprised of HTML pages, visible at
-[`smartcoop.sh`](//smartcoop.sh/documentation), and [man
-pages](/documentation/man-pages), available from the terminal within the
-virtual machine.

--- a/content/documentation.md
+++ b/content/documentation.md
@@ -7,6 +7,9 @@ title: Curiosity
 
 - [About](/about)
 - [Application state](/documentation/state)
+  - [Sent emails](/documentation/emails)
+  - [Quotations](/documentation/quotations)
+  - [Orders](/documentation/orders)
 - [Changelog](/documentation/changelog)
 - [Command-line interfaces](/documentation/clis)
 - [Deployment](/documentation/deployment)

--- a/content/documentation.md
+++ b/content/documentation.md
@@ -10,6 +10,7 @@ title: Curiosity
 - [Changelog](/documentation/changelog)
 - [Command-line interfaces](/documentation/clis)
 - [Deployment](/documentation/deployment)
+- [Emails](/documentation/emails)
 - [Environments](/documentation/environments)
 - [Forms](/documentation/forms)
 - [Library documentation](/documentation/library)

--- a/content/documentation/emails.md
+++ b/content/documentation/emails.md
@@ -19,3 +19,4 @@ The complete queue can be seen at [`/emails`](/emails) and
 
 - [Application state](/documentation/state)
 - [Quotations](/documentation/quotations)
+- [Orders](/documentation/orders)

--- a/content/documentation/emails.md
+++ b/content/documentation/emails.md
@@ -1,0 +1,16 @@
+---
+title: Curiosity
+---
+
+# Sent emails
+
+All the emails that are sent by the system go through an internal queue.
+Sending an email, from the point of view of the system, can thus be done
+atomically within a transaction: either the action that sends an email is done
+completely, or not at all, including sending the email.
+
+Another process should actually send the emails outside the system and drain
+the queue.
+
+The complete queue can be seen at [`/emails`](/emails) and
+[`/emails.json`](/emails.json).

--- a/content/documentation/emails.md
+++ b/content/documentation/emails.md
@@ -2,6 +2,12 @@
 title: Curiosity
 ---
 
+# Email templates
+
+All the emails that can be sent by the system are given by variants of the
+`EmailTemplate` data type. See [their
+documentation](/haddock/Curiosity-Data-Email.html#t:EmailTemplate).
+
 # Sent emails
 
 All the emails that are sent by the system go through an internal queue.

--- a/content/documentation/emails.md
+++ b/content/documentation/emails.md
@@ -14,3 +14,8 @@ the queue.
 
 The complete queue can be seen at [`/emails`](/emails) and
 [`/emails.json`](/emails.json).
+
+# See also
+
+- [Application state](/documentation/state)
+- [Quotations](/documentation/quotations)

--- a/content/documentation/orders.md
+++ b/content/documentation/orders.md
@@ -1,0 +1,14 @@
+---
+title: Curiosity
+---
+
+# Orders
+
+All the orders existing in the system can be seen at [`/orders`](/orders) and
+[`/orders.json`](/orders.json).
+
+# See also
+
+- [Application state](/documentation/state)
+- [Sent emails](/documentation/emails)
+- [Quotations](/documentation/quotations)

--- a/content/documentation/quotations.md
+++ b/content/documentation/quotations.md
@@ -1,0 +1,13 @@
+---
+title: Curiosity
+---
+
+# Quotations
+
+All the quotations existing in the system can be seen at
+[`/quotations`](/quotations) and [`/quotations.json`](/quotations.json).
+
+# See also
+
+- [Application state](/documentation/state)
+- [Sent emails](/documentation/emails)

--- a/content/documentation/quotations.md
+++ b/content/documentation/quotations.md
@@ -11,3 +11,4 @@ All the quotations existing in the system can be seen at
 
 - [Application state](/documentation/state)
 - [Sent emails](/documentation/emails)
+- [Orders](/documentation/orders)

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -15,6 +15,11 @@ files". This makes sure that, as scenarios are created, and as Curiosity
 evolves, the system continues to work as expected, and few bugs can be
 introduced inadvertantly.
 
+To manually run scenarios, see how to use the `cty run` [command-line
+tool](/documentation/clis). If you're a developer, the script to ensure
+scenarios match their corresponding golden files is visible [on
+GitHub](https://github.com/hypered/curiosity/blob/main/tests/run-scenarios.hs)
+
 # Example data
 
 Entering enough data into the system to allow to execute (possibly manually,

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -54,7 +54,7 @@ page](/documentation/live-data).
 
 The test suite of Curiosity contains the following scenarios (those are
 clickable links). For each scenario, it is possible to view all the states
-resulting of each of the commands the execute.
+resulting of each of the commands the scenario executes.
 
 <!--# include virtual="/partials/scenarios" -->
 

--- a/content/documentation/state.md
+++ b/content/documentation/state.md
@@ -60,4 +60,5 @@ in automated [test scenarios](/documentation/scenarios).
 
 # See also
 
+- [Quotations](/documentation/quotations)
 - [Sent emails](/documentation/emails)

--- a/content/documentation/state.md
+++ b/content/documentation/state.md
@@ -60,5 +60,6 @@ in automated [test scenarios](/documentation/scenarios).
 
 # See also
 
-- [Quotations](/documentation/quotations)
 - [Sent emails](/documentation/emails)
+- [Quotations](/documentation/quotations)
+- [Orders](/documentation/orders)

--- a/content/documentation/state.md
+++ b/content/documentation/state.md
@@ -57,3 +57,7 @@ The virtual machine shipped with the prototype (and featured at
 [`smartcoop.sh`](https://smartcoop.sh)) is configured to start with an initial
 state, called [`state-0`](/documentation/state-0). This is the same state used
 in automated [test scenarios](/documentation/scenarios).
+
+# See also
+
+- [Sent emails](/documentation/emails)

--- a/content/documentation/validation.md
+++ b/content/documentation/validation.md
@@ -18,7 +18,7 @@ Example data
     displayed with validation errors.
 
 Some validation data are used to describe and validate contracts. See
-[validation data]( (/documentation/validation-data#simple-contracts).
+[validation data](/documentation/validation-data#simple-contracts).
 
 # See also
 

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -110,6 +110,7 @@ library
     Curiosity.Form.Signup
     Curiosity.Html.Action
     Curiosity.Html.Business
+    Curiosity.Html.Email
     Curiosity.Html.Employment
     Curiosity.Html.Errors
     Curiosity.Html.Homepage

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -119,6 +119,7 @@ library
     Curiosity.Html.Legal
     Curiosity.Html.Misc
     Curiosity.Html.Navbar
+    Curiosity.Html.Order
     Curiosity.Html.Quotation
     Curiosity.Html.Run
     Curiosity.Html.SimpleContract

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,7 +14,7 @@
     "design-hs": {
         "branch": "main",
         "repo": "git@github.com:hypered/smart-design-hs.git",
-        "rev": "3546d3378ed1277935420aa712f58773f976fc5d",
+        "rev": "4233098ba310370587f1b5548e2d78c2d8e0353d",
         "type": "git"
     },
     "gitignore": {

--- a/scenarios/quotation-flow.golden
+++ b/scenarios/quotation-flow.golden
@@ -12,7 +12,7 @@ User created: USER-3
 User updated: USER-3
 10: as susie
 Modifying default user.
-11: forms quotation new
+11: forms quotation new --client charlie
 Quotation form created: TBPJLIUG
 13: forms quotation submit TBPJLIUG
 Quotation form validated.

--- a/scenarios/quotation-flow.txt
+++ b/scenarios/quotation-flow.txt
@@ -8,7 +8,7 @@ user create charlie c charlie@example.com --accept-tos
 user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 
 as susie
-forms quotation new
+forms quotation new --client charlie
 # forms quotation edit
 forms quotation submit TBPJLIUG
 

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -644,7 +644,11 @@ parserFormQuotation =
          )
 
 parserFormNewQuotation :: A.Parser Command
-parserFormNewQuotation = pure $ FormNewQuotation Quotation.emptyCreateQuotationAll
+parserFormNewQuotation = do
+  client <-
+    A.option (A.eitherReader (Right . User.UserName . T.pack))
+    (A.long "client" <> A.help "Client username." <> A.metavar "USERNAME")
+  pure $ FormNewQuotation $ Quotation.CreateQuotationAll (Just client)
 
 parserFormValidateQuotation :: A.Parser Command
 parserFormValidateQuotation = do

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -286,7 +286,7 @@ createUser
   :: forall runtime
    . StmDb runtime
   -> User.Signup
-  -> STM (Either User.UserErr User.UserId)
+  -> STM (Either User.Err User.UserId)
 createUser db User.Signup {..} = do
   STM.catchSTM (Right <$> transaction) (pure . Left)
  where
@@ -312,7 +312,7 @@ createUserFull
   :: forall runtime
    . StmDb runtime
   -> User.UserProfile
-  -> STM (Either User.UserErr User.UserId)
+  -> STM (Either User.Err User.UserId)
 createUserFull db newProfile = if username `elem` User.usernameBlocklist
   then pure . Left $ User.UsernameBlocked
   else do

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -15,6 +15,8 @@ module Curiosity.Core
   , modifyUsers
   , selectUserById
   , selectUserByUsername
+  , modifyQuotations
+  , selectQuotationById
   -- * ID generation
   , generateUserId
   , generateBusinessId
@@ -336,11 +338,12 @@ modifyUsers
   -> ([User.UserProfile] -> [User.UserProfile])
   -> STM ()
 modifyUsers db f =
-  let usersTVar = _dbUserProfiles db in STM.modifyTVar usersTVar f
+  let tvar = _dbUserProfiles db in STM.modifyTVar tvar f
 
+selectUserById :: forall runtime . StmDb runtime -> User.UserId -> STM (Maybe User.UserProfile)
 selectUserById db id = do
-  let usersTVar = _dbUserProfiles db
-  STM.readTVar usersTVar <&> find ((== id) . User._userProfileId)
+  let tvar = _dbUserProfiles db
+  STM.readTVar tvar <&> find ((== id) . User._userProfileId)
 
 selectUserByUsername
   :: forall runtime
@@ -348,10 +351,30 @@ selectUserByUsername
   -> User.UserName
   -> STM (Maybe User.UserProfile)
 selectUserByUsername db username = do
-  let usersTVar = _dbUserProfiles db
-  users' <- STM.readTVar usersTVar
+  let tvar = _dbUserProfiles db
+  records <- STM.readTVar tvar
   pure $ find ((== username) . User._userCredsName . User._userProfileCreds)
-              users'
+              records
+
+
+--------------------------------------------------------------------------------
+modifyQuotations
+  :: forall runtime
+   . StmDb runtime
+  -> ([Quotation.Quotation] -> [Quotation.Quotation])
+  -> STM ()
+modifyQuotations db f =
+  let tvar = _dbQuotations db in STM.modifyTVar tvar f
+
+selectQuotationById
+  :: forall runtime
+   . StmDb runtime
+  -> Quotation.QuotationId
+  -> STM (Maybe Quotation.Quotation)
+selectQuotationById db id = do
+  let tvar = _dbQuotations db
+  records <- STM.readTVar tvar
+  pure $ find ((== id) . Quotation._quotationId) records
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -32,8 +32,9 @@ import           Web.FormUrlEncoded             ( FromForm(..)
 --------------------------------------------------------------------------------
 -- | This represents an email in database.
 data Email = Email
-  { _emailId :: EmailId
-  , _emailTemplate :: EmailTemplate
+  { _emailId        :: EmailId
+  , _emailTemplate  :: EmailTemplate
+  , _emailSender    :: User.UserEmailAddr
   , _emailRecipient :: User.UserEmailAddr
   }
   deriving (Show, Eq, Generic)

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -10,8 +10,10 @@ sent during an STM operation. A separate thread should actually handle them.
 
 -}
 module Curiosity.Data.Email
-  ( -- * Main data representation
-    Email(..)
+  ( -- * Useful constants
+    systemEmailAddr
+    -- * Main data representation
+  , Email(..)
   , EmailId(..)
   , emailIdPrefix
   , EmailTemplate(..)
@@ -27,6 +29,10 @@ import           Data.Aeson
 import qualified Text.Blaze.Html5              as H
 import           Web.FormUrlEncoded             ( FromForm(..)
                                                 )
+
+--------------------------------------------------------------------------------
+systemEmailAddr :: User.UserEmailAddr
+systemEmailAddr = "hello@smartcoop.sh"
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -69,11 +69,13 @@ emailTemplateName t = case t of
 
 --------------------------------------------------------------------------------
 -- | Predicates to filter users.
-data Predicate = AllEmails
+data Predicate = AllEmails | EmailsFor User.UserEmailAddr
   deriving (Eq, Show)
 
 applyPredicate :: Predicate -> Email -> Bool
 applyPredicate AllEmails _ = True
+
+applyPredicate (EmailsFor addr) Email {..} = addr == _emailRecipient
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -15,6 +15,7 @@ module Curiosity.Data.Email
   , EmailId(..)
   , emailIdPrefix
   , EmailTemplate(..)
+  , emailTemplateName
   , Predicate(..)
   , applyPredicate
   , Err(..)
@@ -57,6 +58,13 @@ emailIdPrefix = "EMAIL-"
 data EmailTemplate = SignupConfirmationEmail | QuotationEmail | InvoiceEmail | InvoiceReminderEmail
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
+
+emailTemplateName :: EmailTemplate -> Text
+emailTemplateName t = case t of
+  SignupConfirmationEmail -> "SignupConfirmation"
+  QuotationEmail -> "Quotation"
+  InvoiceEmail -> "Invoice"
+  InvoiceReminderEmail -> "InvoiceReminder"
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -70,6 +70,8 @@ data EmailTemplate =
     SignupConfirmationEmail
     -- ^ An email sent upon signup (see `Curiosity.Data.User.Signup`).
   | QuotationEmail
+    -- ^ An email sent when a quotation form is successfully submitted to the
+    -- system (see `Curiosity.Data.Quotation.SubmitQuotation`).
   | InvoiceEmail
   | InvoiceReminderEmail
   deriving (Show, Eq, Generic)

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -15,6 +15,8 @@ module Curiosity.Data.Email
   , EmailId(..)
   , emailIdPrefix
   , EmailTemplate(..)
+  , Predicate(..)
+  , applyPredicate
   , Err(..)
   ) where
 
@@ -50,10 +52,23 @@ newtype EmailId = EmailId { unEmailId :: Text }
 emailIdPrefix :: Text
 emailIdPrefix = "EMAIL-"
 
+
+--------------------------------------------------------------------------------
 data EmailTemplate = SignupConfirmationEmail | QuotationEmail | InvoiceEmail | InvoiceReminderEmail
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+
+--------------------------------------------------------------------------------
+-- | Predicates to filter users.
+data Predicate = AllEmails
+  deriving (Eq, Show)
+
+applyPredicate :: Predicate -> Email -> Bool
+applyPredicate AllEmails _ = True
+
+
+--------------------------------------------------------------------------------
 data Err = Err
   { unErr :: Text
   }

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -5,7 +5,7 @@ Module: Curiosity.Data.Email
 Description: Email -related data types.
 
 This module contains data types used to represent emails. Within
-`Curiosity.Data`, they are used to record atomically that an email should be
+"Curiosity.Data", they are used to record atomically that an email should be
 sent during an STM operation. A separate thread should actually handle them.
 
 -}
@@ -62,7 +62,16 @@ emailIdPrefix = "EMAIL-"
 
 
 --------------------------------------------------------------------------------
-data EmailTemplate = SignupConfirmationEmail | QuotationEmail | InvoiceEmail | InvoiceReminderEmail
+-- | All the emails that can be sent by the system are given by variants of the
+-- `EmailTemplate` data type. They can be sent by the
+-- `Curiosity.Core.createEmail` function. (TODO This should be a link to
+-- "Curiosity.Runtime".)
+data EmailTemplate =
+    SignupConfirmationEmail
+    -- ^ An email sent upon signup (see `Curiosity.Data.User.Signup`).
+  | QuotationEmail
+  | InvoiceEmail
+  | InvoiceReminderEmail
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
 

--- a/src/Curiosity/Data/Order.hs
+++ b/src/Curiosity/Data/Order.hs
@@ -13,6 +13,8 @@ module Curiosity.Data.Order
     Order(..)
   , OrderId(..)
   , orderIdPrefix
+  , Predicate(..)
+  , applyPredicate
   , Err(..)
   ) where
 
@@ -45,6 +47,17 @@ newtype OrderId = OrderId { unOrderId :: Text }
 orderIdPrefix :: Text
 orderIdPrefix = "ORD-"
 
+
+--------------------------------------------------------------------------------
+-- | Predicates to filter orders.
+data Predicate = AllOrders
+  deriving (Eq, Show)
+
+applyPredicate :: Predicate -> Order -> Bool
+applyPredicate AllOrders _ = True
+
+
+--------------------------------------------------------------------------------
 data Err = Err
   { unErr :: Text
   }

--- a/src/Curiosity/Data/Quotation.hs
+++ b/src/Curiosity/Data/Quotation.hs
@@ -35,6 +35,7 @@ module Curiosity.Data.Quotation
 
 import qualified Commence.Runtime.Errors       as Errs
 import qualified Commence.Types.Wrapped        as W
+import qualified Curiosity.Data.Order          as Order
 import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Html.Errors         as Pages
 import           Data.Aeson
@@ -155,12 +156,19 @@ newtype QuotationId = QuotationId { unQuotationId :: Text }
 quotationIdPrefix :: Text
 quotationIdPrefix = "QUOT-"
 
-data QuotationState = QuotationCreated | QuotationSent | QuotationSigned
+data QuotationState =
+    QuotationCreated
+  | QuotationSent
+  | QuotationSigned Order.OrderId
+    -- ^ A signed quotation is necessarily linked to a created order.
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
 displayQuotationState :: QuotationState -> Text
-displayQuotationState = T.drop (T.length "Quotation") . show
+displayQuotationState = \case
+  QuotationCreated    -> "Created"
+  QuotationSent       -> "Sent"
+  QuotationSigned oid -> "Signed (" <> Order.unOrderId oid <> ")"
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/Quotation.hs
+++ b/src/Curiosity/Data/Quotation.hs
@@ -39,7 +39,6 @@ import qualified Curiosity.Data.Order          as Order
 import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Html.Errors         as Pages
 import           Data.Aeson
-import qualified Data.Text                     as T
 import qualified Data.Text.Lazy                as LT
 import qualified Network.HTTP.Types            as HTTP
 import qualified Text.Blaze.Html5              as H

--- a/src/Curiosity/Data/Quotation.hs
+++ b/src/Curiosity/Data/Quotation.hs
@@ -26,6 +26,7 @@ module Curiosity.Data.Quotation
   , QuotationId(..)
   , quotationIdPrefix
   , QuotationState(..)
+  , displayQuotationState
   , Predicate(..)
   , applyPredicate
   , Err(..)
@@ -34,6 +35,7 @@ module Curiosity.Data.Quotation
 import qualified Commence.Types.Wrapped        as W
 import qualified Curiosity.Data.User           as User
 import           Data.Aeson
+import qualified Data.Text                     as T
 import qualified Text.Blaze.Html5              as H
 import           Web.FormUrlEncoded             ( FromForm(..)
                                                 , parseMaybe
@@ -149,6 +151,9 @@ quotationIdPrefix = "QUOT-"
 data QuotationState = QuotationCreated | QuotationSent | QuotationSigned
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
+
+displayQuotationState :: QuotationState -> Text
+displayQuotationState = T.drop (T.length "Quotation") . show
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/Quotation.hs
+++ b/src/Curiosity/Data/Quotation.hs
@@ -57,6 +57,7 @@ data CreateQuotationAll = CreateQuotationAll
 
 instance FromForm CreateQuotationAll where
   fromForm f = CreateQuotationAll <$> parseMaybe "client-username" f
+    -- TODO Make it Nothing if empty string.
 
 
 --------------------------------------------------------------------------------
@@ -93,17 +94,18 @@ instance FromForm SubmitQuotation where
 validateCreateQuotation
   :: User.UserProfile -> CreateQuotationAll
   -> Maybe User.UserProfile -- ^ The user profile matching the quotation client.
-  -> Either [Err] Quotation
-validateCreateQuotation _ CreateQuotationAll {..} resolvedClient = if null errors
-  then Right quotation
+  -> Either [Err] (Quotation, User.UserProfile)
+validateCreateQuotation _ CreateQuotationAll {..} mresolvedClient = if null errors
+  then Right (quotation, resolvedClient)
   else Left errors
  where
   quotation = Quotation { _quotationId = QuotationId "TODO-DUMMY" }
+  Just resolvedClient = mresolvedClient
   errors = concat
     [ if isJust _createQuotationClientUsername
       then []
       else [Err "Missing client username."]
-    , if isJust resolvedClient
+    , if isJust mresolvedClient
       then []
       else [Err "The client username does not exist."]
     ]

--- a/src/Curiosity/Data/Quotation.hs
+++ b/src/Curiosity/Data/Quotation.hs
@@ -25,6 +25,7 @@ module Curiosity.Data.Quotation
   , Quotation(..)
   , QuotationId(..)
   , quotationIdPrefix
+  , QuotationState(..)
   , Predicate(..)
   , applyPredicate
   , Err(..)
@@ -101,7 +102,10 @@ validateCreateQuotation _ CreateQuotationAll {..} mresolvedClient = if null erro
   then Right (quotation, resolvedClient)
   else Left errors
  where
-  quotation = Quotation { _quotationId = QuotationId "TODO-DUMMY" }
+  quotation = Quotation
+     { _quotationId = QuotationId "TODO-DUMMY"
+     , _quotationState = QuotationSent
+     }
   Just resolvedClient = mresolvedClient
   errors = concat
     [ if isJust _createQuotationClientUsername
@@ -122,7 +126,8 @@ validateCreateQuotation' profile quotation resolvedClient =
 --------------------------------------------------------------------------------
 -- | This represents a quotation in database.
 data Quotation = Quotation
-  { _quotationId :: QuotationId
+  { _quotationId    :: QuotationId
+  , _quotationState :: QuotationState
   }
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
@@ -140,6 +145,10 @@ newtype QuotationId = QuotationId { unQuotationId :: Text }
 
 quotationIdPrefix :: Text
 quotationIdPrefix = "QUOT-"
+
+data QuotationState = QuotationCreated | QuotationSent | QuotationSigned
+  deriving (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/Quotation.hs
+++ b/src/Curiosity/Data/Quotation.hs
@@ -25,6 +25,8 @@ module Curiosity.Data.Quotation
   , Quotation(..)
   , QuotationId(..)
   , quotationIdPrefix
+  , Predicate(..)
+  , applyPredicate
   , Err(..)
   ) where
 
@@ -139,6 +141,17 @@ newtype QuotationId = QuotationId { unQuotationId :: Text }
 quotationIdPrefix :: Text
 quotationIdPrefix = "QUOT-"
 
+
+--------------------------------------------------------------------------------
+-- | Predicates to filter quotations.
+data Predicate = AllQuotations
+  deriving (Eq, Show)
+
+applyPredicate :: Predicate -> Quotation -> Bool
+applyPredicate AllQuotations _ = True
+
+
+--------------------------------------------------------------------------------
 data Err = Err
   { unErr :: Text
   }

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -277,6 +277,7 @@ instance Storage.DBStorageOps UserProfile where
 data Predicate = PredicateEmailAddrToVerify | PredicateHas AccessRight
   deriving (Eq, Show)
 
+applyPredicate :: Predicate -> UserProfile -> Bool
 applyPredicate PredicateEmailAddrToVerify UserProfile {..} =
   isNothing _userProfileEmailAddrVerified
 

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -47,7 +47,7 @@ module Curiosity.Data.User
   , Storage.DBUpdate(..)
   , Storage.DBSelect(..)
   -- * Errors
-  , UserErr(..)
+  , Err(..)
   , usernameBlocklist
   ) where
 
@@ -283,7 +283,7 @@ applyPredicate PredicateEmailAddrToVerify UserProfile {..} =
 
 applyPredicate (PredicateHas a) UserProfile {..} = a `elem` _userProfileRights
 
-data UserErr = UserExists
+data Err = UserExists
              | UsernameBlocked -- ^ See `usernameBlocklist`.
              | UserNotFound Text -- Username or ID.
              | IncorrectUsernameOrPassword
@@ -291,7 +291,7 @@ data UserErr = UserExists
              | MissingRight AccessRight
              deriving (Eq, Exception, Show)
 
-instance Errs.IsRuntimeErr UserErr where
+instance Errs.IsRuntimeErr Err where
   errCode = errCode' . \case
     UserExists                  -> "USER_EXISTS"
     UsernameBlocked             -> "USERNAME_BLOCKED"

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -198,7 +198,7 @@ newtype UserDisplayName = UserDisplayName { unUserDisplayName :: Text }
                           ) via Text
                  deriving (FromHttpApiData, FromForm) via W.Wrapped "display-name" Text
 
-newtype UserEmailAddr = UserEmailAddr Text
+newtype UserEmailAddr = UserEmailAddr { unUserEmailAddr :: Text }
                  deriving ( Eq
                           , Show
                           , IsString

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -22,6 +22,7 @@ import qualified Curiosity.Core                as Core
 import qualified Curiosity.Data                as Data
 import           Curiosity.Data                 ( HaskDb
                                                 )
+import qualified Curiosity.Data.Email          as Email
 import qualified Curiosity.Data.User           as User
 import qualified Language.Haskell.TH.Syntax    as Syntax
 import           Prelude                 hiding ( state )
@@ -61,7 +62,7 @@ signup
   :: User.UserName
   -> User.Password
   -> User.UserEmailAddr
-  -> Run (Either User.Err User.UserId)
+  -> Run (Either User.Err (User.UserId, Email.EmailId))
 signup username password email =
   ask >>= (Run . lift . flip Core.createUser input)
   where input = User.Signup username password email True

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -61,7 +61,7 @@ signup
   :: User.UserName
   -> User.Password
   -> User.UserEmailAddr
-  -> Run (Either User.UserErr User.UserId)
+  -> Run (Either User.Err User.UserId)
 signup username password email =
   ask >>= (Run . lift . flip Core.createUser input)
   where input = User.Signup username password email True

--- a/src/Curiosity/Html/Action.hs
+++ b/src/Curiosity/Html/Action.hs
@@ -5,11 +5,13 @@ under e.g. `cty user do` and the action menu on table views.
 -}
 module Curiosity.Html.Action
   ( SetUserEmailAddrAsVerifiedPage(..)
+  , SetQuotationAsSignedPage(..)
   , ActionResult(..)
   , EchoPage(..)
   ) where
 
-import           Curiosity.Data.User           as User
+import qualified Curiosity.Data.Quotation      as Quotation
+import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
 import qualified Smart.Html.Dsl                as Dsl
 import           Smart.Html.Panel               ( Panel(..) )
@@ -66,6 +68,33 @@ setUserEmailAddrAsVerifiedForm username = H.form $ do
   H.input ! A.type_ "hidden" ! A.id "username" ! A.name "username" ! A.value
     (H.toValue username)
   button "/a/set-email-addr-as-verified" "Set as verified"
+
+
+--------------------------------------------------------------------------------
+-- | A form to perform the SetQuotationAsSigned action.
+data SetQuotationAsSignedPage = SetQuotationAsSignedPage
+  { setQuotationAsSignedQuotation :: Quotation.Quotation
+    -- ^ The quotation to be set as signed.
+  }
+
+instance H.ToMarkup SetQuotationAsSignedPage where
+  toMarkup SetQuotationAsSignedPage {..} =
+    let id = Quotation._quotationId setQuotationAsSignedQuotation
+    in  fullScrollWrapper . panelWrapper $ do
+          H.toMarkup $ setQuotationAsSignedPanel id
+          setQuotationAsSignedForm id
+
+setQuotationAsSignedPanel id =
+  PanelHeaderAndBody "Set quotation as signed"
+    $ H.dl
+    ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
+    $ do
+        keyValuePair "ID" id
+
+setQuotationAsSignedForm id = H.form $ do
+  H.input ! A.type_ "hidden" ! A.id "quotation-id" ! A.name "quotation-id" ! A.value
+    (H.toValue id)
+  button "/a/set-quotation-as-signed" "Set as signed"
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Email.hs
+++ b/src/Curiosity/Html/Email.hs
@@ -29,7 +29,7 @@ instance H.ToMarkup EmailPage where
 
 
 --------------------------------------------------------------------------------
--- | Display enqueued emails that are to the logged in user.
+-- | Display enqueued emails.
 panelSentEmails :: [Email.Email] -> H.Html
 panelSentEmails emails =
   panel' "Emails queued" $ Misc.table titles display emails

--- a/src/Curiosity/Html/Email.hs
+++ b/src/Curiosity/Html/Email.hs
@@ -32,11 +32,15 @@ instance H.ToMarkup EmailPage where
 -- | Display enqueued emails that are to the logged in user.
 panelSentEmails :: [Email.Email] -> H.Html
 panelSentEmails emails =
-  panel' "Emails to be received" $ Misc.table titles display emails
+  panel' "Emails queued" $ Misc.table titles display emails
  where
-  titles = ["ID", "Template", "Recipient"]
+  titles = ["ID", "Template", "Sender", "Recipient"]
   display Email.Email {..} =
-    ( [Email.unEmailId _emailId, Email.emailTemplateName _emailTemplate, User.unUserEmailAddr _emailRecipient]
+    ( [ Email.unEmailId _emailId
+      , Email.emailTemplateName _emailTemplate
+      , User.unUserEmailAddr _emailSender
+      , User.unUserEmailAddr _emailRecipient
+      ]
     , []
     , Nothing
     )

--- a/src/Curiosity/Html/Email.hs
+++ b/src/Curiosity/Html/Email.hs
@@ -34,9 +34,9 @@ panelSentEmails :: [Email.Email] -> H.Html
 panelSentEmails emails =
   panel' "Emails to be received" $ Misc.table titles display emails
  where
-  titles = ["ID", "Template"]
+  titles = ["ID", "Template", "Recipient"]
   display Email.Email {..} =
-    ( [Email.unEmailId _emailId, Email.emailTemplateName _emailTemplate]
+    ( [Email.unEmailId _emailId, Email.emailTemplateName _emailTemplate, User.unUserEmailAddr _emailRecipient]
     , []
     , Nothing
     )

--- a/src/Curiosity/Html/Email.hs
+++ b/src/Curiosity/Html/Email.hs
@@ -1,0 +1,42 @@
+{- |
+Module: Curiosity.Html.Email
+Description: Page and components to display emails.
+-}
+module Curiosity.Html.Email
+  ( EmailPage(..)
+  , panelSentEmails
+  ) where
+
+import qualified Curiosity.Data.Email          as Email
+import qualified Curiosity.Data.User           as User
+import           Curiosity.Html.Misc
+import qualified Smart.Html.Misc               as Misc
+import qualified Text.Blaze.Html5              as H
+
+
+--------------------------------------------------------------------------------
+-- | The page displaye at @/emails@ to show all enqueued emails.
+data EmailPage = EmailPage
+  { _emailPageUser   :: Maybe User.UserProfile
+    -- ^ The logged-in user, if any.
+  , _emailPageEmails :: [Email.Email]
+    -- ^ All enqueued emails.
+  }
+
+instance H.ToMarkup EmailPage where
+  toMarkup (EmailPage mprofile emails) =
+    renderView' mprofile $ panelSentEmails emails
+
+
+--------------------------------------------------------------------------------
+-- | Display enqueued emails that are to the logged in user.
+panelSentEmails :: [Email.Email] -> H.Html
+panelSentEmails emails =
+  panel' "Emails to be received" $ Misc.table titles display emails
+ where
+  titles = ["ID", "Template"]
+  display Email.Email {..} =
+    ( [Email.unEmailId _emailId, Email.emailTemplateName _emailTemplate]
+    , []
+    , Nothing
+    )

--- a/src/Curiosity/Html/Email.hs
+++ b/src/Curiosity/Html/Email.hs
@@ -32,7 +32,7 @@ instance H.ToMarkup EmailPage where
 -- | Display enqueued emails.
 panelSentEmails :: [Email.Email] -> H.Html
 panelSentEmails emails =
-  panel' "Emails queued" $ Misc.table titles display emails
+  panel' "Emails queued" $ Misc.table "emails" titles display emails
  where
   titles = ["ID", "Template", "Sender", "Recipient"]
   display Email.Email {..} =

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -151,7 +151,7 @@ groupExpenses mkey expenses submitUrl = do
                                                           "Add expense"
     case mkey of
       Just key | not (null expenses) ->
-        Misc.table titles (uncurry $ display key) $ zip [0 ..] expenses
+        Misc.table "expenses" titles (uncurry $ display key) $ zip [0 ..] expenses
       _ -> pure ()
     when (not $ null expenses) $ buttonGroup $ buttonAdd submitUrl "Add expense"
  where
@@ -293,7 +293,7 @@ instance H.ToMarkup ConfirmContractPage where
               H.p
                 ! A.class_ "u-text-muted c-body-1"
                 $ "You have no expenses right now."
-            else Misc.table titles display expenses
+            else Misc.table "expenses" titles display expenses
 
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)

--- a/src/Curiosity/Html/Homepage.hs
+++ b/src/Curiosity/Html/Homepage.hs
@@ -9,6 +9,8 @@ module Curiosity.Html.Homepage
 import qualified Curiosity.Data.Email          as Email
 import qualified Curiosity.Data.Quotation      as Quotation
 import qualified Curiosity.Data.User           as User
+import           Curiosity.Html.Email
+import           Curiosity.Html.Misc
 import           Curiosity.Html.Navbar          ( navbar )
 import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Misc               as Misc
@@ -55,7 +57,7 @@ instance H.ToMarkup WelcomePage where
 
 panelEmailAddrToVerify :: [User.UserProfile] -> H.Html
 panelEmailAddrToVerify profiles =
-  panel "Email addresses to verify" $ Misc.table titles display profiles
+  panel' "Email addresses to verify" $ Misc.table titles display profiles
  where
   titles = ["ID", "Username", "Email addr."]
   display User.UserProfile {..} =
@@ -73,7 +75,7 @@ panelEmailAddrToVerify profiles =
 
 panelQuotationForms :: [(Text, Quotation.CreateQuotationAll)] -> H.Html
 panelQuotationForms forms =
-  panel "Quotation forms" $ Misc.table titles display forms
+  panel' "Quotation forms" $ Misc.table titles display forms
  where
   titles = ["Key", "Name"]
   display (key, Quotation.CreateQuotationAll {}) =
@@ -81,36 +83,3 @@ panelQuotationForms forms =
     , []
     , (Just $ "/edit/quotation/" <> key)
     )
-
--- | Display enqueued emails that are to the logged in user.
-panelSentEmails :: [Email.Email] -> H.Html
-panelSentEmails emails =
-  panel "Emails to be received" $ Misc.table titles display emails
- where
-  titles = ["ID", "Template"]
-  display Email.Email {..} =
-    ( [Email.unEmailId _emailId, Email.emailTemplateName _emailTemplate]
-    , []
-    , Nothing
-    )
-
-panel title body =
-  H.div
-    ! A.class_ "o-container o-container--large"
-    $ H.div
-    ! A.class_ "o-container-vertical"
-    $ H.div
-    ! A.class_ "u-padding-vertical-s"
-    $ H.div
-    ! A.class_ "c-panel"
-    $ do
-        H.div
-          ! A.class_ "c-panel__header"
-          $ H.div
-          ! A.class_ "c-toolbar"
-          $ H.div
-          ! A.class_ "c-toolbar__left"
-          $ H.h2
-          ! A.class_ "c-panel__title"
-          $ H.text title
-        H.div ! A.class_ "c-panel__body" $ body

--- a/src/Curiosity/Html/Homepage.hs
+++ b/src/Curiosity/Html/Homepage.hs
@@ -12,6 +12,7 @@ import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Email
 import           Curiosity.Html.Misc
 import           Curiosity.Html.Navbar          ( navbar )
+import           Curiosity.Html.Quotation       ( panelQuotations )
 import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Misc               as Misc
 import qualified Smart.Html.Render             as Render
@@ -28,10 +29,9 @@ data WelcomePage = WelcomePage
   , welcomePageEmailAddrToVerify :: Maybe [User.UserProfile]
     -- ^ Email addr. needing verif., if the user has the right to perform the
     -- corresponding action.
-  , welcomePageQuotationForms :: [(Text, Quotation.CreateQuotationAll)]
-    -- ^ Email addr. needing verif., if the user has the right to perform the
-    -- corresponding action.
-  , welcomePageEmails         :: [Email.Email]
+  , welcomePageQuotationForms    :: [(Text, Quotation.CreateQuotationAll)]
+  , welcomePageQuotations        :: [Quotation.Quotation]
+  , welcomePageEmails            :: [Email.Email]
     -- ^ Enqueued emails being sent to the logged user.
   }
 
@@ -52,6 +52,8 @@ instance H.ToMarkup WelcomePage where
             maybe (pure ()) panelEmailAddrToVerify welcomePageEmailAddrToVerify
 
             panelQuotationForms welcomePageQuotationForms
+
+            panelQuotations welcomePageQuotations
 
             panelSentEmails welcomePageEmails
 

--- a/src/Curiosity/Html/Homepage.hs
+++ b/src/Curiosity/Html/Homepage.hs
@@ -6,6 +6,7 @@ module Curiosity.Html.Homepage
   ( WelcomePage(..)
   ) where
 
+import qualified Curiosity.Data.Email          as Email
 import qualified Curiosity.Data.Quotation      as Quotation
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Navbar          ( navbar )
@@ -28,6 +29,8 @@ data WelcomePage = WelcomePage
   , welcomePageQuotationForms :: [(Text, Quotation.CreateQuotationAll)]
     -- ^ Email addr. needing verif., if the user has the right to perform the
     -- corresponding action.
+  , welcomePageEmails         :: [Email.Email]
+    -- ^ Enqueued emails being sent to the logged user.
   }
 
 instance H.ToMarkup WelcomePage where
@@ -47,6 +50,8 @@ instance H.ToMarkup WelcomePage where
             maybe (pure ()) panelEmailAddrToVerify welcomePageEmailAddrToVerify
 
             panelQuotationForms welcomePageQuotationForms
+
+            panelSentEmails welcomePageEmails
 
 panelEmailAddrToVerify :: [User.UserProfile] -> H.Html
 panelEmailAddrToVerify profiles =
@@ -77,13 +82,25 @@ panelQuotationForms forms =
     , (Just $ "/edit/quotation/" <> key)
     )
 
+-- | Display enqueued emails that are to the logged in user.
+panelSentEmails :: [Email.Email] -> H.Html
+panelSentEmails emails =
+  panel "Emails to be received" $ Misc.table titles display emails
+ where
+  titles = ["ID", "Template"]
+  display Email.Email {..} =
+    ( [Email.unEmailId _emailId, Email.emailTemplateName _emailTemplate]
+    , []
+    , Nothing
+    )
+
 panel title body =
   H.div
     ! A.class_ "o-container o-container--large"
     $ H.div
     ! A.class_ "o-container-vertical"
     $ H.div
-    ! A.class_ "u-padding-vertical-l"
+    ! A.class_ "u-padding-vertical-s"
     $ H.div
     ! A.class_ "c-panel"
     $ do

--- a/src/Curiosity/Html/Homepage.hs
+++ b/src/Curiosity/Html/Homepage.hs
@@ -77,9 +77,9 @@ panelQuotationForms :: [(Text, Quotation.CreateQuotationAll)] -> H.Html
 panelQuotationForms forms =
   panel' "Quotation forms" $ Misc.table titles display forms
  where
-  titles = ["Key", "Name"]
-  display (key, Quotation.CreateQuotationAll {}) =
-    ( [key, "TODO"]
+  titles = ["Key", "Client"]
+  display (key, Quotation.CreateQuotationAll {..}) =
+    ( [key, maybe "" User.unUserName _createQuotationClientUsername]
     , []
-    , (Just $ "/edit/quotation/" <> key)
+    , (Just $ "/edit/quotation/confirm/" <> key)
     )

--- a/src/Curiosity/Html/Homepage.hs
+++ b/src/Curiosity/Html/Homepage.hs
@@ -59,7 +59,7 @@ instance H.ToMarkup WelcomePage where
 
 panelEmailAddrToVerify :: [User.UserProfile] -> H.Html
 panelEmailAddrToVerify profiles =
-  panel' "Email addresses to verify" $ Misc.table titles display profiles
+  panel' "Email addresses to verify" $ Misc.table "addr" titles display profiles
  where
   titles = ["ID", "Username", "Email addr."]
   display User.UserProfile {..} =
@@ -77,7 +77,7 @@ panelEmailAddrToVerify profiles =
 
 panelQuotationForms :: [(Text, Quotation.CreateQuotationAll)] -> H.Html
 panelQuotationForms forms =
-  panel' "Quotation forms" $ Misc.table titles display forms
+  panel' "Quotation forms" $ Misc.table "quotation-forms" titles display forms
  where
   titles = ["Key", "Client"]
   display (key, Quotation.CreateQuotationAll {..}) =

--- a/src/Curiosity/Html/Homepage.hs
+++ b/src/Curiosity/Html/Homepage.hs
@@ -7,11 +7,13 @@ module Curiosity.Html.Homepage
   ) where
 
 import qualified Curiosity.Data.Email          as Email
+import qualified Curiosity.Data.Order          as Order
 import qualified Curiosity.Data.Quotation      as Quotation
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Email
 import           Curiosity.Html.Misc
 import           Curiosity.Html.Navbar          ( navbar )
+import           Curiosity.Html.Order           ( panelOrders )
 import           Curiosity.Html.Quotation       ( panelQuotations )
 import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Misc               as Misc
@@ -31,6 +33,7 @@ data WelcomePage = WelcomePage
     -- corresponding action.
   , welcomePageQuotationForms    :: [(Text, Quotation.CreateQuotationAll)]
   , welcomePageQuotations        :: [Quotation.Quotation]
+  , welcomePageOrders            :: [Order.Order]
   , welcomePageEmails            :: [Email.Email]
     -- ^ Enqueued emails being sent to the logged user.
   }
@@ -54,6 +57,8 @@ instance H.ToMarkup WelcomePage where
             panelQuotationForms welcomePageQuotationForms
 
             panelQuotations welcomePageQuotations
+
+            panelOrders welcomePageOrders
 
             panelSentEmails welcomePageEmails
 

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {- |
 Module: Curiosity.Html.Misc
 Description: Helper functions to build HTML views.
@@ -33,6 +34,8 @@ module Curiosity.Html.Misc
   -- View
   , editButton
 
+  , iconError
+
   -- Keep here:
   , renderView
   , renderView'
@@ -50,7 +53,9 @@ import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Render             as Render
 import           Smart.Html.Shared.Html.Icons   ( divIconAdd
                                                 , divIconCheck
+                                                , svgIconCircleError
                                                 , svgIconEdit
+                                                , OSvgIconDiv(..)
                                                 )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!)
@@ -355,6 +360,11 @@ editButton lnk =
     $ do
         H.div ! A.class_ "o-svg-icon o-svg-icon-edit" $ H.toHtml svgIconEdit
         H.span ! A.class_ "c-button__label" $ "Edit"
+
+
+--------------------------------------------------------------------------------
+iconError =
+  Just $ OSvgIconDiv @"circle-error" svgIconCircleError
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -11,6 +11,7 @@ module Curiosity.Html.Misc
   , fullScroll
   , groupLayout
   , panel
+  , panel'
   , panelStandard
   , header
 
@@ -167,6 +168,27 @@ panel s content = H.div ! A.class_ "c-panel u-spacer-bottom-l" $ do
   H.div ! A.class_ "c-panel__header" $ H.h2 ! A.class_ "c-panel__title" $ H.text
     s
   H.div ! A.class_ "c-panel__body" $ groupLayout $ content
+
+panel' panelTitle body =
+  H.div
+    ! A.class_ "o-container o-container--large"
+    $ H.div
+    ! A.class_ "o-container-vertical"
+    $ H.div
+    ! A.class_ "u-padding-vertical-s"
+    $ H.div
+    ! A.class_ "c-panel"
+    $ do
+        H.div
+          ! A.class_ "c-panel__header"
+          $ H.div
+          ! A.class_ "c-toolbar"
+          $ H.div
+          ! A.class_ "c-toolbar__left"
+          $ H.h2
+          ! A.class_ "c-panel__title"
+          $ H.text panelTitle
+        H.div ! A.class_ "c-panel__body" $ body
 
 panelStandard s content = H.div ! A.class_ "c-panel u-spacer-bottom-l" $ do
   H.div ! A.class_ "c-panel__header" $ H.h2 ! A.class_ "c-panel__title" $ H.text

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -29,7 +29,9 @@ module Curiosity.Html.Misc
   , buttonGroup
   , buttonBar
   , buttonPrimary
+  , buttonPrimaryDisabled
   , buttonSecondary
+  , buttonSecondaryDisabled
 
   -- View
   , editButton
@@ -327,11 +329,29 @@ buttonPrimary submitUrl label =
         H.span ! A.class_ "c-button__label" $ H.text label
         divIconCheck
 
+buttonPrimaryDisabled label =
+  H.button
+    ! A.class_ "c-button c-button--primary"
+    ! A.disabled "disabled"
+    $ H.span
+    ! A.class_ "c-button__content"
+    $ do
+        H.span ! A.class_ "c-button__label" $ H.text label
+        divIconCheck
+
 buttonSecondary submitUrl label =
   H.button
     ! A.class_ "c-button c-button--secondary"
     ! A.formaction submitUrl
     ! A.formmethod "POST"
+    $ H.span
+    ! A.class_ "c-button__content"
+    $ H.span ! A.class_ "c-button__label" $ H.text label
+
+buttonSecondaryDisabled label =
+  H.button
+    ! A.class_ "c-button c-button--secondary"
+    ! A.disabled "disabled"
     $ H.span
     ! A.class_ "c-button__content"
     $ H.span ! A.class_ "c-button__label" $ H.text label

--- a/src/Curiosity/Html/Order.hs
+++ b/src/Curiosity/Html/Order.hs
@@ -1,0 +1,43 @@
+{- |
+Module: Curiosity.Html.Order
+Description: Order pages (view and edit).
+-}
+module Curiosity.Html.Order
+  ( OrderPage(..)
+  , panelOrders
+  ) where
+
+import qualified Curiosity.Data.Order          as Order
+import qualified Curiosity.Data.User           as User
+import           Curiosity.Html.Misc
+import qualified Smart.Html.Misc               as Misc
+import qualified Text.Blaze.Html5              as H
+
+
+--------------------------------------------------------------------------------
+-- | The page displaye at @/orders@ to show all orders.
+data OrderPage = OrderPage
+  { _emailPageUser   :: Maybe User.UserProfile
+    -- ^ The logged-in user, if any.
+  , _emailPageOrders :: [Order.Order]
+    -- ^ All enqueued emails.
+  }
+
+instance H.ToMarkup OrderPage where
+  toMarkup (OrderPage mprofile emails) =
+    renderView' mprofile $ panelOrders emails
+
+
+--------------------------------------------------------------------------------
+-- | Display orders.
+panelOrders :: [Order.Order] -> H.Html
+panelOrders orders =
+  panel' "Orders" $ Misc.table "orders" titles display orders
+ where
+  titles = ["ID"]
+  display Order.Order {..} =
+    ( [ Order.unOrderId _orderId
+      ]
+    , []
+    , Nothing
+    )

--- a/src/Curiosity/Html/Quotation.hs
+++ b/src/Curiosity/Html/Quotation.hs
@@ -11,6 +11,7 @@ module Curiosity.Html.Quotation
 import qualified Curiosity.Data.Quotation      as Quotation
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
+import           Smart.Html.Panel               ( Panel(..) )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
@@ -38,7 +39,7 @@ data CreateQuotationPage = CreateQuotationPage
     -- ^ The user creating the quotation
   , _createQuotationPageKey         :: Maybe Text
     -- ^ The form editing session key, if the form was already saved
-  , _createQuotationQuotation       :: Quotation.CreateQuotationAll
+  , _createQuotationPageQuotation   :: Quotation.CreateQuotationAll
   , _createQuotationPageSubmitURL   :: H.AttributeValue
   }
 
@@ -46,7 +47,8 @@ instance H.ToMarkup CreateQuotationPage where
   toMarkup (CreateQuotationPage profile mkey quotation submitUrl) =
     renderForm profile $ groupLayout $ do
       title "New quotation"
-      inputText "Quotation name" "name" Nothing Nothing
+      inputText "Client username" "client-username"
+        (H.toValue . User.unUserName <$> Quotation._createQuotationClientUsername quotation) Nothing
       submitButton submitUrl
         $ maybe "Create new quotation" (const "Save quotation") mkey
 
@@ -62,9 +64,18 @@ data ConfirmQuotationPage = ConfirmQuotationPage
   }
 
 instance H.ToMarkup ConfirmQuotationPage where
-  toMarkup (ConfirmQuotationPage profile key (Quotation.CreateQuotationAll{}) meditUrl submitUrl)
+  toMarkup (ConfirmQuotationPage profile key (Quotation.CreateQuotationAll {..}) meditUrl submitUrl)
     = renderFormLarge profile $ do
       title' "New quotation" meditUrl
+
+      H.div
+        ! A.class_ "u-padding-vertical-l"
+        $ H.toMarkup
+        $ PanelHeaderAndBody "XXX"
+        $ H.dl
+        ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
+        $ do
+            keyValuePair "Client username" $ maybe "" User.unUserName _createQuotationClientUsername
 
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)

--- a/src/Curiosity/Html/Quotation.hs
+++ b/src/Curiosity/Html/Quotation.hs
@@ -86,7 +86,13 @@ instance H.ToMarkup ConfirmQuotationPage where
 
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)
-      button submitUrl "Submit quotation"
+
+      buttonGroup $ do
+        -- TODO Add edit button
+        let label = "Submit quotation"
+        if null errors
+          then buttonPrimary submitUrl label
+          else buttonPrimaryDisabled label
 
 validationErrors errors =
   if null errors

--- a/src/Curiosity/Html/Quotation.hs
+++ b/src/Curiosity/Html/Quotation.hs
@@ -11,7 +11,10 @@ module Curiosity.Html.Quotation
 import qualified Curiosity.Data.Quotation      as Quotation
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
+import qualified Smart.Html.Alert              as Alert
+import qualified Smart.Html.Button             as Button
 import           Smart.Html.Panel               ( Panel(..) )
+import           Smart.Html.Shared.Types        ( Body(..) )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
@@ -59,14 +62,18 @@ data ConfirmQuotationPage = ConfirmQuotationPage
     -- ^ The user creating the quotation
   , _confirmQuotationPageKey         :: Text
   , _confirmQuotationPageQuotation   :: Quotation.CreateQuotationAll
+  , _confirmQuotationPageErrors      :: [Quotation.Err]
+    -- Validation errors, if any.
   , _confirmQuotationPageEditURL     :: Maybe H.AttributeValue
   , _confirmQuotationPageSubmitURL   :: H.AttributeValue
   }
 
 instance H.ToMarkup ConfirmQuotationPage where
-  toMarkup (ConfirmQuotationPage profile key (Quotation.CreateQuotationAll {..}) meditUrl submitUrl)
+  toMarkup (ConfirmQuotationPage profile key (Quotation.CreateQuotationAll {..}) errors meditUrl submitUrl)
     = renderFormLarge profile $ do
       title' "New quotation" meditUrl
+
+      validationErrors errors
 
       H.div
         ! A.class_ "u-padding-vertical-l"
@@ -80,3 +87,13 @@ instance H.ToMarkup ConfirmQuotationPage where
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)
       button submitUrl "Submit quotation"
+
+validationErrors errors =
+  if null errors
+  then mempty
+  else
+    H.div ! A.class_ "u-spacer-bottom-l" $ H.toMarkup $ Alert.Alert
+      Alert.AlertError
+      iconError
+      (Body $ "Validation errors: " <> show (map Quotation.unErr errors))
+      Button.NoButton

--- a/src/Curiosity/Html/Quotation.hs
+++ b/src/Curiosity/Html/Quotation.hs
@@ -43,10 +43,10 @@ panelQuotations :: [Quotation.Quotation] -> H.Html
 panelQuotations quotations =
   panel' "Quotations" $ Misc.table titles display quotations
  where
-  titles = ["ID"]
+  titles = ["ID", "State"]
   display Quotation.Quotation {..} =
     ( [ Quotation.unQuotationId _quotationId
-      , show _quotationState
+      , Quotation.displayQuotationState  _quotationState
       ]
     , []
     , Nothing

--- a/src/Curiosity/Html/Quotation.hs
+++ b/src/Curiosity/Html/Quotation.hs
@@ -41,14 +41,20 @@ instance H.ToMarkup QuotationPage where
 -- | Display quotations.
 panelQuotations :: [Quotation.Quotation] -> H.Html
 panelQuotations quotations =
-  panel' "Quotations" $ Misc.table titles display quotations
+  panel' "Quotations" $ Misc.table "quotations" titles display quotations
  where
   titles = ["ID", "State"]
   display Quotation.Quotation {..} =
     ( [ Quotation.unQuotationId _quotationId
       , Quotation.displayQuotationState  _quotationState
       ]
-    , []
+    , if _quotationState == Quotation.QuotationSent
+      then [ ( Misc.divIconCheck
+             , "Set as signed"
+             , "/action/set-quotation-as-signed/" <> Quotation.unQuotationId _quotationId
+             )
+           ]
+      else []
     , Nothing
     )
 

--- a/src/Curiosity/Html/Quotation.hs
+++ b/src/Curiosity/Html/Quotation.hs
@@ -46,6 +46,7 @@ panelQuotations quotations =
   titles = ["ID"]
   display Quotation.Quotation {..} =
     ( [ Quotation.unQuotationId _quotationId
+      , show _quotationState
       ]
     , []
     , Nothing

--- a/src/Curiosity/Html/Quotation.hs
+++ b/src/Curiosity/Html/Quotation.hs
@@ -3,7 +3,9 @@ Module: Curiosity.Html.Quotation
 Description: Quotation pages (view and edit).
 -}
 module Curiosity.Html.Quotation
-  ( QuotationView(..)
+  ( QuotationPage(..)
+  , panelQuotations
+  , QuotationView(..)
   , CreateQuotationPage(..)
   , ConfirmQuotationPage(..)
   ) where
@@ -13,11 +15,41 @@ import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
 import qualified Smart.Html.Alert              as Alert
 import qualified Smart.Html.Button             as Button
+import qualified Smart.Html.Misc               as Misc
 import           Smart.Html.Panel               ( Panel(..) )
 import           Smart.Html.Shared.Types        ( Body(..) )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
+
+
+--------------------------------------------------------------------------------
+-- | The page displaye at @/quotations@ to show all quotations.
+data QuotationPage = QuotationPage
+  { _emailPageUser   :: Maybe User.UserProfile
+    -- ^ The logged-in user, if any.
+  , _emailPageQuotations :: [Quotation.Quotation]
+    -- ^ All enqueued emails.
+  }
+
+instance H.ToMarkup QuotationPage where
+  toMarkup (QuotationPage mprofile emails) =
+    renderView' mprofile $ panelQuotations emails
+
+
+--------------------------------------------------------------------------------
+-- | Display quotations.
+panelQuotations :: [Quotation.Quotation] -> H.Html
+panelQuotations quotations =
+  panel' "Quotations" $ Misc.table titles display quotations
+ where
+  titles = ["ID"]
+  display Quotation.Quotation {..} =
+    ( [ Quotation.unQuotationId _quotationId
+      ]
+    , []
+    , Nothing
+    )
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -199,7 +199,7 @@ groupDates editDateBaseUrl removeDateBaseUrl mkey dates submitUrl = do
                                                           "Add date"
     case mkey of
       Just key | not (null dates) ->
-        Misc.table titles (uncurry $ display key) $ zip [0 ..] dates
+        Misc.table "dates" titles (uncurry $ display key) $ zip [0 ..] dates
       _ -> pure ()
     when (not $ null dates) $ buttonGroup $ buttonAdd submitUrl "Add date"
  where
@@ -301,7 +301,7 @@ groupExpenses editExpenseBaseUrl removeExpenseBaseUrl mkey expenses submitUrl = 
                                                           "Add expense"
     case mkey of
       Just key | not (null expenses) ->
-        Misc.table titles (uncurry $ display key) $ zip [0 ..] expenses
+        Misc.table "expenses" titles (uncurry $ display key) $ zip [0 ..] expenses
       _ -> pure ()
     when (not $ null expenses) $ buttonGroup $ buttonAdd submitUrl "Add expense"
  where
@@ -657,7 +657,7 @@ instance H.ToMarkup ConfirmSimpleContractPage where
               H.p
                 ! A.class_ "u-text-muted c-body-1"
                 $ "You have added no expenses."
-            else Misc.table titles display expenses
+            else Misc.table "expenses" titles display expenses
 
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -682,6 +682,3 @@ validationErrors errors =
       iconError
       (Body $ "Validation errors: " <> show (map SimpleContract.unErr errors))
       Button.NoButton
-
-iconError =
-  Just $ OSvgIconDiv @"circle-error" svgIconCircleError

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -661,7 +661,13 @@ instance H.ToMarkup ConfirmSimpleContractPage where
 
       H.input ! A.type_ "hidden" ! A.id "key" ! A.name "key" ! A.value
         (H.toValue key)
-      button submitUrl "Submit contract" -- TODO Add edit button
+
+      buttonGroup $ do
+        -- TODO Add edit button
+        let label = "Submit contract"
+        if null errors
+          then buttonPrimary submitUrl label
+          else buttonPrimaryDisabled label
    where
     username =
       User.unUserName . User._userCredsName $ User._userProfileCreds profile

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -97,22 +97,22 @@ interpret' runtime user dir content nesting = go user [] 0
         separated         = map T.pack . wordsq $ T.unpack prefix
         grouped           = T.unwords separated
         nbr'  = succ nbr
-        trace = Trace nbr
-                      ln
-                      grouped
-                      (if T.null comment then Nothing else Just comment)
-                      nesting
-                      user'
+        trace' = Trace nbr
+                       ln
+                       grouped
+                       (if T.null comment then Nothing else Just comment)
+                       nesting
+                       user'
     case separated of
       []               -> go user' acc nbr rest
       ["as", username] -> do
         st <- Rt.runRunM runtime Rt.state
-        let t    = trace ["Modifying default user."] ExitSuccess [] st
+        let t    = trace' ["Modifying default user."] ExitSuccess [] st
             acc' = acc ++ [t]
         go (User.UserName username) acc' nbr' rest
       ["quit"] -> do
         st <- Rt.runRunM runtime Rt.state
-        let t    = trace ["Exiting."] ExitSuccess [] st
+        let t    = trace' ["Exiting."] ExitSuccess [] st
             acc' = acc ++ [t]
         go user' acc' nbr' rest
       input -> do
@@ -126,7 +126,7 @@ interpret' runtime user dir content nesting = go user [] 0
               Command.Reset _ -> do
                 Rt.runRunM runtime $ Rt.reset
                 st <- Rt.runRunM runtime Rt.state
-                let t = trace ["Resetting to the empty state."] ExitSuccess [] st
+                let t = trace' ["Resetting to the empty state."] ExitSuccess [] st
                     acc' = acc ++ [t]
                 go user' acc' nbr' rest
               Command.Run _ scriptPath -> do
@@ -135,23 +135,23 @@ interpret' runtime user dir content nesting = go user [] 0
                                                   (dir </> scriptPath)
                                                   (succ nesting)
                 st <- Rt.runRunM runtime Rt.state
-                let t    = trace [] ExitSuccess output' st
+                let t    = trace' [] ExitSuccess output' st
                     acc' = acc ++ [t]
                 go user' acc' nbr' rest
               _ -> do
                 (_, output) <- Rt.handleCommand runtime user' command
                 st <- Rt.runRunM runtime Rt.state
-                let t    = trace output ExitSuccess [] st
+                let t    = trace' output ExitSuccess [] st
                     acc' = acc ++ [t]
                 go user' acc' nbr' rest
           A.Failure err -> do
             st <- Rt.runRunM runtime Rt.state
-            let t    = trace [show err] (ExitFailure 1) [] st
+            let t    = trace' [show err] (ExitFailure 1) [] st
                 acc' = acc ++ [t]
             go user' acc' nbr' rest
           A.CompletionInvoked _ -> do
             st <- Rt.runRunM runtime Rt.state
-            let t    = trace ["Shouldn't happen."] (ExitFailure 1) [] st
+            let t    = trace' ["Shouldn't happen."] (ExitFailure 1) [] st
                 acc' = acc ++ [t]
             go user' acc' nbr' rest
 

--- a/src/Curiosity/Parse.hs
+++ b/src/Curiosity/Parse.hs
@@ -16,10 +16,8 @@ module Curiosity.Parse
 import qualified Commence.Multilogging         as ML
 import           Control.Lens                  as Lens
 import qualified Control.Monad.Log             as L
-import qualified Crypto.JOSE.JWK               as JWK
 import qualified Options.Applicative           as A
 import qualified Servant.Auth.Server           as SAuth
-import qualified System.Log.FastLogger         as FL
 
 
 --------------------------------------------------------------------------------
@@ -59,10 +57,6 @@ mkLoggingConf :: FilePath -> ML.LoggingConf
 mkLoggingConf path = ML.LoggingConf (ML.LoggingFile path)
                                     "Curiosity"
                                     L.levelInfo
-
-flspec :: FilePath -> FL.FileLogSpec
-flspec path = FL.FileLogSpec path (1024 * 1024) 10
-  -- 1MB, or about 5240 200-character lines, and keeping 10 rotated files.
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -55,6 +55,9 @@ module Curiosity.Runtime
   , filterQuotations
   , filterQuotations'
   , selectQuotationById
+  -- ** Orders
+  , filterOrders
+  , filterOrders'
   -- ** Contract
   , newCreateContractForm
   , readCreateContractForm
@@ -1241,6 +1244,20 @@ selectQuotationById
   -> IO (Maybe Quotation.Quotation)
 selectQuotationById db id =
   STM.atomically $ Core.selectQuotationById db id
+
+
+--------------------------------------------------------------------------------
+filterOrders :: Core.StmDb runtime -> Order.Predicate -> STM [Order.Order]
+filterOrders db predicate = do
+  let tvar = Data._dbOrders db
+  records <- STM.readTVar tvar
+  pure $ filter (Order.applyPredicate predicate) records
+
+filterOrders' :: Order.Predicate -> RunM [Order.Order]
+filterOrders' predicate = do
+  db <- asks _rDb
+  liftIO . STM.atomically $ filterOrders db predicate
+
 
 --------------------------------------------------------------------------------
 -- | Create a new form instance in the staging area.

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -675,7 +675,7 @@ submitQuotationSuccess id =
 setUserEmailAddrAsVerifiedFull
   :: Core.StmDb runtime
   -> (User.UserProfile, User.UserName)
-  -> STM (Either User.UserErr ())
+  -> STM (Either User.Err ())
 setUserEmailAddrAsVerifiedFull db (user, input) = transaction
  where
   transaction = do
@@ -1042,7 +1042,7 @@ submitCreateContractForm' db (profile, input) = do
 formNewQuotation
   :: User.UserName
   -> Quotation.CreateQuotationAll
-  -> RunM (Either User.UserErr Text)
+  -> RunM (Either User.Err Text)
 formNewQuotation user input =
   ML.localEnv (<> "Command" <> "FormNewQuotation") $ do
     ML.info $ "Instanciating new quotation form..."
@@ -1503,7 +1503,7 @@ instance S.DBStorage AppM STM User.UserProfile where
 
   type Db AppM STM User.UserProfile = Core.StmDb Runtime
 
-  type DBError AppM STM User.UserProfile = User.UserErr
+  type DBError AppM STM User.UserProfile = User.Err
 
   dbUpdate db@Data.Db {..} = \case
 
@@ -1586,7 +1586,7 @@ filterUsers' predicate = do
   db <- asks _rDb
   liftIO . STM.atomically $ filterUsers db predicate
 
-createUser :: User.Signup -> RunM (Either User.UserErr User.UserId)
+createUser :: User.Signup -> RunM (Either User.Err User.UserId)
 createUser input = ML.localEnv (<> "Command" <> "CreateUser") $ do
   ML.info $ "Creating user..."
   db   <- asks _rDb
@@ -1600,7 +1600,7 @@ setUserEmailAddrAsVerified
   :: forall runtime
    . Core.StmDb runtime
   -> User.UserName
-  -> STM (Either User.UserErr ())
+  -> STM (Either User.Err ())
 setUserEmailAddrAsVerified db username = do
   mprofile <- Core.selectUserByUsername db username
   case mprofile of

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -51,6 +51,8 @@ module Curiosity.Runtime
   , readCreateQuotationFormResolved'
   , writeCreateQuotationForm
   , submitCreateQuotationForm
+  , filterQuotations
+  , filterQuotations'
   -- ** Contract
   , newCreateContractForm
   , readCreateContractForm
@@ -1183,6 +1185,17 @@ submitCreateQuotationForm' db (profile, input) resolvedClient = do
         Right id -> pure $ Right (id, resolvedClient)
         Left err -> pure $ Left err
     Left  err -> pure . Left $ Quotation.Err (show err)
+
+filterQuotations :: Core.StmDb runtime -> Quotation.Predicate -> STM [Quotation.Quotation]
+filterQuotations db predicate = do
+  let tvar = Data._dbQuotations db
+  records <- STM.readTVar tvar
+  pure $ filter (Quotation.applyPredicate predicate) records
+
+filterQuotations' :: Quotation.Predicate -> RunM [Quotation.Quotation]
+filterQuotations' predicate = do
+  db <- asks _rDb
+  liftIO . STM.atomically $ filterQuotations db predicate
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -564,7 +564,7 @@ handleCommand runtime@Runtime {..} user command = do
     Command.SignQuotation input ->
       liftIO . STM.atomically $ Core.selectUserByUsername _rDb user >>= \case
         Just profile -> do
-          mid <- signQuotation _rDb (profile, input)
+          mid <- setQuotationAsSignedFull _rDb (profile, input)
           case mid of
             Right id ->
               pure (ExitSuccess, ["Order created: " <> Order.unOrderId id])

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -755,12 +755,12 @@ createQuotation
    . Core.StmDb runtime
   -> Quotation.Quotation
   -> STM (Either Quotation.Err Quotation.QuotationId)
-createQuotation db _ = do
+createQuotation db quotation = do
   STM.catchSTM (Right <$> transaction) (pure . Left)
  where
   transaction = do
     newId <- Core.generateQuotationId db
-    let new = Quotation.Quotation newId
+    let new = quotation { Quotation._quotationId = newId }
     createQuotationFull db new >>= either STM.throwSTM pure
 
 createQuotationFull

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -642,7 +642,7 @@ handleCommand runtime@Runtime {..} user command = do
         Nothing ->
           pure (ExitFailure 1, ["Username not found: " <> User.unUserName user])
     Command.Step -> do
-      let transaction rt _ = do
+      let transaction _ _ = do
             users <- filterUsers _rDb User.PredicateEmailAddrToVerify
             mapM
               ( setUserEmailAddrAsVerified _rDb

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1375,10 +1375,10 @@ echoSubmitQuotation
   :: ServerC m => FilePath -> Quotation.SubmitQuotation -> m Pages.EchoPage
 echoSubmitQuotation dataDir (Quotation.SubmitQuotation key) = do
   profile <- readJson $ dataDir </> "alice.json"
-  output <- withRuntime $ Rt.readCreateQuotationForm' profile key
+  output <- withRuntime $ Rt.readCreateQuotationFormResolved' profile key
   case output of
-    Right quotation -> pure . Pages.EchoPage $ show
-      (quotation, Quotation.validateCreateQuotation profile quotation)
+    Right (quotation, resovedClient) -> pure . Pages.EchoPage $ show
+      (quotation, Quotation.validateCreateQuotation profile quotation resovedClient)
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 
 -- | Create a form, generating a new key. This is normally used with a

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -723,8 +723,10 @@ showHomePage authResult = withMaybeUser
       else pure Nothing
     mquotationForms <-
           withRuntime $ Rt.readCreateQuotationForms' profile
+    -- TODO Filter emails for this user only.
+    emails <- withRuntime $ Rt.filterEmails' Email.AllEmails
     let quotationForms = either (const []) identity mquotationForms
-    pure . SS.P.PageR $ Pages.WelcomePage profile profiles quotationForms
+    pure . SS.P.PageR $ Pages.WelcomePage profile profiles quotationForms emails
   )
 
 

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -46,6 +46,7 @@ import qualified Curiosity.Data.Country        as Country
 import qualified Curiosity.Data.Email          as Email
 import qualified Curiosity.Data.Employment     as Employment
 import qualified Curiosity.Data.Legal          as Legal
+import qualified Curiosity.Data.Order          as Order
 import qualified Curiosity.Data.Quotation      as Quotation
 import qualified Curiosity.Data.SimpleContract as SimpleContract
 import qualified Curiosity.Data.User           as User
@@ -1175,7 +1176,7 @@ handleSetQuotationAsSigned (Quotation.SetQuotationAsSigned id) profile
       db
       (profile, id)
     pure $ Pages.ActionResult "Set quotation as signed" $ case output of
-      Right ()  -> "Success"
+      Right id  -> "Success. Order created: " <> Order.unOrderId id
       Left  err -> "Failure: " <> show err
 
 

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -723,8 +723,8 @@ showHomePage authResult = withMaybeUser
       else pure Nothing
     mquotationForms <-
           withRuntime $ Rt.readCreateQuotationForms' profile
-    -- TODO Filter emails for this user only.
-    emails <- withRuntime $ Rt.filterEmails' Email.AllEmails
+    emails <- withRuntime $ Rt.filterEmails'
+      (Email.EmailsFor $ User._userProfileEmailAddr profile)
     let quotationForms = either (const []) identity mquotationForms
     pure . SS.P.PageR $ Pages.WelcomePage profile profiles quotationForms emails
   )

--- a/tests/Curiosity/RuntimeSpec.hs
+++ b/tests/Curiosity/RuntimeSpec.hs
@@ -32,15 +32,17 @@ spec = do
 
       muser `shouldBe` Nothing
 
-    it "Adding a user, returns a user." $ do
+    it "Adding a user, returns a user and an email." $ do
       runtime <- boot' emptyHask "/tmp/curiosity-test-xxx-3.log"
       let db = _rDb runtime
           input = Signup "alice" "secret" "alice@example.com" True
-      Right uid <- atomically $ createUser db input
+      Right (uid, eid) <- atomically $ createUser db input
       Just profile <- atomically $ selectUserById db uid
 
       uid `shouldBe` "USER-1"
       _userProfileId profile `shouldBe` uid
+
+      eid `shouldBe` "EMAIL-1"
 
     it "Blocklisted username cannot be used." $ do
       runtime <- boot' emptyHask "/tmp/curiosity-test-xxx-4.log"

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -6,6 +6,7 @@ import qualified Curiosity.Command             as Command
 import qualified Curiosity.Data                as Data
 import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Counter        as C
+import qualified Curiosity.Data.Email          as Email
 import qualified Curiosity.Data.Legal          as Legal
 import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Run                 as Run
@@ -102,6 +103,10 @@ spec = do
         let aliceState = Data.emptyHask
               { Data._dbNextUserId   = C.CounterValue 2
               , Data._dbUserProfiles = Identity [alice]
+              , Data._dbNextEmailId  = C.CounterValue 2
+              , Data._dbEmails       = Identity
+                  [Email.Email "EMAIL-1" Email.SignupConfirmationEmail
+                    Email.systemEmailAddr "alice@example.com"]
               }
         mapM_
           go

--- a/tests/run-scenarios.hs
+++ b/tests/run-scenarios.hs
@@ -1,5 +1,10 @@
--- | Run scripts similarly to `cty run`, ensuring their outputs are identical
--- to "golden" (expected) results.
+-- | This test program run scripts similarly to @cty run@, ensuring their
+-- outputs are identical to "golden" (expected) results. Scenarios (and their
+-- golden files) can be found in the @scenarios/@ directory in the Curiosity
+-- repository.
+--
+-- Use e.g. @scripts/run-tests.sh@ to execute this program.
+
 import qualified Curiosity.Interpret           as Inter
 import qualified Data.Text                     as T
 import           System.FilePath
@@ -7,9 +12,11 @@ import           System.FilePath
 import           Test.Tasty
 import qualified Test.Tasty.Silver             as Silver
 
+
 --------------------------------------------------------------------------------
 main :: IO ()
 main = do
+  -- List all scenarios, comparing them to their corresponding golden files.
   goldens <- Inter.listScenarios "scenarios/" >>= mapM mkGoldenTest
   defaultMain $ testGroup "Tests" goldens
 
@@ -17,8 +24,11 @@ main = do
 --------------------------------------------------------------------------------
 mkGoldenTest :: FilePath -> IO TestTree
 mkGoldenTest path = do
+  -- `path` looks like @scenarios/quotation-flow.txt@.
+  -- `testName` looks like @quotation-flow@.
+  -- `goldenPath` looks like @scenarios/quotation-flow.golden@.
   let testName   = takeBaseName path
-  let goldenPath = replaceExtension path ".golden"
+      goldenPath = replaceExtension path ".golden"
   pure $ Silver.goldenVsAction testName goldenPath action convert
  where
   action :: IO [Text]


### PR DESCRIPTION
This branch mainly completes the web interface version of the quotation flow (as visible in `scenarios/quotation-flow.golden`). One of the main aspect is sending emails during some operations, and thus this branch makes it possible to see the sent emails. This also means a client is now necessary within the `Quotation` object so that an email has a meaningful recipient.

To better see the complete flow, in addition of emails, we now display quotation forms, quotations, and orders on the user homepage, and state is added to the `Quotation` object to know if it is sent or signed.

An interesting aspect is that the "signed" state requires an order ID, making it more difficult to forget to create an order in the same transaction that sets the state to "signed".