### PR TITLE
Document the main sale flow

### DIFF
--- a/content/documentation.md
+++ b/content/documentation.md
@@ -24,6 +24,7 @@ title: Curiosity
 - [Permissions](/documentation/permissions)
 - [Scenarios](/documentation/scenarios)
 - [Sitemap](/documentation/sitemap)
+- [Smart](/documentation/smart)
 - [Source code](/documentation/source)
 - [state-0](/documentation/state-0)
 - [UBL](/documentation/ubl)

--- a/content/documentation/changelog.md
+++ b/content/documentation/changelog.md
@@ -4,6 +4,14 @@ title: Curiosity
 
 # Changelog
 
+This [changelog](https://en.wikipedia.org/wiki/Changelog) is a list of notable
+changes (e.g. new features or bug fixes) made to the Curiosity project. This
+helps people get a quick overview of recent evolutions of the project. Most
+entries in the changelog link to Pull Requests (PRs), i.e. proposals by
+developers (or more generally, contributors) to apply changes to the code base.
+PRs may contain additional details and discussions, or provide historical
+context.
+
 ## 2022-10-21
 
 **Add a "Quick start" section to the [CLIs

--- a/content/documentation/changelog.md
+++ b/content/documentation/changelog.md
@@ -8,9 +8,9 @@ This [changelog](https://en.wikipedia.org/wiki/Changelog) is a list of notable
 changes (e.g. new features or bug fixes) made to the Curiosity project. This
 helps people get a quick overview of recent evolutions of the project. Most
 entries in the changelog link to Pull Requests (PRs), i.e. proposals by
-developers (or more generally, contributors) to apply changes to the code base.
-PRs may contain additional details and discussions, or provide historical
-context.
+developers (or more generally, contributors) to apply changes to the [code
+base](/documentation/source).  PRs may contain additional details and
+discussions, or provide historical context.
 
 ## 2022-10-21
 

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -64,3 +64,7 @@ resulting of each of the commands the scenario executes.
 <!--# include virtual="/partials/scenarios" -->
 
 The list [as JSON](/partials/scenarios.json).
+
+Some scenarios have additional documentation:
+
+- [Quotation flow](/documentation/scenarios/quotation-flow)

--- a/content/documentation/scenarios/quotation-flow.md
+++ b/content/documentation/scenarios/quotation-flow.md
@@ -5,3 +5,7 @@ title: Curiosity
 # Quotation flow
 
 <!--# include virtual="/partials/scenarios/quotation-flow" -->
+
+# See also
+
+- [Scenarios](/documentation/scenarios)

--- a/content/documentation/scenarios/quotation-flow.md
+++ b/content/documentation/scenarios/quotation-flow.md
@@ -1,0 +1,7 @@
+---
+title: Curiosity
+---
+
+# Quotation flow
+
+<!--# include virtual="/partials/scenarios/quotation-flow" -->

--- a/content/documentation/smart.md
+++ b/content/documentation/smart.md
@@ -46,7 +46,7 @@ and fulfillment flux (5-10).
 | 3    | OrderResponse       |                     |
 | 4    |                     | OrderChange         |
 | 4    |                     | OrderCancellation   |
-| 5    | DespatchAdvice      |                     |
+| 5    | DispatchAdvice      |                     |
 | 6    |                     | ReceiptAdvice       |
 | 6    |                     | ApplicationResponse |
 | 7    | Invoice             |                     |

--- a/content/documentation/smart.md
+++ b/content/documentation/smart.md
@@ -1,3 +1,7 @@
+---
+title: Curiosity
+---
+
 # Business specifications
 
 ## Big picture
@@ -8,19 +12,30 @@ The Smart application
 - records contractual documents ;
 - communicates these documents and collects agreements and signatures ;
 - processes these documents in the accounts ;
-- and produces views, possibly recalculated, for various legal or management purposes.Users are commercial parties (sellers, buyers, in the generic sense of the term), data entry operators, advisors and supervisors, but also recipients of legally required reports.
+- and produces views, possibly recalculated, for various legal or management
+  purposes.Users are commercial parties (sellers, buyers, in the generic sense
+  of the term), data entry operators, advisors and supervisors, but also
+  recipients of legally required reports.
 
-As standard, Smart operates through its business units - which will always be referenced in an agreement and in accounting. 
+As standard, Smart operates through its business units - which will always be
+referenced in an agreement and in accounting.
 
-These units (several thousand) are autonomous, and are driven by users who often have no knowledge of commercial or accounting management.
+These units (several thousand) are autonomous, and are driven by users who
+often have no knowledge of commercial or accounting management.
 
-Business processes are determined by the actors' place in the Smart eco-system, from which their rights are specified, and by multiple deadlines and dates usually set by law.
+Business processes are determined by the actors' place in the Smart eco-system,
+from which their rights are specified, and by multiple deadlines and dates
+usually set by law.
 
 ## A standardized framework
 
-The framework used is the [UBL standard (v 2.3)](https://docs.oasis-open.org/ubl/UBL-2.3.html). Invoice, CreditNote and DebitNote messages must be interoperable with the [Peppol standard](https://docs.peppol.eu/poacc/billing/3.0/bis/).
+The framework used is the [UBL standard (v
+2.3)](https://docs.oasis-open.org/ubl/UBL-2.3.html). Invoice, CreditNote and
+DebitNote messages must be interoperable with the [Peppol
+standard](https://docs.peppol.eu/poacc/billing/3.0/bis/).
 
-List of most used messages in business process : commitment flux (steps 1-4) and fulfillment flux (5-10).
+List of most used messages in business process : commitment flux (steps 1-4)
+and fulfillment flux (5-10).
 
 | Step | Seller              | Buyer               |
 | ---- | ------------------- | ------------------- |
@@ -41,17 +56,26 @@ List of most used messages in business process : commitment flux (steps 1-4) and
 | 9    | Statement           |                     |
 | 10   | Reminder            |                     |
 
-And : DocumentStatusRequest, DocumentStatus, Enquiry, EnquiryResponse, ExceptionCriteria, ExceptionNotification.
+And : DocumentStatusRequest, DocumentStatus, Enquiry, EnquiryResponse,
+ExceptionCriteria, ExceptionNotification.
 
-All actors are referenced in the **Party** object, considered in the Smart application as a UBL document. This object provides the schema of their data sheet and the relationships they have with each other.
+All actors are referenced in the **Party** object, considered in the Smart
+application as a UBL document. This object provides the schema of their data
+sheet and the relationships they have with each other.
 
-Each document recorded at time T reflects **<u>the complete state</u>** at that time of a transaction. The Smart application is data-driven.
+Each document recorded at time T reflects **<u>the complete state</u>** at that
+time of a transaction. The Smart application is data-driven.
 
-The documents are immutable. They can only be created and viewed, but never updated or deleted. Before the creation of a document, the data are only "*form data*".
+The documents are immutable. They can only be created and viewed, but never
+updated or deleted. Before the creation of a document, the data are only "*form
+data*".
 
-A document is always issued: first created, then sent to one or more recipents . The issuer of a document is always presumed to have accepted its terms.
+A document is always issued: first created, then sent to one or more recipents
+. The issuer of a document is always presumed to have accepted its terms.
 
-The business rules concern (almost) only the creation of a document. And the life cycle of the business process in which this document takes place. The concept of deadline is essential in a business process.
+The business rules concern (almost) only the creation of a document. And the
+life cycle of the business process in which this document takes place. The
+concept of deadline is essential in a business process.
 
 ## The Happy Path of a business transaction (sale)
 
@@ -63,38 +87,54 @@ The business rules concern (almost) only the creation of a document. And the lif
 
 Step 1 : **INITIALIZATION**
 
-The seller registers and sends an quotation to the buyer. 
+The seller registers and sends an quotation to the buyer.
 
-> The application checks before saving the document whether the data in the form is well formed, complete and complies with business requirements.
+> The application checks before saving the document whether the data in the
+> form is well formed, complete and complies with business requirements.
 
 Step 2 : **ORDERING** (commitment)
 
-The buyer accepts the quotation (ApplicationResponse), creates a purchase order and sends it. The seller accepts the order form and informs the buyer (OrderResponseSimple).
+The buyer accepts the quotation (ApplicationResponse), creates a purchase order
+and sends it. The seller accepts the order form and informs the buyer
+(OrderResponseSimple).
 
 Step 3 : **DELIVERY** (fulfillment)
 
-The order is delivered (DispatchAdvice). The buyer confirms receipt of the order (ReceiptAdvice).
+The order is delivered (DispatchAdvice). The buyer confirms receipt of the
+order (ReceiptAdvice).
 
 Step 4 : **INVOICING** (fulfillment)
 
 The seller registers an invoice and sends it to the buyer.
 
-Smart entity registers an internal credit note (shared costs) and sends it to the business unit.
+Smart entity registers an internal credit note (shared costs) and sends it to
+the business unit.
 
-Smart entity registers an internal  credit note (VAT management) and sends it to the business unit.
+Smart entity registers an internal  credit note (VAT management) and sends it
+to the business unit.
 
 >  The accounting interpreter processes the invoice and the two credit notes.
 
 Step 5 : **PAYMENT** (fulfillment)
 
-The buyer pays the invoice and the seller's bank issues a bank statement (RemittanceAdvice).
+The buyer pays the invoice and the seller's bank issues a bank statement
+(RemittanceAdvice).
 
-The Smart entity credits the business unit's bank account with the amount paid by the buyer: the Smart entity's internal bank issues a debit bank statement and the business unit's internal bank issues a credit bank statement.
+The Smart entity credits the business unit's bank account with the amount paid
+by the buyer: the Smart entity's internal bank issues a debit bank statement
+and the business unit's internal bank issues a credit bank statement.
 
-The business unit pays the Smart entity the two credit notes received. Its internal bank issues two debit bank statements, and the Smart entity's internal bank issues two credit bank statements.
+The business unit pays the Smart entity the two credit notes received. Its
+internal bank issues two debit bank statements, and the Smart entity's internal
+bank issues two credit bank statements.
 
->  The accounting interpreter processes the seven bank statements (RemittanceAdvice).
+>  The accounting interpreter processes the seven bank statements
+>  (RemittanceAdvice).
 
-> At the end of the month, a VAT report is issued to the tax authorities (this report can be seen as a SelfBilledCreditNote or a DebitNote), and the VAT due to the State is paid by the Smart entity, which receives a debit bank statement from its bank. The accounting interpreter processes the VAT report and the payment to the State.
+> At the end of the month, a VAT report is issued to the tax authorities (this
+> report can be seen as a SelfBilledCreditNote or a DebitNote), and the VAT due
+> to the State is paid by the Smart entity, which receives a debit bank
+> statement from its bank. The accounting interpreter processes the VAT report
+> and the payment to the State.
 
 <u>**END business process (life cycle)**</u>

--- a/content/documentation/smart.md
+++ b/content/documentation/smart.md
@@ -13,7 +13,7 @@ The Smart application
 - communicates these documents and collects agreements and signatures ;
 - processes these documents in the accounts ;
 - and produces views, possibly recalculated, for various legal or management
-  purposes.Users are commercial parties (sellers, buyers, in the generic sense
+  purposes. Users are commercial parties (sellers, buyers, in the generic sense
   of the term), data entry operators, advisors and supervisors, but also
   recipients of legally required reports.
 
@@ -70,8 +70,8 @@ The documents are immutable. They can only be created and viewed, but never
 updated or deleted. Before the creation of a document, the data are only "*form
 data*".
 
-A document is always issued: first created, then sent to one or more recipents
-. The issuer of a document is always presumed to have accepted its terms.
+A document is always issued: first created, then sent to one or more recipents.
+The issuer of a document is always presumed to have accepted its terms.
 
 The business rules concern (almost) only the creation of a document. And the
 life cycle of the business process in which this document takes place. The
@@ -87,7 +87,7 @@ concept of deadline is essential in a business process.
 
 Step 1 : **INITIALIZATION**
 
-The seller registers and sends an quotation to the buyer.
+The seller registers and sends a quotation to the buyer.
 
 > The application checks before saving the document whether the data in the
 > form is well formed, complete and complies with business requirements.

--- a/content/documentation/smart.md
+++ b/content/documentation/smart.md
@@ -1,0 +1,100 @@
+# Business specifications
+
+## Big picture
+
+The Smart application
+
+- collects data ;
+- records contractual documents ;
+- communicates these documents and collects agreements and signatures ;
+- processes these documents in the accounts ;
+- and produces views, possibly recalculated, for various legal or management purposes.Users are commercial parties (sellers, buyers, in the generic sense of the term), data entry operators, advisors and supervisors, but also recipients of legally required reports.
+
+As standard, Smart operates through its business units - which will always be referenced in an agreement and in accounting. 
+
+These units (several thousand) are autonomous, and are driven by users who often have no knowledge of commercial or accounting management.
+
+Business processes are determined by the actors' place in the Smart eco-system, from which their rights are specified, and by multiple deadlines and dates usually set by law.
+
+## A standardized framework
+
+The framework used is the [UBL standard (v 2.3)](https://docs.oasis-open.org/ubl/UBL-2.3.html). Invoice, CreditNote and DebitNote messages must be interoperable with the [Peppol standard](https://docs.peppol.eu/poacc/billing/3.0/bis/).
+
+List of most used messages in business process : commitment flux (steps 1-4) and fulfillment flux (5-10).
+
+| Step | Seller              | Buyer               |
+| ---- | ------------------- | ------------------- |
+| 1    | Quotation           |                     |
+| 2    |                     | ApplicationResponse |
+| 2    |                     | Order               |
+| 3    | OrderResponseSimple |                     |
+| 3    | OrderResponse       |                     |
+| 4    |                     | OrderChange         |
+| 4    |                     | OrderCancellation   |
+| 5    | DespatchAdvice      |                     |
+| 6    |                     | ReceiptAdvice       |
+| 6    |                     | ApplicationResponse |
+| 7    | Invoice             |                     |
+| 7    | CreditNote          |                     |
+| 7    | DebitNote           |                     |
+| 8    | RemittanceAdvice    | RemittanceAdvice    |
+| 9    | Statement           |                     |
+| 10   | Reminder            |                     |
+
+And : DocumentStatusRequest, DocumentStatus, Enquiry, EnquiryResponse, ExceptionCriteria, ExceptionNotification.
+
+All actors are referenced in the **Party** object, considered in the Smart application as a UBL document. This object provides the schema of their data sheet and the relationships they have with each other.
+
+Each document recorded at time T reflects **<u>the complete state</u>** at that time of a transaction. The Smart application is data-driven.
+
+The documents are immutable. They can only be created and viewed, but never updated or deleted. Before the creation of a document, the data are only "*form data*".
+
+A document is always issued: first created, then sent to one or more recipents . The issuer of a document is always presumed to have accepted its terms.
+
+The business rules concern (almost) only the creation of a document. And the life cycle of the business process in which this document takes place. The concept of deadline is essential in a business process.
+
+## The Happy Path of a business transaction (sale)
+
+- Seller : Smart entity
+- Agent of Seller : Business unit
+- Buyer : any third party
+
+<u>**START business process (life cycle)**</u>
+
+Step 1 : **INITIALIZATION**
+
+The seller registers and sends an quotation to the buyer. 
+
+> The application checks before saving the document whether the data in the form is well formed, complete and complies with business requirements.
+
+Step 2 : **ORDERING** (commitment)
+
+The buyer accepts the quotation (ApplicationResponse), creates a purchase order and sends it. The seller accepts the order form and informs the buyer (OrderResponseSimple).
+
+Step 3 : **DELIVERY** (fulfillment)
+
+The order is delivered (DispatchAdvice). The buyer confirms receipt of the order (ReceiptAdvice).
+
+Step 4 : **INVOICING** (fulfillment)
+
+The seller registers an invoice and sends it to the buyer.
+
+Smart entity registers an internal credit note (shared costs) and sends it to the business unit.
+
+Smart entity registers an internal  credit note (VAT management) and sends it to the business unit.
+
+>  The accounting interpreter processes the invoice and the two credit notes.
+
+Step 5 : **PAYMENT** (fulfillment)
+
+The buyer pays the invoice and the seller's bank issues a bank statement (RemittanceAdvice).
+
+The Smart entity credits the business unit's bank account with the amount paid by the buyer: the Smart entity's internal bank issues a debit bank statement and the business unit's internal bank issues a credit bank statement.
+
+The business unit pays the Smart entity the two credit notes received. Its internal bank issues two debit bank statements, and the Smart entity's internal bank issues two credit bank statements.
+
+>  The accounting interpreter processes the seven bank statements (RemittanceAdvice).
+
+> At the end of the month, a VAT report is issued to the tax authorities (this report can be seen as a SelfBilledCreditNote or a DebitNote), and the VAT due to the State is paid by the Smart entity, which receives a debit bank statement from its bank. The accounting interpreter processes the VAT report and the payment to the State.
+
+<u>**END business process (life cycle)**</u>


### PR DESCRIPTION
This adds a dedicated documentation page written by Roger to document some business matter, and in particular a Sale flow. To contrast that flow with the existing `quotation-flow.golden`, this scenario is now rendered within a documentation page.