### PR TITLE
Simplify the `Data.Db` data type

### DIFF
--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -54,7 +54,7 @@ Additionally, we want to parameterise over a @runtime@ type parameter. This is
 a container type of the database.
 -}
 -- brittany-disable-next-binding
-data Db (datastore :: Type -> Type) (runtime :: Type) = Db
+data Db (datastore :: Type -> Type) = Db
   { _dbNextBusinessId   :: C.CounterValue datastore Int
   , _dbBusinessUnits    :: datastore [Business.Unit]
   , _dbNextLegalId      :: C.CounterValue datastore Int
@@ -88,16 +88,16 @@ data Db (datastore :: Type -> Type) (runtime :: Type) = Db
 
 -- | Hask database type: used for starting the system, values reside in @Hask@
 -- (thus `Identity`)
-type HaskDb runtime = Db Identity runtime
+type HaskDb = Db Identity
 
-deriving instance Eq (HaskDb runtime)
-deriving instance Show (HaskDb runtime)
-deriving instance Generic (HaskDb runtime)
-deriving anyclass instance ToJSON (HaskDb runtime)
-deriving anyclass instance FromJSON (HaskDb runtime)
+deriving instance Eq HaskDb
+deriving instance Show HaskDb
+deriving instance Generic HaskDb
+deriving anyclass instance ToJSON HaskDb
+deriving anyclass instance FromJSON HaskDb
 
 -- | Instantiate a seed database that is empty.
-emptyHask :: forall runtime . HaskDb runtime
+emptyHask :: HaskDb
 emptyHask = Db (pure 1)
                (pure mempty)
                (pure 1)
@@ -141,18 +141,17 @@ instance E.IsRuntimeErr DbErr where
 
 --------------------------------------------------------------------------------
 -- | Write an entire db state to bytes.
-serialiseDb :: forall runtime . HaskDb runtime -> LByteString
+serialiseDb :: HaskDb -> LByteString
 serialiseDb = encode
 {-# INLINE serialiseDb #-}
 
 -- | Read an entire db state from bytes.
-deserialiseDb :: forall runtime . LByteString -> Either DbErr (HaskDb runtime)
+deserialiseDb :: LByteString -> Either DbErr HaskDb
 deserialiseDb = first (DbDecodeFailed . T.pack) . eitherDecode
 {-# INLINE deserialiseDb #-}
 
 -- | Read an entire db state from bytes.
-deserialiseDbStrict
-  :: forall runtime . ByteString -> Either DbErr (HaskDb runtime)
+deserialiseDbStrict :: ByteString -> Either DbErr HaskDb
 deserialiseDbStrict = first (DbDecodeFailed . T.pack) . eitherDecodeStrict
 {-# INLINE deserialiseDbStrict #-}
 

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -29,17 +29,17 @@ import           Prelude                 hiding ( state )
 
 
 --------------------------------------------------------------------------------
-newtype Run a = Run { runM :: ReaderT (Core.StmDb ()) STM a }
+newtype Run a = Run { runM :: ReaderT Core.StmDb STM a }
   deriving ( Functor
            , Applicative
            , Monad
-           , MonadReader (Core.StmDb ())
+           , MonadReader Core.StmDb
            )
 
 -- Is it possible to implement MonadFail only when the return type is Either ?
 -- deriving instance MonadFail (Run (Either Text a))
 
-run :: forall a . HaskDb () -> Run a -> IO a
+run :: forall a . HaskDb -> Run a -> IO a
 run db Run {..} =
   STM.atomically $ do
      db' <- Core.instantiateStmDb db
@@ -49,7 +49,7 @@ run db Run {..} =
 --------------------------------------------------------------------------------
 db0 = Data.emptyHask
 
-state :: Run (HaskDb ())
+state :: Run HaskDb
 state = ask >>= (Run . lift . Core.readFullStmDbInHask')
 
 reset :: Run ()

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -67,7 +67,7 @@ data Trace = Trace
   , traceOutput   :: [Text]
   , traceExitCode :: ExitCode
   , traceNested   :: [Trace]
-  , traceState    :: Data.HaskDb Rt.Runtime -- ^ The resulting state.
+  , traceState    :: Data.HaskDb -- ^ The resulting state.
   }
 
 -- | Keep all traces, but removes the `traceNested` indirection.

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -125,7 +125,7 @@ run (Command.CommandWithTarget (Command.Parse confParser) _ _) =
         Command.ParseState -> do
           let result = Aeson.eitherDecodeStrict (T.encodeUtf8 content)
           case result of
-            Right (value :: Data.HaskDb Rt.Runtime) -> do
+            Right (value :: Data.HaskDb) -> do
               print value
               exitSuccess
             Left err -> do

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -235,11 +235,11 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                   :> Capture "name" FilePath
                   :> Capture "nbr" Int
                   :> "state.json"
-                  :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] (HaskDb Rt.Runtime))
+                  :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] HaskDb)
 
              :<|> "state" :> Get '[B.HTML] Pages.EchoPage
              :<|> "state.json"
-                  :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] (HaskDb Rt.Runtime))
+                  :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] HaskDb)
 
              :<|> "emails"
                   :> H.UserAuthentication :>  Get '[B.HTML] Pages.EmailPage
@@ -649,7 +649,7 @@ type ServerC m
     , MonadReader Rt.Runtime m
     , MonadIO m
     , Show (S.DBError m STM User.UserProfile)
-    , S.Db m STM User.UserProfile ~ Core.StmDb Rt.Runtime
+    , S.Db m STM User.UserProfile ~ Core.StmDb
     )
 
 
@@ -2537,7 +2537,7 @@ showScenarioStateAsJson
   => FilePath
   -> FilePath
   -> Int
-  -> m (JP.PrettyJSON '[ 'JP.DropNulls] (HaskDb Rt.Runtime))
+  -> m (JP.PrettyJSON '[ 'JP.DropNulls] HaskDb)
 showScenarioStateAsJson scenariosDir name nbr = do
   let path = scenariosDir </> name <> ".txt"
   ts <- liftIO $ Inter.handleRun' path
@@ -2623,7 +2623,7 @@ showState = do
 -- TODO The passwords are displayed in clear. Would be great to have the option
 -- to hide/show them.
 showStateAsJson
-  :: ServerC m => m (JP.PrettyJSON '[ 'JP.DropNulls] (HaskDb Rt.Runtime))
+  :: ServerC m => m (JP.PrettyJSON '[ 'JP.DropNulls] HaskDb)
 showStateAsJson = do
   db <- withRuntime Rt.state
   pure $ JP.PrettyJSON db


### PR DESCRIPTION
The `Data.Db` type was parameterized by a "runtime" type, propagated to `HaskDb` and `StmDb`.

I think the parameter was no longer necessary since I removed the `RuntimeHasStmDb` class in b9972e90281723a3b18f857bf7ddfb763a17e7e9.

It is now removed.