### PR TITLE
Restructure modules for cleaner code.

### DIFF
--- a/bin/cty-sock.hs
+++ b/bin/cty-sock.hs
@@ -29,7 +29,7 @@ mainParserInfo =
 
 runWithConf conf = do
   putStrLn @Text "Creating runtime..."
-  runtime <- Rt.boot conf Rt.NoThreads >>= either throwIO pure
+  runtime <- Rt.bootConf conf Rt.NoThreads >>= either throwIO pure
 
   putStrLn @Text "Creating curiosity.sock..."
   sock <- socket AF_UNIX Stream 0

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -130,6 +130,7 @@ library
     Curiosity.Process
     Curiosity.Run
     Curiosity.Runtime
+    Curiosity.Runtime.Type
     Curiosity.Server
     Curiosity.Server.Helpers
     WaiAppStatic.Storage.Filesystem.Extended

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -135,6 +135,7 @@ library
     Curiosity.Runtime.Error
     --- runtime: effectful operations that are run in IO. 
     Curiosity.Runtime.IO
+    Curiosity.Runtime.IO.AppM
 
     Curiosity.Server
     Curiosity.Server.Helpers

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -131,6 +131,7 @@ library
     Curiosity.Run
     Curiosity.Runtime
     Curiosity.Runtime.Type
+    Curiosity.Runtime.Error
     Curiosity.Server
     Curiosity.Server.Helpers
     WaiAppStatic.Storage.Filesystem.Extended

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -129,9 +129,13 @@ library
     Curiosity.Parse
     Curiosity.Process
     Curiosity.Run
+    -- runtime: datatypes, errors etc. 
     Curiosity.Runtime
     Curiosity.Runtime.Type
     Curiosity.Runtime.Error
+    --- runtime: effectful operations that are run in IO. 
+    Curiosity.Runtime.IO
+
     Curiosity.Server
     Curiosity.Server.Helpers
     WaiAppStatic.Storage.Filesystem.Extended

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -114,7 +114,7 @@ applyPredicate (AndEmails predicates) email =
 
 
 --------------------------------------------------------------------------------
-data Err = Err
+newtype Err = Err
   { unErr :: Text
   }
   deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -49,6 +49,7 @@ module Curiosity.Data.User
   , Storage.DBSelect(..)
   -- * Errors
   , Err(..)
+  , userNotFound
   , usernameBlocklist
   ) where
 
@@ -174,7 +175,7 @@ data AccessRight = CanCreateContracts | CanVerifyEmailAddr
   deriving anyclass (ToJSON, FromJSON)
 
 permissions :: [AccessRight]
-permissions = [toEnum 0..]
+permissions = [toEnum 0 ..]
 
 -- | The username is an identifier (i.e. it is unique).
 newtype UserName = UserName { unUserName :: Text }
@@ -383,3 +384,7 @@ usernameBlocklist =
   , "state"
   , "views"
   ]
+
+-- | Convenient way to create a `UserNotFound` value on `Left.`
+userNotFound :: forall a . Text -> Either Err a
+userNotFound = Left . UserNotFound . mappend "User not found: "

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -51,7 +51,7 @@ import qualified System.FilePath.Glob          as Glob
 --------------------------------------------------------------------------------
 handleRun :: P.Conf -> User.UserName -> FilePath -> Bool -> IO ExitCode
 handleRun conf user scriptPath withFinal = do
-  runtime <- Rt.boot conf Rt.NoThreads >>= either throwIO pure
+  runtime <- Rt.bootConf conf Rt.NoThreads >>= either throwIO pure
   (code, output) <- interpret runtime user scriptPath
   Rt.powerdown runtime
   when withFinal $ print output
@@ -59,7 +59,7 @@ handleRun conf user scriptPath withFinal = do
 
 handleRunNoTrace :: P.Conf -> User.UserName -> FilePath -> Bool -> IO ExitCode
 handleRunNoTrace conf user scriptPath withFinal = do
-  runtime <- Rt.boot conf Rt.NoThreads >>= either throwIO pure
+  runtime <- Rt.bootConf conf Rt.NoThreads >>= either throwIO pure
   output <- interpretFile' runtime user scriptPath 0
   Rt.powerdown runtime
   when withFinal $ print output
@@ -77,7 +77,7 @@ handleRun' scriptPath = do
             -- RuntimeException openFile: resource busy (file is locked)
         , P._confDbFile  = Nothing
         }
-  runtime <- Rt.boot conf Rt.NoThreads >>= either throwIO pure
+  runtime <- Rt.bootConf conf Rt.NoThreads >>= either throwIO pure
   output  <- interpretFile runtime "system" scriptPath 0
   Rt.powerdown runtime
   pure output

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -1040,7 +1040,7 @@ formNewQuotation
   -> RunM (Either User.Err Text)
 formNewQuotation user input =
   ML.localEnv (<> "Command" <> "FormNewQuotation") $ do
-    ML.info $ "Instanciating new quotation form..."
+    ML.info "Instantiating new quotation form..."
     db   <- asks _rDb
     mkey <-
       liftIO . STM.atomically $ Core.selectUserByUsername db user >>= \case
@@ -1059,7 +1059,7 @@ formNewQuotation'
   :: User.UserProfile -> Quotation.CreateQuotationAll -> RunM Text
 formNewQuotation' profile input =
   ML.localEnv (<> "Command" <> "FormNewQuotation") $ do
