### PR TITLE
Add a processing thread to send emails

### DIFF
--- a/bin/cty-sock.hs
+++ b/bin/cty-sock.hs
@@ -29,7 +29,7 @@ mainParserInfo =
 
 runWithConf conf = do
   putStrLn @Text "Creating runtime..."
-  runtime <- Rt.boot conf >>= either throwIO pure
+  runtime <- Rt.boot conf Rt.NoThreads >>= either throwIO pure
 
   putStrLn @Text "Creating curiosity.sock..."
   sock <- socket AF_UNIX Stream 0

--- a/scripts/ghci-repl.conf
+++ b/scripts/ghci-repl.conf
@@ -1,4 +1,5 @@
 :load ../smart-design-hs/lib/src/Prelude.hs
 import Prelude
 :set -XImplicitPrelude
-:load bin/cty-repl.hs
+:load bin/cty.hs
+:main repl

--- a/scripts/ghci-repl.sh
+++ b/scripts/ghci-repl.sh
@@ -5,7 +5,7 @@
 #   - -XNoImplicitPrelude is set here on the command-line
 #   - The ghci.conf file will load smart-design-hs's Prelude
 #   - Then set again -XImplicitPrelude
-#   - Then load what we want: cty-repl.hs
+#   - Then load what we want: cty.hs
 
 ghc --interactive \
   -i../smart-design-hs/lib/src/ \

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -53,6 +53,8 @@ data Command =
     -- ^ Spwan the thread processing enqueued emails.
   | StopEmail
     -- ^ Kill the thread processing enqueued emails.
+  | StepEmail
+    -- ^ Run one iteration of the email processing loop.
   | CreateBusinessEntity Business.Create
   | UpdateBusinessEntity Business.Update
   | CreateLegalEntity Legal.Create
@@ -255,6 +257,12 @@ parser =
            )
 
       <> A.command
+           "step-email"
+           ( A.info (parserStepEmail <**> A.helper)
+           $ A.progDesc "Run one iteration of the email processing loop"
+           )
+
+      <> A.command
            "business"
            ( A.info (parserBusiness <**> A.helper)
            $ A.progDesc "Commands related to business entities"
@@ -402,6 +410,9 @@ parserStartEmail = pure StartEmail
 
 parserStopEmail :: A.Parser Command
 parserStopEmail = pure StopEmail
+
+parserStepEmail :: A.Parser Command
+parserStepEmail = pure StepEmail
 
 parserBusiness :: A.Parser Command
 parserBusiness =

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -47,6 +47,12 @@ data Command =
     -- ^ Parse a single command.
   | State Bool
     -- ^ Show the full state. If True, use Haskell format instead of JSON.
+  | Threads
+    -- ^ Show the state of the threads.
+  | StartEmail
+    -- ^ Spwan the thread processing enqueued emails.
+  | StopEmail
+    -- ^ Kill the thread processing enqueued emails.
   | CreateBusinessEntity Business.Create
   | UpdateBusinessEntity Business.Update
   | CreateLegalEntity Legal.Create
@@ -231,6 +237,24 @@ parser =
            )
 
       <> A.command
