### PR TITLE
Document golden testing, improve `cty run`

### DIFF
--- a/content/documentation.md
+++ b/content/documentation.md
@@ -27,6 +27,7 @@ title: Curiosity
 - [Smart](/documentation/smart)
 - [Source code](/documentation/source)
 - [state-0](/documentation/state-0)
+- [Tests](/documentation/tests)
 - [UBL](/documentation/ubl)
 - [Validation rules](/documentation/validation)
 - [Views](/documentation/views)

--- a/content/documentation/clis.md
+++ b/content/documentation/clis.md
@@ -107,7 +107,7 @@ a new user with `cty user create --help`:
 $ cty user create alice a alice@example.com --accept-tos
 User created: USER-1
 $ cty user create mila m mila@example.com --accept-tos
-User created: USER-1
+User created: USER-2
 $ cty state | jq '._dbUserProfiles | .[] | {username: ._userProfileCreds._userCredsName, email: ._userProfileEmailAddr}'
 {
   "username": "alice",

--- a/content/documentation/clis.md
+++ b/content/documentation/clis.md
@@ -142,6 +142,13 @@ User created: USER-2
 Note: the `reset` command makes the state empty, resulting in the same state as
 `cty init`.
 
+Such scripts are used to create a [test suite](/documentation/tests),
+demonstrating the behavior of Curiosity. They are located in the [`/scenarios`
+directory](https://github.com/hypered/curiosity/tree/main/scenarios) within the
+GitHub repository. They are also listed [in the
+documentation](/documentation/scenarios#scenarios) from where they can be run
+and explored.
+
 To expose the state file using a web interface, `cty serve` can be used. By
 default it uses port 9000. In the specific case of the `smartcoop.sh` machine,
 it can be reached by using the [`play.smartcoop.sh`](https://play.smartcoop.sh)

--- a/content/documentation/scenarios.md
+++ b/content/documentation/scenarios.md
@@ -9,16 +9,16 @@ of test scenarios. To do so, Curiosity supports running scripts: they are
 textual sequences of commands that mimic closely what can be done through the
 web interface.
 
-As part of Curiosity's test suite, a [collection of scenarios](#scenarios) are
-run and their results are compared to known sources of truth, called "golden
-files". This makes sure that, as scenarios are created, and as Curiosity
-evolves, the system continues to work as expected, and few bugs can be
-introduced inadvertantly.
+As part of Curiosity's [test suite](/documentation/tests), a [collection of
+scenarios](#scenarios) are run and their results are compared to known sources
+of truth, called "golden files". This makes sure that, as scenarios are
+created, and as Curiosity evolves, the system continues to work as expected,
+and few bugs can be introduced inadvertantly.
 
 To manually run scenarios, see how to use the `cty run` [command-line
 tool](/documentation/clis). If you're a developer, the script to ensure
 scenarios match their corresponding golden files is visible [on
-GitHub](https://github.com/hypered/curiosity/blob/main/tests/run-scenarios.hs)
+GitHub](https://github.com/hypered/curiosity/blob/main/tests/run-scenarios.hs).
 
 # Example data
 
@@ -68,3 +68,7 @@ The list [as JSON](/partials/scenarios.json).
 Some scenarios have additional documentation:
 
 - [Quotation flow](/documentation/scenarios/quotation-flow)
+
+# See also
+
+- [Tests](/documentation/tests)

--- a/content/documentation/tests.md
+++ b/content/documentation/tests.md
@@ -1,0 +1,137 @@
+---
+title: Curiosity
+---
+
+# Tests
+
+Testing an application is an important process to ensure it behaves as
+intended. This can be done manually or with an automated test suite, and
+various ways of writing a test suite are possible.
+
+Curiosity uses an approach where scripts understood by its
+[CLI](/documentation/clis) are run, and their output compared to [golden
+files](https://ro-che.info/articles/2017-12-04-golden-tests).
+
+All the scenarios are located in the [`/scenarios`
+directory](https://github.com/hypered/curiosity/tree/main/scenarios) within the
+GitHub repository. They are also [listed](/documentation/scenarios#scenarios)
+in the documentation from where they can be run and explored.
+
+Because commands understood by `cty run` map to operations that can be carried
+away by the web interface and vice versa, such scripts provide a
+straightforward, but precise way to describe and run scenarios. And as we will
+see, by making sure their output match expected results, they can also be used
+to ensure the system behaves as intended.
+
+In the rest of this section, we go into some details of their usage.
+
+# `cty run` scripts
+
+Let's use the scenario called
+[`0.txt`](https://github.com/hypered/curiosity/blob/main/scenarios/0.txt),
+reproduced here:
+
+<pre><code><!--# include virtual="/scenarios/0.txt" --></code></pre>
+
+It can be executed by the `cty run` command:
+
+<pre><code>$ cty run scenarios/0.txt
+<!--# include virtual="/scenarios/0.golden" --></code></pre>
+
+In the web interface, we can also show the same execution, but with additional
+links to intermediate states:
+
+<!--# include virtual="/partials/scenarios/0" -->
+
+Let's comment what's happening. Each command in the source script is visible in
+the output of `cty run`, prefixed with its line number. Because the second line
+in the script is a comment (and thus there is nothing the execute), we can see
+that the ouput jumps from line 1 to line 3.
+
+After each command, `cty run` displays the output of that particular command,
+exactly in the same way the same command run with `cty` would do. Those lines
+are not prefixed by any number.
+
+In this particular script, each command produces only one line of output, but
+some commands produce more.
+
+Note: It is important to understand that all the output of a single command
+correspond to state changes that happen atomically: either the command produces
+some effect and eveything is reflected in that output, or if the system crash
+in the middle of the command, then no change at all will be applied to the
+state.
+
+Finally, in the web rendering of the output, after each command, there is a
+link to explore the full state of the system, exactly as it was right after
+that command.
+
+Note: When run in the web interface, the script is provided its own state and
+it doesn't affect the main state of the web application.
+
+Note: The `quit` command is not necessary to end a script, but it can be useful
+to be inserted within a script when working on it, to temporarily "skip" the
+rest of the script.
+
+# Golden files
+
+In the [source
+directory](https://github.com/hypered/curiosity/tree/main/scenarios), for each
+script (ending with a `.txt` file extension), there is a corresponding golden
+file (ending with a `.golden` file extension).
+
+The content of a golden file is supposed to be exactly the same as the ouptut
+of running the corresponding script; i.e. the content of
+[`0.golden`](https://github.com/hypered/curiosity/blob/main/scenarios/0.golden)
+should be the same as what you can see above.
+
+To make sure this is the case, especially as the project evolves, an [automated
+test](https://github.com/hypered/curiosity/blob/main/tests/run-scenarios.hs)
+lists all the scenarios, executes them, and checks their output against the
+golden files.
+
+Note: In the above example, we see that creating a new User object is reflected
+by the display of its ID. We also see that if necessary, we can use additional
+command to "read" interesting bits of data from the system, ensuring that they
+are as we expect them, e.g. that the ID `USER-1` is indeed associated to the
+`alice` username.
+
+# Happy paths and alternate paths
+
+The above scenario is very short and has also another characteristic: it is
+called a [happy path](https://en.wikipedia.org/wiki/Happy_path); everything
+goes smoothly and no validation rule fails.
+
+In contrast, if we also want to make sure the system behaves as intended in
+some other conditions, we can also explore alternative path.
+
+We now show a scenario that fails a validation rule regarding the [valid
+usernames](/documentation/validation-data#users).
+
+The scenario is called
+[`1.txt`](https://github.com/hypered/curiosity/blob/main/scenarios/1.txt),
+reproduced here:
+
+<pre><code><!--# include virtual="/scenarios/1.txt" --></code></pre>
+
+Again, it can be executed by the `cty run` command:
+
+<pre><code>$ cty run scenarios/1.txt
+<!--# include virtual="/scenarios/1.golden" --></code></pre>
+
+And can be displayed in the web interface as a nice table:
+
+<!--# include virtual="/partials/scenarios/1" -->
+
+This scenario checks that the username `about` cannot be used when creating a
+new user. Indeed the golden file ensures that the `UsernameBlocked` error
+condition is reported.
+
+Note: Curiosity shows user profiles at the `/<username>` route (e.g. see
+[Alice's profile](/alice)), so a username like `about` would clash with the
+real [About](/about) page. Even if such a page didn't exist, we would still
+need to prevent users from creating pages that may look like official Curiosity
+pages when they are not.
+
+# See also
+
+- [Scenarios](/documentation/scenarios)

--- a/scenarios/1.golden
+++ b/scenarios/1.golden
@@ -1,22 +1,4 @@
-4: reset
+1: reset
 Resetting to the empty state.
-5: as alice
-Modifying default user.
-6: user create alice secret alice@example.com --accept-tos
-User created: USER-1
-7: user create bob secret bob@example.com --accept-tos
-User created: USER-2
-8: user do set-email-addr-as-verified bob
-User successfully updated.
-9: user do set-email-addr-as-verified bob
-EmailAddrAlreadyVerified
-11: reset
-Resetting to the empty state.
-12: as bob
-Modifying default user.
-13: user create alice secret alice@example.com --accept-tos
-User created: USER-1
-14: user create bob secret bob@example.com --accept-tos
-User created: USER-2
-15: user do set-email-addr-as-verified alice
-MissingRight CanVerifyEmailAddr
+3: user create about secret alice@example.com --accept-tos
+UsernameBlocked

--- a/scenarios/1.txt
+++ b/scenarios/1.txt
@@ -1,15 +1,3 @@
-# This shows that the first user can verify an email address, but not the
-# second user.
-
 reset
-as alice
-user create alice secret alice@example.com --accept-tos
-user create bob secret bob@example.com --accept-tos
-user do set-email-addr-as-verified bob  # Will succeed.
-user do set-email-addr-as-verified bob  # This is already done.
-
-reset
-as bob
-user create alice secret alice@example.com --accept-tos
-user create bob secret bob@example.com --accept-tos
-user do set-email-addr-as-verified alice  # Will fail: missing right.
+# Shows that a user called "about" cannot be created
+user create about secret alice@example.com --accept-tos

--- a/scenarios/2.golden
+++ b/scenarios/2.golden
@@ -1,0 +1,22 @@
+4: reset
+Resetting to the empty state.
+5: as alice
+Modifying default user.
+6: user create alice secret alice@example.com --accept-tos
+User created: USER-1
+7: user create bob secret bob@example.com --accept-tos
+User created: USER-2
+8: user do set-email-addr-as-verified bob
+User successfully updated.
+9: user do set-email-addr-as-verified bob
+EmailAddrAlreadyVerified
+11: reset
+Resetting to the empty state.
+12: as bob
+Modifying default user.
+13: user create alice secret alice@example.com --accept-tos
+User created: USER-1
+14: user create bob secret bob@example.com --accept-tos
+User created: USER-2
+15: user do set-email-addr-as-verified alice
+MissingRight CanVerifyEmailAddr

--- a/scenarios/2.txt
+++ b/scenarios/2.txt
@@ -1,0 +1,15 @@
+# This shows that the first user can verify an email address, but not the
+# second user.
+
+reset
+as alice
+user create alice secret alice@example.com --accept-tos
+user create bob secret bob@example.com --accept-tos
+user do set-email-addr-as-verified bob  # Will succeed.
+user do set-email-addr-as-verified bob  # This is already done.
+
+reset
+as bob
+user create alice secret alice@example.com --accept-tos
+user create bob secret bob@example.com --accept-tos
+user do set-email-addr-as-verified alice  # Will fail: missing right.

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -369,7 +369,7 @@ parserRun = Run <$> P.confParser <*> A.argument
   (A.metavar "FILE" <> A.action "file" <> A.help "Script to run.")
 
 parserParse :: A.Parser Command
-parserParse = Parse <$> (parserCommand <|> parserObject <|> parserFileName)
+parserParse = Parse <$> (parserCommand <|> parserFileName <|> parserObject)
 
 parserCommand :: A.Parser ParseConf
 parserCommand = ConfCommand <$> A.strOption

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 module Curiosity.Command
   ( Command(..)
+  , RunOutput(..)
   , QueueName(..)
   , Queues(..)
   , ParseConf(..)
@@ -41,8 +42,8 @@ data Command =
     -- ^ Run a REPL.
   | Serve P.Conf P.ServerConf
     -- ^ Run an HTTP server.
-  | Run P.Conf FilePath
-    -- ^ Interpret a script.
+  | Run P.Conf FilePath RunOutput
+    -- ^ Interpret a script. If True, outputs traces, otherwise only the final state.
   | Parse ParseConf
     -- ^ Parse a single command.
   | State Bool
@@ -97,6 +98,16 @@ data Command =
   | ShowId Text
     -- ^ If not a command per se, assume it's an ID to be looked up.
   deriving (Eq, Show)
+
+-- | Select if traces and/or the final state should be output.
+--   run --silent      # no traces, no final state
+--   run --final-only  # no traces,    final state, for streaming
+--   run --final       #    traces,    final state
+--   run               #    traces, no final state, equivalent to
+--   run --traces-only #    traces, no final state
+data RunOutput = RunOutput Bool Bool
+  deriving (Eq, Show)
+
 
 data QueueName = EmailAddrToVerify
   deriving (Eq, Show)
@@ -367,6 +378,23 @@ parserRun :: A.Parser Command
 parserRun = Run <$> P.confParser <*> A.argument
   A.str
   (A.metavar "FILE" <> A.action "file" <> A.help "Script to run.")
+  <*>
+      (   (A.flag' (RunOutput False False) $ A.long "silent" <> A.help
+           "Don't display traces, nor the final state."
+          )
+      <|> (A.flag' (RunOutput False True) $ A.long "final-only" <> A.help
+           "Don't display traces, but display the final state."
+           -- Showing the final state ensures that the effect of the commands
+           -- are applied.
+          )
+      <|> (A.flag' (RunOutput True True) $ A.long "final" <> A.help
+           "Display both traces and the final state."
+          )
+      <|> (A.flag (RunOutput True False) (RunOutput True False) $ A.long "traces-only"
+           <> A.help
+           "Display traces but not the final state. This is the default."
+          )
+      )
 
 parserParse :: A.Parser Command
 parserParse = Parse <$> (parserCommand <|> parserFileName <|> parserObject)

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -1,11 +1,32 @@
 {-# LANGUAGE TupleSections #-}
+{- |
+Module: Curiosity.Interpret
+Description: This module defines the core of the Curiosity interpreter: it
+parses `cty` commands (one per line), and apply them one at a time to an
+initial state.
+
+This interpretation is used in multiple places:
+
+- `cty run` is the CLI interpreter
+- `cty run` supports a nested interpreter through the `run` command
+- `cty serve` exposes the interpreter at the `/run` route (where currently a
+  single command is supported at a time)
+- `run-scenarions.hs` uses the interpreter and compares the results to golden
+  files
+
+In addition, `cty run --final-only` is intended to benchmark Curiosity by
+feeding (possibly) very long scripts.
+
+-}
+
 module Curiosity.Interpret
   ( Trace(..)
   , handleRun
+  , handleRunNoTrace
   , handleRun'
-  , interpretFile
   , interpret
-  , interpret'
+  , interpretFile
+  , interpretLines
   , formatOutput
   , flatten
   , pad
@@ -28,12 +49,21 @@ import qualified System.FilePath.Glob          as Glob
 
 
 --------------------------------------------------------------------------------
-handleRun :: P.Conf -> User.UserName -> FilePath -> IO ExitCode
-handleRun conf user scriptPath = do
+handleRun :: P.Conf -> User.UserName -> FilePath -> Bool -> IO ExitCode
+handleRun conf user scriptPath withFinal = do
   runtime <- Rt.boot conf Rt.NoThreads >>= either throwIO pure
-  code    <- interpret runtime user scriptPath
+  (code, output) <- interpret runtime user scriptPath
   Rt.powerdown runtime
+  when withFinal $ print output
   exitWith code
+
+handleRunNoTrace :: P.Conf -> User.UserName -> FilePath -> Bool -> IO ExitCode
+handleRunNoTrace conf user scriptPath withFinal = do
+  runtime <- Rt.boot conf Rt.NoThreads >>= either throwIO pure
+  output <- interpretFile' runtime user scriptPath 0
+  Rt.powerdown runtime
+  when withFinal $ print output
+  exitWith ExitSuccess
 
 -- | Similar to `handleRun`, but capturing the output, and logging elsewhere
 -- than normally: this is used in tests and in the `/scenarios` handler.
@@ -48,12 +78,15 @@ handleRun' scriptPath = do
   Rt.powerdown runtime
   pure output
 
-interpret :: Rt.Runtime -> User.UserName -> FilePath -> IO ExitCode
+interpret :: Rt.Runtime -> User.UserName -> FilePath -> IO (ExitCode, Data.HaskDb)
 interpret runtime user path = do
   output <- interpretFile runtime user path 0
   let (exitCode, ls) = formatOutput output
+      finalState = case ls of
+        [] -> Data.emptyHask
+        _ -> traceState $ last output
   mapM_ putStrLn ls
-  pure exitCode
+  pure (exitCode, finalState)
 
 
 --------------------------------------------------------------------------------
@@ -79,16 +112,30 @@ interpretFile :: Rt.Runtime -> User.UserName -> FilePath -> Int -> IO [Trace]
 interpretFile runtime user path nesting = do
   let dir = takeDirectory path
   content <- T.lines <$> readFile path
-  interpret' runtime user dir content nesting
+  interpretLines runtime user dir content nesting [] (\t acc -> acc ++ [t])
 
-interpret'
+-- | TODO This is similar to `interpretFile` but this doesn't collect the
+-- individual traces. Still, a call to `Rt.state` is done after each command
+-- and maybe this could be avoided.
+-- The idea is to be able to use this function on some large script to
+-- benchmark the system and make sure it can process each supported operation
+-- quickly.
+interpretFile' :: Rt.Runtime -> User.UserName -> FilePath -> Int -> IO Data.HaskDb
+interpretFile' runtime user path nesting = do
+  let dir = takeDirectory path
+  content <- T.lines <$> readFile path
+  interpretLines runtime user dir content nesting Data.emptyHask (\t _ -> traceState t)
+
+interpretLines
   :: Rt.Runtime
   -> User.UserName
   -> FilePath
   -> [Text]
   -> Int
-  -> IO [Trace]
-interpret' runtime user dir content nesting = go user [] 0
+  -> acc
+  -> (Trace -> acc -> acc)
+  -> IO acc
+interpretLines runtime user dir content nesting acc0 accumulate = go user acc0 0
   $ zip [1 :: Int ..] content
  where
   go _ acc _ []                  = pure acc
@@ -108,12 +155,12 @@ interpret' runtime user dir content nesting = go user [] 0
       ["as", username] -> do
         st <- Rt.runRunM runtime Rt.state
         let t    = trace' ["Modifying default user."] ExitSuccess [] st
-            acc' = acc ++ [t]
+            acc' = accumulate t acc
         go (User.UserName username) acc' nbr' rest
       ["quit"] -> do
         st <- Rt.runRunM runtime Rt.state
         let t    = trace' ["Exiting."] ExitSuccess [] st
-            acc' = acc ++ [t]
+            acc' = accumulate t acc
         go user' acc' nbr' rest
       input -> do
         let result =
@@ -127,32 +174,32 @@ interpret' runtime user dir content nesting = go user [] 0
                 Rt.runRunM runtime $ Rt.reset
                 st <- Rt.runRunM runtime Rt.state
                 let t = trace' ["Resetting to the empty state."] ExitSuccess [] st
-                    acc' = acc ++ [t]
+                    acc' = accumulate t acc
                 go user' acc' nbr' rest
-              Command.Run _ scriptPath -> do
+              Command.Run _ scriptPath _ -> do
                 output' <- liftIO $ interpretFile runtime
                                                   user
                                                   (dir </> scriptPath)
                                                   (succ nesting)
                 st <- Rt.runRunM runtime Rt.state
                 let t    = trace' [] ExitSuccess output' st
-                    acc' = acc ++ [t]
+                    acc' = accumulate t acc
                 go user' acc' nbr' rest
               _ -> do
                 (_, output) <- Rt.handleCommand runtime user' command
                 st <- Rt.runRunM runtime Rt.state
                 let t    = trace' output ExitSuccess [] st
-                    acc' = acc ++ [t]
+                    acc' = accumulate t acc
                 go user' acc' nbr' rest
           A.Failure err -> do
             st <- Rt.runRunM runtime Rt.state
             let t    = trace' [show err] (ExitFailure 1) [] st
-                acc' = acc ++ [t]
+                acc' = accumulate t acc
             go user' acc' nbr' rest
           A.CompletionInvoked _ -> do
             st <- Rt.runRunM runtime Rt.state
             let t    = trace' ["Shouldn't happen."] (ExitFailure 1) [] st
-                acc' = acc ++ [t]
+                acc' = accumulate t acc
             go user' acc' nbr' rest
 
 

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -70,7 +70,11 @@ handleRunNoTrace conf user scriptPath withFinal = do
 handleRun' :: FilePath -> IO [Trace]
 handleRun' scriptPath = do
   let conf = P.Conf
-        { P._confLogging = P.mkLoggingConf "/tmp/cty-serve-explore.log"
+        { P._confLogging = P.noLoggingConf
+            -- P.mkLoggingConf "/tmp/cty-serve-explore.log"
+            -- TOOD Multiple concurrent calls to the same log file
+            -- end up with
+            -- RuntimeException openFile: resource busy (file is locked)
         , P._confDbFile  = Nothing
         }
   runtime <- Rt.boot conf Rt.NoThreads >>= either throwIO pure

--- a/src/Curiosity/Parse.hs
+++ b/src/Curiosity/Parse.hs
@@ -8,6 +8,7 @@ module Curiosity.Parse
   , defaultConf
   , defaultLoggingConf
   , mkLoggingConf
+  , noLoggingConf
   , confParser
   , serverParser
   , defaultServerConf
@@ -57,6 +58,11 @@ mkLoggingConf :: FilePath -> ML.LoggingConf
 mkLoggingConf path = ML.LoggingConf (ML.LoggingFile path)
                                     "Curiosity"
                                     L.levelInfo
+
+noLoggingConf :: ML.LoggingConf
+noLoggingConf = ML.LoggingConf ML.NoLogging
+                               "Curiosity"
+                               L.levelInfo
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -144,7 +144,7 @@ run (Command.CommandWithTarget (Command.Parse confParser) _ _) =
     -- TODO We need a parser for multiple commands separated by newlines.
     Command.ConfFileName fileName -> do
       content <- T.lines <$> readFile fileName
-      print content
+      mapM_ print content
       exitSuccess
 
     Command.ConfStdin -> do

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -91,12 +91,18 @@ run (Command.CommandWithTarget (Command.Serve conf serverConf) target _) = do
       putStrLn @Text "TODO"
       exitFailure
 
-run (Command.CommandWithTarget (Command.Run _ scriptPath) target (Command.User user))
+run (Command.CommandWithTarget (Command.Run _ scriptPath runOutput) target (Command.User user))
   = case target of
-    Command.MemoryTarget -> do
-      Inter.handleRun P.defaultConf user scriptPath
-    Command.StateFileTarget path -> do
-      Inter.handleRun P.defaultConf { P._confDbFile = Just path } user scriptPath
+    Command.MemoryTarget ->
+      let  Command.RunOutput withTraces withFinal = runOutput in
+      if withTraces
+      then Inter.handleRun P.defaultConf user scriptPath withFinal
+      else Inter.handleRunNoTrace P.defaultConf user scriptPath withFinal
+    Command.StateFileTarget path ->
+      let Command.RunOutput withTraces withFinal = runOutput in
+      if withTraces
+      then Inter.handleRun P.defaultConf { P._confDbFile = Just path } user scriptPath withFinal
+      else Inter.handleRunNoTrace P.defaultConf { P._confDbFile = Just path } user scriptPath withFinal
     Command.UnixDomainTarget _ -> do
       putStrLn @Text "TODO"
       exitFailure
@@ -327,8 +333,8 @@ repl runtime user = HL.runInputT HL.defaultSettings loop
             -- We ignore the Configuration here. Probably this should be moved
             -- to Rt.handleCommand too.
             Command.Reset _          -> Rt.runRunM runtime $ Rt.reset
-            Command.Run _ scriptPath -> do
-              code <- liftIO $ Inter.interpret runtime user scriptPath
+            Command.Run _ scriptPath _ -> do
+              (code, _) <- liftIO $ Inter.interpret runtime user scriptPath
               case code of
                 ExitSuccess   -> pure ()
                 ExitFailure _ -> output' "Script failed."

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -2481,7 +2481,8 @@ handleRun authResult (Data.Command cmd) = withMaybeUser
  where
   run' mprofile = do
     runtime <- ask
-    output  <- liftIO $ Inter.interpret' runtime username "/tmp/nowhere" [cmd] 0
+    output  <- liftIO $ Inter.interpretLines runtime username "/tmp/nowhere" [cmd] 0
+      [] (\t acc -> acc ++ [t])
     let (_, ls) = Inter.formatOutput output
     pure $ unlines ls
    where

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -23,9 +23,8 @@ module Curiosity.Server
     -- * Scenarios
     --
     -- $scenarios
-  , showScenario
-  , showScenarioState
-  , showScenarioStateAsJson
+  , partialScenarioState
+  , partialScenarioStateAsJson
   , partialScenarios
   , partialScenariosAsJson
   ) where
@@ -223,19 +222,7 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                   :> ReqBody '[FormUrlEncoded] Data.Command
                   :> Post '[B.HTML] Pages.EchoPage
 
-             :<|> "scenarios"
-                  :> Capture "name" FilePath
-                  :> Get '[B.HTML] H.Html
-             :<|> "scenarios"
-                  :> Capture "name" FilePath
-                  :> Capture "nbr" Int
-                  :> "state"
-                  :> Get '[B.HTML] H.Html
-             :<|> "scenarios"
-                  :> Capture "name" FilePath
-                  :> Capture "nbr" Int
-                  :> "state.json"
-                  :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] HaskDb)
+             :<|> "scenarios" :> Raw
 
              :<|> "state" :> Get '[B.HTML] Pages.EchoPage
              :<|> "state.json"
@@ -492,6 +479,16 @@ type Partials =
 
   :<|> "partials" :> "scenarios"
        :> Capture "name" FilePath :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "scenarios"
+       :> Capture "name" FilePath
+       :> Capture "nbr" Int
+       :> "state"
+       :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "scenarios"
+       :> Capture "name" FilePath
+       :> Capture "nbr" Int
+       :> "state.json"
+       :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] HaskDb)
 
   -- live data
   :<|> "partials" :> "legal-entities" :> Get '[B.HTML] H.Html
@@ -549,9 +546,7 @@ serverT natTrans ctx conf jwtS root dataDir scenariosDir =
 
     :<|> showRun
     :<|> handleRun
-    :<|> showScenario scenariosDir
-    :<|> showScenarioState scenariosDir
-    :<|> showScenarioStateAsJson scenariosDir
+    :<|> serveScenario scenariosDir
 
     :<|> showState
     :<|> showStateAsJson
@@ -633,10 +628,20 @@ partials scenariosDir =
     :<|> partialScenarios scenariosDir
     :<|> partialScenariosAsJson scenariosDir
     :<|> partialScenario scenariosDir
+    :<|> partialScenarioState scenariosDir
+    :<|> partialScenarioStateAsJson scenariosDir
 
     -- live data
     :<|> partialLegalEntities
     :<|> partialLegalEntitiesAsJson
+
+
+--------------------------------------------------------------------------------
+serveScenario :: ServerC m => FilePath -> Tagged m Application
+serveScenario path = serveDirectoryWith settings
+ where
+  settings = (defaultWebAppSettings path) { ss404Handler = Just custom404 }
+
 
 --------------------------------------------------------------------------------
 -- | Minimal set of constraints needed on some monad @m@ to be satisfied to be
@@ -2496,50 +2501,22 @@ handleRun authResult (Data.Command cmd) = withMaybeUser
 --
 -- Expose @cty run@ scenarios found in the @`scenarios/`@ directory.
 
-showScenario :: ServerC m => FilePath -> FilePath -> m H.Html
-showScenario scenariosDir name = do
-  let path = scenariosDir </> name <> ".txt"
-  ts <- liftIO $ Inter.handleRun' path
-  pure . H.pre . H.code $ mapM_ displayTrace ts
- where
-  displayTrace Inter.Trace {..} = do
-    H.text
-      $  Inter.pad traceNesting
-      <> show traceLineNbr
-      <> ": "
-      <> traceCommand
-      <> "    "
-    H.a
-      ! A.href
-          (  H.toValue
-          $  "/scenarios/"
-          <> name
-          <> "/"
-          <> show traceNumber
-          <> "/state.json"
-          )
-      $ "View state"
-    H.text "\n"
-    mapM_ (\o -> H.text (Inter.pad traceNesting) >> H.text o >> H.text "\n")
-          traceOutput
-    mapM_ displayTrace traceNested
-
 -- | Show the state after a specific command, given as its number within the
 -- script.
-showScenarioState :: ServerC m => FilePath -> FilePath -> Int -> m H.Html
-showScenarioState scenariosDir name nbr = do
+partialScenarioState :: ServerC m => FilePath -> FilePath -> Int -> m H.Html
+partialScenarioState scenariosDir name nbr = do
   let path = scenariosDir </> name <> ".txt"
   ts <- liftIO $ Inter.handleRun' path
   let ts' = Inter.flatten ts
   pure . H.code . H.pre $ H.text $ show . Inter.traceState $ ts' !! nbr
 
-showScenarioStateAsJson
+partialScenarioStateAsJson
   :: ServerC m
   => FilePath
   -> FilePath
   -> Int
   -> m (JP.PrettyJSON '[ 'JP.DropNulls] HaskDb)
-showScenarioStateAsJson scenariosDir name nbr = do
+partialScenarioStateAsJson scenariosDir name nbr = do
   let path = scenariosDir </> name <> ".txt"
   ts <- liftIO $ Inter.handleRun' path
   let ts' = Inter.flatten ts
@@ -2552,12 +2529,11 @@ partialScenarios scenariosDir = do
   pure . H.ul $ mapM_ displayScenario names
  where
   displayScenario name = H.li $ do
-    H.a ! A.href (H.toValue $ "/scenarios/" <> name) $ H.code $ H.string name
+    H.a ! A.href (H.toValue $ "/partials/scenarios/" <> name) $ H.code $ H.string name
 
 partialScenariosAsJson :: ServerC m => FilePath -> m [FilePath]
 partialScenariosAsJson = listScenarioNames
 
--- | Similar to `showScenario` but with a richer rendering.
 partialScenario :: ServerC m => FilePath -> FilePath -> m H.Html
 partialScenario scenariosDir name = do
   let path = scenariosDir </> name <> ".txt"
@@ -2593,7 +2569,7 @@ partialScenario scenariosDir name = do
       H.td $ H.a
         ! A.href
             (  H.toValue
-            $  "/scenarios/"
+            $  "/partials/scenarios/"
             <> name
             <> "/"
             <> show traceNumber
@@ -2695,6 +2671,7 @@ custom404 _request sendResponse = sendResponse $ Wai.responseLBS
 
 --------------------------------------------------------------------------------
 -- | Serve example data as JSON files.
+serveData :: ServerC m => FilePath -> Tagged m Application
 serveData path = serveDirectoryWith settings
  where
   settings = (defaultWebAppSettings path) { ss404Handler = Just custom404 }


### PR DESCRIPTION
This mainly adds a documentation page to explain how golden testing works in the Curiosity project. To do so, some new routes are added to be able to embed scenarios and their golden files within the documentation page.

This also adds some flags to `cty run` to be able to control whether regular output and/or the final state of the scenario should be printed to the console.

A nice aspect of using the new flags is that `cty run`, when only reporting the final state, should not retain in memory more than the runtime state, and that displaying it should make sure its final state is fully evaluated. This could be the basis for some benchmarking code (e.g. process a long scenario as fast as possible).