-    ML.info $ "Instanciating new quotation form..."
+    ML.info "Instantiating new quotation form..."
     db  <- asks _rDb
     key <- liftIO . STM.atomically $ do
       newCreateQuotationForm db (profile, input)
@@ -1178,8 +1178,8 @@ submitCreateQuotationForm'
   -> Maybe User.UserProfile
   -> STM
        (Either Quotation.Err (Quotation.QuotationId, User.UserProfile))
-submitCreateQuotationForm' db (profile, input) resolvedClient = do
-  let mc = Quotation.validateCreateQuotation profile input resolvedClient
+submitCreateQuotationForm' db (profile, input) mResolvedClient = do
+  let mc = Quotation.validateCreateQuotation profile input mResolvedClient
   case mc of
     Right (c, resolvedClient) -> do
       mid <- createQuotation db c
@@ -1508,7 +1508,7 @@ filterUsers' predicate = do
 
 createUser :: User.Signup -> RunM (Either User.Err User.UserId)
 createUser input = ML.localEnv (<> "Command" <> "CreateUser") $ do
-  ML.info $ "Creating user..."
+  ML.info "Creating user..."
   db   <- asks _rDb
   muid <- liftIO . STM.atomically $ Core.createUser db input
   case muid of

--- a/src/Curiosity/Runtime/Error.hs
+++ b/src/Curiosity/Runtime/Error.hs
@@ -1,6 +1,6 @@
 module Curiosity.Runtime.Error
   ( IOErr(..)
-  , UnspeciedErr(..)
+  , UnspecifiedErr(..)
   ) where
 
 import qualified Commence.Runtime.Errors       as Errs
@@ -25,11 +25,11 @@ instance Errs.IsRuntimeErr IOErr where
 
 -- | A placeholder error type, used until better handling (at the call site) is
 -- put in place.
-newtype UnspeciedErr = UnspeciedErr Text
+newtype UnspecifiedErr = UnspecifiedErr Text
   deriving Show
 
-instance Errs.IsRuntimeErr UnspeciedErr where
-  errCode UnspeciedErr{} = "ERR.FILE_NOT_FOUND"
-  httpStatus UnspeciedErr{} = HTTP.notFound404
+instance Errs.IsRuntimeErr UnspecifiedErr where
+  errCode UnspecifiedErr{} = "ERR.FILE_NOT_FOUND"
+  httpStatus UnspecifiedErr{} = HTTP.notFound404
   userMessage = Just . \case
-    UnspeciedErr msg -> T.unwords ["Error:", msg]
+    UnspecifiedErr msg -> T.unwords ["Error:", msg]

--- a/src/Curiosity/Runtime/Error.hs
+++ b/src/Curiosity/Runtime/Error.hs
@@ -1,0 +1,35 @@
+module Curiosity.Runtime.Error
+  ( IOErr(..)
+  , UnspeciedErr(..)
+  ) where
+
+import qualified Commence.Runtime.Errors       as Errs
+import qualified Data.Text                     as T
+import qualified Network.HTTP.Types            as HTTP
+
+--------------------------------------------------------------------------------
+-- TODO Integrity check:
+-- All UserIds must resolve: _entityUsersAndRoles.
+-- List containing UserIds should not have duplicates: _entityUsersAndRoles.
+
+
+--------------------------------------------------------------------------------
+newtype IOErr = FileDoesntExistErr FilePath
+  deriving Show
+
+instance Errs.IsRuntimeErr IOErr where
+  errCode FileDoesntExistErr{} = "ERR.FILE_NOT_FOUND"
+  httpStatus FileDoesntExistErr{} = HTTP.notFound404
+  userMessage = Just . \case
+    FileDoesntExistErr fpath -> T.unwords ["File doesn't exist:", T.pack fpath]
+
+-- | A placeholder error type, used until better handling (at the call site) is
+-- put in place.
+newtype UnspeciedErr = UnspeciedErr Text
+  deriving Show
+
+instance Errs.IsRuntimeErr UnspeciedErr where
+  errCode UnspeciedErr{} = "ERR.FILE_NOT_FOUND"
+  httpStatus UnspeciedErr{} = HTTP.notFound404
+  userMessage = Just . \case
+    UnspeciedErr msg -> T.unwords ["Error:", msg]

--- a/src/Curiosity/Runtime/IO.hs
+++ b/src/Curiosity/Runtime/IO.hs
@@ -167,8 +167,7 @@ saveDbAs runtime fpath = do
 
 -- | Reads all values of the `Db` product type from `STM.STM` to @Hask@.
 readFullStmDbInHask
-  :: forall runtime m
-   . MonadIO m
+  :: MonadIO m
   => Core.StmDb
   -> m Data.HaskDb
 readFullStmDbInHask = liftIO . STM.atomically . Core.readFullStmDbInHask'