+           "threads"
+           ( A.info (parserThreads <**> A.helper)
+           $ A.progDesc "Show the threads state"
+           )
+
+      <> A.command
+           "start-email"
+           ( A.info (parserStartEmail <**> A.helper)
+           $ A.progDesc "Start the thread processing enqueued emails"
+           )
+
+      <> A.command
+           "stop-email"
+           ( A.info (parserStopEmail <**> A.helper)
+           $ A.progDesc "Stop the thread processing enqueued emails"
+           )
+
+      <> A.command
            "business"
            ( A.info (parserBusiness <**> A.helper)
            $ A.progDesc "Commands related to business entities"
@@ -369,6 +393,15 @@ parserObject =
 parserState :: A.Parser Command
 parserState = State <$> A.switch
   (A.long "hs" <> A.help "Use the Haskell format (default is JSON).")
+
+parserThreads :: A.Parser Command
+parserThreads = pure Threads
+
+parserStartEmail :: A.Parser Command
+parserStartEmail = pure StartEmail
+
+parserStopEmail :: A.Parser Command
+parserStopEmail = pure StopEmail
 
 parserBusiness :: A.Parser Command
 parserBusiness =

--- a/src/Curiosity/Html/Email.hs
+++ b/src/Curiosity/Html/Email.hs
@@ -29,10 +29,10 @@ instance H.ToMarkup EmailPage where
 
 
 --------------------------------------------------------------------------------
--- | Display enqueued emails.
+-- | Display emails.
 panelSentEmails :: [Email.Email] -> H.Html
 panelSentEmails emails =
-  panel' "Emails queued" $ Misc.table "emails" titles display emails
+  panel' "Emails" $ Misc.table "emails" titles display emails
  where
   titles = ["ID", "Template", "Sender", "Recipient", "State"]
   display Email.Email {..} =

--- a/src/Curiosity/Html/Email.hs
+++ b/src/Curiosity/Html/Email.hs
@@ -34,12 +34,15 @@ panelSentEmails :: [Email.Email] -> H.Html
 panelSentEmails emails =
   panel' "Emails queued" $ Misc.table "emails" titles display emails
  where
-  titles = ["ID", "Template", "Sender", "Recipient"]
+  titles = ["ID", "Template", "Sender", "Recipient", "State"]
   display Email.Email {..} =
     ( [ Email.unEmailId _emailId
       , Email.emailTemplateName _emailTemplate
       , User.unUserEmailAddr _emailSender
       , User.unUserEmailAddr _emailRecipient
+      , case _emailState of
+          Email.EmailTodo -> "TODO"
+          Email.EmailDone -> "DONE"
       ]
     , []
     , Nothing

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -30,7 +30,7 @@ import qualified System.FilePath.Glob          as Glob
 --------------------------------------------------------------------------------
 handleRun :: P.Conf -> User.UserName -> FilePath -> IO ExitCode
 handleRun conf user scriptPath = do
-  runtime <- Rt.boot conf >>= either throwIO pure
+  runtime <- Rt.boot conf Rt.NoThreads >>= either throwIO pure
   code    <- interpret runtime user scriptPath
   Rt.powerdown runtime
   exitWith code
@@ -43,7 +43,7 @@ handleRun' scriptPath = do
         { P._confLogging = P.mkLoggingConf "/tmp/cty-serve-explore.log"
         , P._confDbFile  = Nothing
         }
-  runtime <- Rt.boot conf >>= either throwIO pure
+  runtime <- Rt.boot conf Rt.NoThreads >>= either throwIO pure
   output  <- interpretFile runtime "system" scriptPath 0
   Rt.powerdown runtime
   pure output

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -218,7 +218,9 @@ run (Command.CommandWithTarget command target (Command.User user)) = do
 --------------------------------------------------------------------------------
 handleServe :: P.Conf -> P.ServerConf -> IO ExitCode
 handleServe conf serverConf = do
-  runtime@Rt.Runtime {..} <- Rt.boot conf Rt.NoThreads >>= either throwIO pure
+  threads <- Rt.emptyHttpThreads
+  runtime@Rt.Runtime {..} <- Rt.boot conf threads >>= either throwIO pure
+  Rt.runRunM runtime Rt.spawnEmailThread
   P.startServer serverConf runtime >>= P.endServer _rLoggers
   mPowerdownErrs <- Rt.powerdown runtime
   maybe exitSuccess throwIO mPowerdownErrs

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -754,7 +754,10 @@ showHomePage authResult = withMaybeUser
     mquotationForms <-
           withRuntime $ Rt.readCreateQuotationForms' profile
     emails <- withRuntime $ Rt.filterEmails'
-      (Email.EmailsFor $ User._userProfileEmailAddr profile)
+      (Email.AndEmails
+        [ Email.EmailsFor $ User._userProfileEmailAddr profile
+        , Email.EmailsDone
+        ])
     quotations <- withRuntime $ Rt.filterQuotations' Quotation.AllQuotations
     orders <- withRuntime $ Rt.filterOrders' Order.AllOrders
     let quotationForms = either (const []) identity mquotationForms

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -106,12 +106,22 @@ spec = do
               , Data._dbNextEmailId  = C.CounterValue 2
               , Data._dbEmails       = Identity
                   [Email.Email "EMAIL-1" Email.SignupConfirmationEmail
-                    Email.systemEmailAddr "alice@example.com"]
+                    Email.systemEmailAddr "alice@example.com" Email.EmailTodo]
+              }
+        -- The same state, but with the email set to DONE.
+        let aliceState' = Data.emptyHask
+              { Data._dbNextUserId   = C.CounterValue 2
+              , Data._dbUserProfiles = Identity [alice]
+              , Data._dbNextEmailId  = C.CounterValue 2
+              , Data._dbEmails       = Identity
+                  [Email.Email "EMAIL-1" Email.SignupConfirmationEmail
+                    Email.systemEmailAddr "alice@example.com" Email.EmailDone]
               }
         mapM_
           go
           [ ("init" , Data.emptyHask)
           , ("user create alice a alice@example.com --accept-tos", aliceState)
+          , ("step-email", aliceState')
           , ("reset", Data.emptyHask)
           ]
 


### PR DESCRIPTION
A thread is now running in the HTTP server and in the REPL to "send" emails. Currently it simply changes the email state from "TODO" to "DONE". Commands are added to stop or start the thread, or to run its logic manually. This can be used within the HTTP server or the REPL when the thread is stopped, or with `cty` or `cty run`.