--- a/src/Curiosity/Runtime/IO.hs
+++ b/src/Curiosity/Runtime/IO.hs
@@ -1,0 +1,174 @@
+module Curiosity.Runtime.IO
+  (
+    -- * managing runtimes: boot, shutdown etc. 
+    boot
+  , boot'
+  , instantiateDb
+  , readDb
+  , readDbSafe
+  , powerdown
+  , saveDb
+  , saveDbAs
+  , readFullStmDbInHask 
+  ) where
+
+import qualified Curiosity.Core                as Core
+import qualified Data.ByteString.Lazy          as BS
+import qualified Commence.Multilogging         as ML
+import qualified Commence.Runtime.Errors       as Errs
+import qualified Control.Concurrent.STM        as STM
+import           Control.Lens
+import qualified Curiosity.Data                as Data
+import qualified Curiosity.Parse               as Command
+import qualified Curiosity.Runtime.Error       as RErr
+import           Curiosity.Runtime.Type
+import qualified Data.Text                     as T
+import qualified Data.Text.Encoding            as TE
+import qualified Data.Text.IO                  as T
+import           System.Directory               ( doesFileExist )
+
+
+--------------------------------------------------------------------------------
+-- | Boot up a runtime.
+boot
+  :: MonadIO m
+  => Command.Conf -- ^ configuration to boot with.
+  -> Threads
+  -> m (Either Errs.RuntimeErr Runtime)
+boot _rConf _rThreads =
+  liftIO
+      (  try @SomeException
+      .  ML.makeDefaultLoggersWithConf
+      $  _rConf
+      ^. Command.confLogging
+      )
+    >>= \case
+          Left loggerErrs ->
+            putStrLn @Text
+                (  "Cannot instantiate, logger instantiation failed: "
+                <> show loggerErrs
+                )
+              $> Left (Errs.RuntimeException loggerErrs)
+          Right _rLoggers -> do
+            eDb <- instantiateDb _rConf
+            pure $ case eDb of
+              Left  err  -> Left err
+              Right _rDb -> Right Runtime { .. }
+
+-- | Create a runtime from a given state.
+boot' :: MonadIO m => Data.HaskDb -> FilePath -> m Runtime
+boot' db logsPath = do
+  let loggingConf = Command.mkLoggingConf logsPath
+      _rConf      = Command.defaultConf { Command._confLogging = loggingConf }
+  _rDb      <- liftIO . STM.atomically $ Core.instantiateStmDb db
+  _rLoggers <- ML.makeDefaultLoggersWithConf loggingConf
+  let _rThreads = NoThreads
+  pure $ Runtime { .. }
+
+{- | Instantiate the db.
+
+1. The state is either the empty db, or if a _confDbFile file is specified, is
+read from the file.
+
+2. Whenever the application exits, the state is written to disk, if a
+_confDbFile is specified.
+-}
+instantiateDb
+  :: forall m
+   . MonadIO m
+  => Command.Conf
+  -> m (Either Errs.RuntimeErr Core.StmDb)
+instantiateDb Command.Conf {..} = readDbSafe _confDbFile
+
+readDb
+  :: forall m
+   . MonadIO m
+  => Maybe FilePath
+  -> m (Either Errs.RuntimeErr Core.StmDb)
+readDb mpath = case mpath of
+  Just fpath -> do
+    -- We may want to read the file only when the file exists.
+    exists <- liftIO $ doesFileExist fpath
+    if exists then fromFile fpath else useEmpty
+  Nothing -> useEmpty
+ where
+  fromFile fpath = liftIO (try @SomeException $ T.readFile fpath) >>= \case
+    Left err ->
+      putStrLn @Text ("Unable to read db file: " <> maybe "" T.pack mpath)
+        $> Left (Errs.RuntimeException err)
+    Right fdata ->
+           -- We may want to deserialise the data only when the data is non-empty.
+                   if T.null fdata
+      then useEmpty
+      else
+        Data.deserialiseDbStrict (TE.encodeUtf8 fdata)
+          & either (pure . Left . Errs.knownErr) useState
+  useEmpty = Right <$> liftIO (STM.atomically Core.instantiateEmptyStmDb)
+  useState = fmap Right . liftIO . STM.atomically . Core.instantiateStmDb
+
+-- | A safer version of readDb: this fails if the file doesn't exist or is
+-- empty. This helps in catching early mistake, e.g. from user specifying the
+-- wrong file name on the command-line.
+readDbSafe
+  :: forall m
+   . MonadIO m
+  => Maybe FilePath
+  -> m (Either Errs.RuntimeErr Core.StmDb)
+readDbSafe mpath = case mpath of
+  Just fpath -> do
+    -- We may want to read the file only when the file exists.
+    exists <- liftIO $ doesFileExist fpath
+    if exists
+      then fromFile fpath
+      else pure . Left . Errs.knownErr $ RErr.FileDoesntExistErr fpath
+  Nothing -> useEmpty
+ where
+  fromFile fpath = do
+    fdata <- liftIO (T.readFile fpath)
+    Data.deserialiseDbStrict (TE.encodeUtf8 fdata)
+      & either (pure . Left . Errs.knownErr) useState
+  useEmpty = Right <$> liftIO (STM.atomically Core.instantiateEmptyStmDb)
+  useState = fmap Right . liftIO . STM.atomically . Core.instantiateStmDb
+
+-- | Power down the application: attempting to save the DB state in given file,
+-- if possible, and reporting errors otherwise.
+powerdown :: MonadIO m => Runtime -> m (Maybe Errs.RuntimeErr)
+powerdown runtime@Runtime {..} = do
+  mDbSaveErr <- saveDb runtime
+  reportDbSaveErr mDbSaveErr
+  -- finally, close loggers.
+  eLoggingCloseErrs <- liftIO . try @SomeException $ ML.flushAndCloseLoggers
+    _rLoggers
+  reportLoggingCloseErrs eLoggingCloseErrs
+  pure $ mDbSaveErr <|> first Errs.RuntimeException eLoggingCloseErrs ^? _Left
+ where
+  reportLoggingCloseErrs eLoggingCloseErrs =
+    when (isLeft eLoggingCloseErrs)
+      .  putStrLn @Text
+      $  "Errors when closing loggers: "
+      <> show eLoggingCloseErrs
+  reportDbSaveErr mDbSaveErr =
+    when (isJust mDbSaveErr)
+      .  putStrLn @Text
+      $  "DB state cannot be saved: "
+      <> show mDbSaveErr
+
+saveDb :: MonadIO m => Runtime -> m (Maybe Errs.RuntimeErr)
+saveDb runtime =
+  maybe (pure Nothing) (saveDbAs runtime) $ _rConf runtime ^. Command.confDbFile
+
+saveDbAs :: MonadIO m => Runtime -> FilePath -> m (Maybe Errs.RuntimeErr)
+saveDbAs runtime fpath = do
+  haskDb <- readFullStmDbInHask $ _rDb runtime
+  let bs = Data.serialiseDb haskDb
+  liftIO
+      (try @SomeException (T.writeFile fpath . TE.decodeUtf8 $ BS.toStrict bs))
+    <&> either (Just . Errs.RuntimeException) (const Nothing)
+
+-- | Reads all values of the `Db` product type from `STM.STM` to @Hask@.
+readFullStmDbInHask
+  :: forall runtime m
+   . MonadIO m
+  => Core.StmDb
+  -> m Data.HaskDb
+readFullStmDbInHask = liftIO . STM.atomically . Core.readFullStmDbInHask'

--- a/src/Curiosity/Runtime/IO.hs
+++ b/src/Curiosity/Runtime/IO.hs
@@ -1,8 +1,8 @@
 module Curiosity.Runtime.IO
   (
     -- * managing runtimes: boot, shutdown etc. 
-    boot
-  , boot'
+    bootConf
+  , bootDbAndLogFile
   , instantiateDb
   , readDb
   , readDbSafe
@@ -30,12 +30,12 @@ import           System.Directory               ( doesFileExist )
 
 --------------------------------------------------------------------------------
 -- | Boot up a runtime.
-boot
+bootConf
   :: MonadIO m
-  => Command.Conf -- ^ configuration to boot with.
+  => Command.Conf -- ^ configuration to bootConf with.
   -> Threads
   -> m (Either Errs.RuntimeErr Runtime)
-boot _rConf _rThreads =
+bootConf _rConf _rThreads =
   liftIO
       (  try @SomeException
       .  ML.makeDefaultLoggersWithConf
@@ -56,8 +56,8 @@ boot _rConf _rThreads =
               Right _rDb -> Right Runtime { .. }
 
 -- | Create a runtime from a given state.
-boot' :: MonadIO m => Data.HaskDb -> FilePath -> m Runtime
-boot' db logsPath = do
+bootDbAndLogFile :: MonadIO m => Data.HaskDb -> FilePath -> m Runtime
+bootDbAndLogFile db logsPath = do
   let loggingConf = Command.mkLoggingConf logsPath
       _rConf      = Command.defaultConf { Command._confLogging = loggingConf }
   _rDb      <- liftIO . STM.atomically $ Core.instantiateStmDb db

--- a/src/Curiosity/Runtime/IO/AppM.hs
+++ b/src/Curiosity/Runtime/IO/AppM.hs
@@ -69,6 +69,7 @@ instance S.DBTransaction AppM STM where
 
 --------------------------------------------------------------------------------
 -- | Definition of all operations for the UserProfiles (selects and updates)
+-- The instance must reside here to avoid an Orphan instance. 
 instance S.DBStorage AppM STM User.UserProfile where
 
   type Db AppM STM User.UserProfile = Core.StmDb

--- a/src/Curiosity/Runtime/IO/AppM.hs
+++ b/src/Curiosity/Runtime/IO/AppM.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE TypeFamilies  #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+module Curiosity.Runtime.IO.AppM
+  ( AppM(..)
+  , runAppMSafe
+  , checkCredentials
+  ) where
+
+import qualified Commence.Multilogging         as ML
+import qualified Commence.Runtime.Errors       as Errs
+import qualified Commence.Runtime.Storage      as S
+import           Commence.Types.Secret          ( (=:=) )
+import qualified Control.Concurrent.STM        as STM
+import           Control.Lens                  as Lens
+import "exceptions" Control.Monad.Catch         ( MonadCatch
+                                                , MonadMask
+                                                , MonadThrow
+                                                )
+import qualified Curiosity.Core                as Core
+import qualified Curiosity.Data                as Data
+import qualified Curiosity.Data.User           as User
+import           Curiosity.Runtime.Type        as RType
+import           Prelude                 hiding ( state )
+
+
+--------------------------------------------------------------------------------
+newtype AppM a = AppM { runAppM :: ReaderT Runtime (ExceptT Errs.RuntimeErr IO) a }
+  deriving ( Functor
+           , Applicative
+           , Monad
+           , MonadIO
+           , MonadReader Runtime
+           , MonadError Errs.RuntimeErr
+           , MonadThrow
+           , MonadCatch
+           , MonadMask
+           )
+
+-- | Run the `AppM` computation catching all possible exceptions.
+runAppMSafe
+  :: forall a m
+   . MonadIO m
+  => Runtime
+  -> AppM a
+  -> m (Either Errs.RuntimeErr a)
+runAppMSafe runtime AppM {..} =
+  liftIO
+    . fmap (join . first Errs.RuntimeException)
+    . try @SomeException
+    . runExceptT
+    $ runReaderT runAppM runtime
+
+
+--------------------------------------------------------------------------------
+-- | Support for logging for the application
+instance ML.MonadAppNameLogMulti AppM where
+  askLoggers = asks _rLoggers
+  localLoggers modLogger =
+    local (over rLoggers . over ML.appNameLoggers $ fmap modLogger)
+
+instance S.DBTransaction AppM STM where
+  liftTxn =
+    liftIO
+      . fmap (first Errs.RuntimeException)
+      . try @SomeException
+      . STM.atomically
+
+
+--------------------------------------------------------------------------------
+-- | Definition of all operations for the UserProfiles (selects and updates)
+instance S.DBStorage AppM STM User.UserProfile where
+
+  type Db AppM STM User.UserProfile = Core.StmDb
+
+  type DBError AppM STM User.UserProfile = User.Err
+
+  dbUpdate db@Data.Db {..} = \case
+
+    User.UserCreate input -> second pure <$> Core.createUserFull db input
+
+    User.UserCreateGeneratingUserId input ->
+      second (pure . fst) <$> Core.createUser db input
+
+    User.UserDelete id ->
+      S.dbSelect @AppM @STM db (User.SelectUserById id) <&> headMay >>= maybe
+        (pure . userNotFound $ show id)
+        (fmap Right . deleteUser)
+     where
+      deleteUser _ =
+        modifyUserProfiles id (filter $ (/= id) . S.dbId) _dbUserProfiles
+
+    User.UserUpdate id (User.Update mname mbio) ->
+      S.dbSelect @AppM @STM db (User.SelectUserById id) <&> headMay >>= maybe
+        (pure . userNotFound $ show id)
+        (fmap Right . updateUser)
+     where
+      updateUser _ = modifyUserProfiles id replaceOlder _dbUserProfiles
+      change =
+        set User.userProfileBio mbio . set User.userProfileDisplayName mname
+      replaceOlder users =
+        [ if S.dbId u == id then change u else u | u <- users ]
+
+  dbSelect db = \case
+
+    User.UserLoginWithUserName input -> toList <$> checkCredentials db input
+
+    User.SelectUserById        id    -> toList <$> Core.selectUserById db id
+
+    User.SelectUserByUserName username ->
+      toList <$> Core.selectUserByUsername db username
+
+userNotFound = Left . User.UserNotFound . mappend "User not found: "
+
+modifyUserProfiles id f userProfiles = STM.modifyTVar userProfiles f $> [id]
+
+checkCredentials
+  :: Core.StmDb -> User.Credentials -> STM (Maybe User.UserProfile)
+checkCredentials db User.Credentials {..} = do
+  mprofile <- Core.selectUserByUsername db _userCredsName
+  case mprofile of
+    Just profile | checkPassword profile _userCredsPassword ->
+      pure $ Just profile
+    _ -> pure Nothing
+
+-- TODO Use constant-time string comparison.
+checkPassword :: User.UserProfile -> User.Password -> Bool
+checkPassword profile (User.Password passInput) = storedPass =:= passInput
+ where
+  User.Password storedPass =
+    profile ^. User.userProfileCreds . User.userCredsPassword

--- a/src/Curiosity/Runtime/IO/AppM.hs
+++ b/src/Curiosity/Runtime/IO/AppM.hs
@@ -84,7 +84,7 @@ instance S.DBStorage AppM STM User.UserProfile where
 
     User.UserDelete id ->
       S.dbSelect @AppM @STM db (User.SelectUserById id) <&> headMay >>= maybe
-        (pure . userNotFound $ show id)
+        (pure . User.userNotFound $ show id)
         (fmap Right . deleteUser)
      where
       deleteUser _ =
@@ -92,7 +92,7 @@ instance S.DBStorage AppM STM User.UserProfile where
 
     User.UserUpdate id (User.Update mname mbio) ->
       S.dbSelect @AppM @STM db (User.SelectUserById id) <&> headMay >>= maybe
-        (pure . userNotFound $ show id)
+        (pure . User.userNotFound $ show id)
         (fmap Right . updateUser)
      where
       updateUser _ = modifyUserProfiles id replaceOlder _dbUserProfiles
@@ -109,8 +109,6 @@ instance S.DBStorage AppM STM User.UserProfile where
 
     User.SelectUserByUserName username ->
       toList <$> Core.selectUserByUsername db username
-
-userNotFound = Left . User.UserNotFound . mappend "User not found: "
 
 modifyUserProfiles id f userProfiles = STM.modifyTVar userProfiles f $> [id]
 

--- a/src/Curiosity/Runtime/Type.hs
+++ b/src/Curiosity/Runtime/Type.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Curiosity.Runtime.Type
+  ( Runtime(..)
+  , rConf
+  , rDb
+  , rLoggers
+  , Threads(..)
+  ) where
+
+import qualified Commence.Multilogging         as ML
+import           Control.Lens
+import qualified Curiosity.Core                as Core
+import qualified Curiosity.Parse               as Command
+
+
+--------------------------------------------------------------------------------
+-- | The runtime, a central product type that should contain all our runtime
+-- supporting values: the STM state, loggers, and processing threads.
+data Runtime = Runtime
+  { _rConf    :: Command.Conf -- ^ The application configuration.
+  , _rDb      :: Core.StmDb -- ^ The Storage.
+  , _rLoggers :: ML.AppNameLoggers -- ^ Multiple loggers to log over.
+  , _rThreads :: Threads -- ^ Additional threads running e.g. async tasks.
+  }
+
+-- | Describes the threading configuration: what the main thread is, and what
+-- additional threads can be created.
+data Threads =
+    NoThreads
+    -- ^ Means that threads can't be started or stopped dynamically.
+  | ReplThreads
+    -- ^ Means the main thread is the REPL, started with `cty repl`.
+    { _tEmailThread :: MVar ThreadId
+    }
+  | HttpThreads
+    -- ^ Means the main thread is the HTTP server, started with `cty serve`.
+    { _tEmailThread :: MVar ThreadId
+    }
+
+makeLenses ''Runtime

--- a/src/Curiosity/Runtime/Type.hs
+++ b/src/Curiosity/Runtime/Type.hs
@@ -5,26 +5,12 @@ module Curiosity.Runtime.Type
   , rDb
   , rLoggers
   , Threads(..)
-  -- * managing runtimes: boot, shutdown etc. 
-  , boot
-  , boot'
-  , instantiateDb
-  , readDb
-  , readDbSafe
   ) where
 
 import qualified Commence.Multilogging         as ML
-import qualified Commence.Runtime.Errors       as Errs
-import qualified Control.Concurrent.STM        as STM
 import           Control.Lens
 import qualified Curiosity.Core                as Core
-import qualified Curiosity.Data                as Data
 import qualified Curiosity.Parse               as Command
-import qualified Curiosity.Runtime.Error       as RErr
-import qualified Data.Text                     as T
-import qualified Data.Text.Encoding            as TE
-import qualified Data.Text.IO                  as T
-import           System.Directory               ( doesFileExist )
 
 
 --------------------------------------------------------------------------------
@@ -52,106 +38,3 @@ data Threads =
     }
 
 makeLenses ''Runtime
-
-
---------------------------------------------------------------------------------
--- | Boot up a runtime.
-boot
-  :: MonadIO m
-  => Command.Conf -- ^ configuration to boot with.
-  -> Threads
-  -> m (Either Errs.RuntimeErr Runtime)
-boot _rConf _rThreads =
-  liftIO
-      (  try @SomeException
-      .  ML.makeDefaultLoggersWithConf
-      $  _rConf
-      ^. Command.confLogging
-      )
-    >>= \case
-          Left loggerErrs ->
-            putStrLn @Text
-                (  "Cannot instantiate, logger instantiation failed: "
-                <> show loggerErrs
-                )
-              $> Left (Errs.RuntimeException loggerErrs)
-          Right _rLoggers -> do
-            eDb <- instantiateDb _rConf
-            pure $ case eDb of
-              Left  err  -> Left err
-              Right _rDb -> Right Runtime { .. }
-
--- | Create a runtime from a given state.
-boot' :: MonadIO m => Data.HaskDb -> FilePath -> m Runtime
-boot' db logsPath = do
-  let loggingConf = Command.mkLoggingConf logsPath
-      _rConf      = Command.defaultConf { Command._confLogging = loggingConf }
-  _rDb      <- liftIO . STM.atomically $ Core.instantiateStmDb db
-  _rLoggers <- ML.makeDefaultLoggersWithConf loggingConf
-  let _rThreads = NoThreads
-  pure $ Runtime { .. }
-
-{- | Instantiate the db.
-
-1. The state is either the empty db, or if a _confDbFile file is specified, is
-read from the file.
-
-2. Whenever the application exits, the state is written to disk, if a
-_confDbFile is specified.
--}
-instantiateDb
-  :: forall m
-   . MonadIO m
-  => Command.Conf
-  -> m (Either Errs.RuntimeErr Core.StmDb)
-instantiateDb Command.Conf {..} = readDbSafe _confDbFile
-
-readDb
-  :: forall m
-   . MonadIO m
-  => Maybe FilePath
-  -> m (Either Errs.RuntimeErr Core.StmDb)
-readDb mpath = case mpath of
-  Just fpath -> do
-    -- We may want to read the file only when the file exists.
-    exists <- liftIO $ doesFileExist fpath
-    if exists then fromFile fpath else useEmpty
-  Nothing -> useEmpty
- where
-  fromFile fpath = liftIO (try @SomeException $ T.readFile fpath) >>= \case
-    Left err ->
-      putStrLn @Text ("Unable to read db file: " <> maybe "" T.pack mpath)
-        $> Left (Errs.RuntimeException err)
-    Right fdata ->
-           -- We may want to deserialise the data only when the data is non-empty.
-                   if T.null fdata
-      then useEmpty
-      else
-        Data.deserialiseDbStrict (TE.encodeUtf8 fdata)
-          & either (pure . Left . Errs.knownErr) useState
-  useEmpty = Right <$> liftIO (STM.atomically Core.instantiateEmptyStmDb)
-  useState = fmap Right . liftIO . STM.atomically . Core.instantiateStmDb
-
--- | A safer version of readDb: this fails if the file doesn't exist or is
--- empty. This helps in catching early mistake, e.g. from user specifying the
--- wrong file name on the command-line.
-readDbSafe
-  :: forall m
-   . MonadIO m
-  => Maybe FilePath
-  -> m (Either Errs.RuntimeErr Core.StmDb)
-readDbSafe mpath = case mpath of
-  Just fpath -> do
-    -- We may want to read the file only when the file exists.
-    exists <- liftIO $ doesFileExist fpath
-    if exists
-      then fromFile fpath
-      else pure . Left . Errs.knownErr $ RErr.FileDoesntExistErr fpath
-  Nothing -> useEmpty
- where
-  fromFile fpath = do
-    fdata <- liftIO (T.readFile fpath)
-    Data.deserialiseDbStrict (TE.encodeUtf8 fdata)
-      & either (pure . Left . Errs.knownErr) useState
-  useEmpty = Right <$> liftIO (STM.atomically Core.instantiateEmptyStmDb)
-  useState = fmap Right . liftIO . STM.atomically . Core.instantiateStmDb

--- a/src/Curiosity/Runtime/Type.hs
+++ b/src/Curiosity/Runtime/Type.hs
@@ -5,12 +5,26 @@ module Curiosity.Runtime.Type
   , rDb
   , rLoggers
   , Threads(..)
+  -- * managing runtimes: boot, shutdown etc. 
+  , boot
+  , boot'
+  , instantiateDb
+  , readDb
+  , readDbSafe
   ) where
 
 import qualified Commence.Multilogging         as ML
+import qualified Commence.Runtime.Errors       as Errs
+import qualified Control.Concurrent.STM        as STM
 import           Control.Lens
 import qualified Curiosity.Core                as Core
+import qualified Curiosity.Data                as Data
 import qualified Curiosity.Parse               as Command
+import qualified Curiosity.Runtime.Error       as RErr
+import qualified Data.Text                     as T
+import qualified Data.Text.Encoding            as TE
+import qualified Data.Text.IO                  as T
+import           System.Directory               ( doesFileExist )
 
 
 --------------------------------------------------------------------------------
@@ -38,3 +52,106 @@ data Threads =
     }
 
 makeLenses ''Runtime
+
+
+--------------------------------------------------------------------------------
+-- | Boot up a runtime.
+boot
+  :: MonadIO m
+  => Command.Conf -- ^ configuration to boot with.
+  -> Threads
+  -> m (Either Errs.RuntimeErr Runtime)
+boot _rConf _rThreads =
+  liftIO
+      (  try @SomeException
+      .  ML.makeDefaultLoggersWithConf
+      $  _rConf
+      ^. Command.confLogging
+      )
+    >>= \case
+          Left loggerErrs ->
+            putStrLn @Text
+                (  "Cannot instantiate, logger instantiation failed: "
+                <> show loggerErrs
+                )
+              $> Left (Errs.RuntimeException loggerErrs)
+          Right _rLoggers -> do
+            eDb <- instantiateDb _rConf
+            pure $ case eDb of
+              Left  err  -> Left err
+              Right _rDb -> Right Runtime { .. }
+
+-- | Create a runtime from a given state.
+boot' :: MonadIO m => Data.HaskDb -> FilePath -> m Runtime
+boot' db logsPath = do
+  let loggingConf = Command.mkLoggingConf logsPath
+      _rConf      = Command.defaultConf { Command._confLogging = loggingConf }
+  _rDb      <- liftIO . STM.atomically $ Core.instantiateStmDb db
+  _rLoggers <- ML.makeDefaultLoggersWithConf loggingConf
+  let _rThreads = NoThreads
+  pure $ Runtime { .. }
+
+{- | Instantiate the db.
+
+1. The state is either the empty db, or if a _confDbFile file is specified, is
+read from the file.
+
+2. Whenever the application exits, the state is written to disk, if a
+_confDbFile is specified.
+-}
+instantiateDb
+  :: forall m
+   . MonadIO m
+  => Command.Conf
+  -> m (Either Errs.RuntimeErr Core.StmDb)
+instantiateDb Command.Conf {..} = readDbSafe _confDbFile
+
+readDb
+  :: forall m
+   . MonadIO m
+  => Maybe FilePath
+  -> m (Either Errs.RuntimeErr Core.StmDb)
+readDb mpath = case mpath of
+  Just fpath -> do
+    -- We may want to read the file only when the file exists.
+    exists <- liftIO $ doesFileExist fpath
+    if exists then fromFile fpath else useEmpty
+  Nothing -> useEmpty
+ where
+  fromFile fpath = liftIO (try @SomeException $ T.readFile fpath) >>= \case
+    Left err ->
+      putStrLn @Text ("Unable to read db file: " <> maybe "" T.pack mpath)
+        $> Left (Errs.RuntimeException err)
+    Right fdata ->
+           -- We may want to deserialise the data only when the data is non-empty.
+                   if T.null fdata
+      then useEmpty
+      else
+        Data.deserialiseDbStrict (TE.encodeUtf8 fdata)
+          & either (pure . Left . Errs.knownErr) useState
+  useEmpty = Right <$> liftIO (STM.atomically Core.instantiateEmptyStmDb)
+  useState = fmap Right . liftIO . STM.atomically . Core.instantiateStmDb
+
+-- | A safer version of readDb: this fails if the file doesn't exist or is
+-- empty. This helps in catching early mistake, e.g. from user specifying the
+-- wrong file name on the command-line.
+readDbSafe
+  :: forall m
+   . MonadIO m
+  => Maybe FilePath
+  -> m (Either Errs.RuntimeErr Core.StmDb)
+readDbSafe mpath = case mpath of
+  Just fpath -> do
+    -- We may want to read the file only when the file exists.
+    exists <- liftIO $ doesFileExist fpath
+    if exists
+      then fromFile fpath
+      else pure . Left . Errs.knownErr $ RErr.FileDoesntExistErr fpath
+  Nothing -> useEmpty
+ where
+  fromFile fpath = do
+    fdata <- liftIO (T.readFile fpath)
+    Data.deserialiseDbStrict (TE.encodeUtf8 fdata)
+      & either (pure . Left . Errs.knownErr) useState
+  useEmpty = Right <$> liftIO (STM.atomically Core.instantiateEmptyStmDb)
+  useState = fmap Right . liftIO . STM.atomically . Core.instantiateStmDb

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1164,7 +1164,7 @@ handleUserProfileUpdate update profile = do
   case eIds of
     Right (Right [_]) ->
       pure $ addHeader @"Location" ("/settings/profile") NoContent
-    _ -> Errs.throwError' $ Rt.UnspeciedErr "Cannot update the user."
+    _ -> Errs.throwError' $ Rt.UnspecifiedErr "Cannot update the user."
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1190,12 +1190,12 @@ handleSetQuotationAsSigned
   => Quotation.SetQuotationAsSigned
   -> User.UserProfile
   -> m Pages.ActionResult
-handleSetQuotationAsSigned (Quotation.SetQuotationAsSigned id) profile
+handleSetQuotationAsSigned (Quotation.SetQuotationAsSigned qid) profile
   = do
     db     <- asks Rt._rDb
     output <- liftIO . atomically $ Rt.setQuotationAsSignedFull
       db
-      (profile, id)
+      (profile, qid)
     pure $ Pages.ActionResult "Set quotation as signed" $ case output of
       Right id  -> "Success. Order created: " <> Order.unOrderId id
       Left  err -> "Failure: " <> show err

--- a/tests/Curiosity/RuntimeSpec.hs
+++ b/tests/Curiosity/RuntimeSpec.hs
@@ -5,7 +5,8 @@ module Curiosity.RuntimeSpec
 import           Curiosity.Core
 import           Curiosity.Data
 import           Curiosity.Data.User
-import           Curiosity.Runtime              (boot', _rDb)
+import           Curiosity.Runtime.IO           ( bootDbAndLogFile )
+import           Curiosity.Runtime.Type         ( _rDb )
 import           Test.Hspec
 
 
@@ -15,7 +16,7 @@ spec = do
   describe "Runtime" $ do
     it "Should boot." $ do
       -- TODO I don't like that this involves logging stuff.
-      runtime <- boot' emptyHask "/tmp/curiosity-test-xxx-1.log"
+      runtime <- bootDbAndLogFile emptyHask "/tmp/curiosity-test-xxx-1.log"
       let db = _rDb runtime
       st <- atomically $ readFullStmDbInHask' db
       st `shouldBe` emptyHask
@@ -26,14 +27,14 @@ spec = do
       -- otherwise a "resource busy (file is locked)" will occur.
       -- Which is indeed related to logging, which I'd like to remove from
       -- these tests / runtime.
-      runtime <- boot' emptyHask "/tmp/curiosity-test-xxx-2.log"
+      runtime <- bootDbAndLogFile emptyHask "/tmp/curiosity-test-xxx-2.log"
       let db = _rDb runtime
       muser <- atomically $ selectUserById db "USER-1"
 
       muser `shouldBe` Nothing
 
     it "Adding a user, returns a user and an email." $ do
-      runtime <- boot' emptyHask "/tmp/curiosity-test-xxx-3.log"
+      runtime <- bootDbAndLogFile emptyHask "/tmp/curiosity-test-xxx-3.log"
       let db = _rDb runtime
           input = Signup "alice" "secret" "alice@example.com" True
       Right (uid, eid) <- atomically $ createUser db input
@@ -45,7 +46,7 @@ spec = do
       eid `shouldBe` "EMAIL-1"
 
     it "Blocklisted username cannot be used." $ do
-      runtime <- boot' emptyHask "/tmp/curiosity-test-xxx-4.log"
+      runtime <- bootDbAndLogFile emptyHask "/tmp/curiosity-test-xxx-4.log"
       let db = _rDb runtime
           input = Signup "smartcoop" "secret" "smartcoop@example.com" True
       muser <- atomically $ createUser db input


### PR DESCRIPTION
- Split runtime into a separate "Type" module.
- Minor cleanup: use newtypes.
- Split out an "Error" module.
