### PR TITLE
Augment the legal entity, user profile, and business unit types

### DIFF
--- a/content/documentation/objects/entities.md
+++ b/content/documentation/objects/entities.md
@@ -4,4 +4,11 @@ title: Curiosity
 
 # Legal entities
 
-See [example](/views/entity/one.json). — [JSON](/data/one.json)
+One S.A.
+
+:   See [static example](/views/entity/one.json) (— [JSON](/data/one.json),
+    [UBL](/ubl/PartyLegalEntity/one.json)), or [live example](/entity/one).
+
+## Authorizations
+
+See the [library documentation](/haddock/Curiosity-Data-Legal.html#t:Authorization).

--- a/content/documentation/objects/units.md
+++ b/content/documentation/objects/units.md
@@ -4,4 +4,7 @@ title: Curiosity
 
 # Business units
 
-See [example](/views/unit/alpha.json). — [JSON](/data/alpha.json)
+Alpha
+
+:   See [static example](/views/unit/alpha.json) (— [JSON](/data/alpha.json)),
+    or [live example](/alpha).

--- a/content/documentation/objects/users.md
+++ b/content/documentation/objects/users.md
@@ -20,7 +20,10 @@ The email address is necessary because it is used by the password reset process
 Most features of the system are available to users "upgraded" from the "base"
 status.
 
-See [example](/views/profile/bob-0.json). — [JSON](/data/bob-0.json)
+Bob
+
+:   See [static example](/views/profile/bob-0.json) (—
+    [JSON](/data/bob-0.json)), or [live example](/bob).
 
 ## Completion-1 user
 
@@ -33,7 +36,10 @@ The additional information are:
 - Postal address
 - Telephone number
 
-See [example](/views/profile/bob-1.json). — [JSON](/data/bob-1.json)
+Bob
+
+:   See [static example](/views/profile/bob-1.json) (—
+    [JSON](/data/bob-1.json)), or [live example](/bob).
 
 ## Completion-2 user
 
@@ -44,7 +50,14 @@ The additional information are:
 
 - EId
 
-See [example](/views/profile/bob-2.json). — [JSON](/data/bob-2.json)
+Bob
+
+:   See [static example](/views/profile/bob-2.json) (—
+    [JSON](/data/bob-2.json)), or [live example](/bob).
+
+## Authorizations
+
+See the [library documentation](/haddock/Curiosity-Data-User.html#t:Authorization).
 
 ## Questions
 

--- a/data/alice-with-bio.json
+++ b/data/alice-with-bio.json
@@ -10,5 +10,6 @@
   "_userProfileTosConsent": true,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
-  "_userProfileRights": ["CanVerifyEmailAddr"]
+  "_userProfileRights": ["CanVerifyEmailAddr"],
+  "_userProfileAuthorizations": []
 }

--- a/data/alice.json
+++ b/data/alice.json
@@ -8,5 +8,6 @@
   "_userProfileTosConsent": true,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
-  "_userProfileRights": ["CanCreateContracts", "CanVerifyEmailAddr"]
+  "_userProfileRights": ["CanCreateContracts", "CanVerifyEmailAddr"],
+  "_userProfileAuthorizations": ["AuthorizedAsEmployee"]
 }

--- a/data/alpha.json
+++ b/data/alpha.json
@@ -1,5 +1,9 @@
 {
   "_entityId": "BENT-1",
   "_entitySlug": "alpha",
-  "_entityName": "Alpha"
+  "_entityName": "Alpha",
+  "_entityType": "TODO",
+  "_entityHolders": [],
+  "_entityAuthorizations": [],
+  "_entityScopes": []
 }

--- a/data/bob-0.json
+++ b/data/bob-0.json
@@ -9,5 +9,6 @@
   "_userProfileTosConsent": true,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
-  "_userProfileRights": []
+  "_userProfileRights": [],
+  "_userProfileAuthorizations": []
 }

--- a/data/bob-1.json
+++ b/data/bob-1.json
@@ -14,5 +14,6 @@
     "_userProfileAddrAndTelVerified": "2022-08-02"
   },
   "_userProfileCompletion2": {},
-  "_userProfileRights": []
+  "_userProfileRights": [],
+  "_userProfileAuthorizations": []
 }

--- a/data/bob-2.json
+++ b/data/bob-2.json
@@ -17,5 +17,6 @@
     "_userProfileEId": "xxxx",
     "_userProfileEIdVerified": "2022-08-02"
   },
-  "_userProfileRights": []
+  "_userProfileRights": [],
+  "_userProfileAuthorizations": []
 }

--- a/data/charlie.json
+++ b/data/charlie.json
@@ -9,5 +9,6 @@
   "_userProfileTosConsent": false,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
-  "_userProfileRights": []
+  "_userProfileRights": [],
+  "_userProfileAuthorizations": []
 }

--- a/data/mila.json
+++ b/data/mila.json
@@ -8,5 +8,6 @@
   "_userProfileTosConsent": true,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
-  "_userProfileRights": []
+  "_userProfileRights": [],
+  "_userProfileAuthorizations": []
 }

--- a/data/one.json
+++ b/data/one.json
@@ -4,5 +4,6 @@
   "_entityName": "One S.A.",
   "_entityCbeNumber": "100200300",
   "_entityVatNumber": "BE0100200300",
-  "_entityUsersAndRoles": []
+  "_entityUsersAndRoles": [],
+  "_entityAuthorizations": []
 }

--- a/scenarios/init-entities.golden
+++ b/scenarios/init-entities.golden
@@ -2,3 +2,5 @@
 Legal entity created: LENT-1
 2: legal update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
 Legal entity updated: one
+3: legal link-user one USER-1 --validator
+Legal entity updated: one

--- a/scenarios/init-entities.txt
+++ b/scenarios/init-entities.txt
@@ -1,2 +1,3 @@
 legal create one "One S.A." 100200300 BE0100200300
 legal update one "One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One."
+legal link-user one USER-1 --validator

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -18,6 +18,8 @@ Resetting to the empty state.
 > Legal entity created: LENT-1
 > 2: legal update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
 > Legal entity updated: one
+> 3: legal link-user one USER-1 --validator
+> Legal entity updated: one
 4: run init-units.txt
 > 1: business create alpha Alpha
 > Business entity created: BENT-1

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -60,6 +60,7 @@ data Command =
   | UpdateBusinessEntity Business.Update
   | CreateLegalEntity Legal.Create
   | UpdateLegalEntity Legal.Update
+  | LinkLegalEntityToUser Text User.UserId Legal.ActingRole
   | CreateUser User.Signup
   | SelectUser Bool User.UserId Bool
     -- ^ Show a given user. If True, use Haskell format instead of JSON. If
@@ -499,6 +500,11 @@ parserLegal =
          ( A.info (parserUpdateLegalEntity <**> A.helper)
          $ A.progDesc "Update a legal entity"
          )
+    <> A.command
+         "link-user"
+         ( A.info (parserLegalLinkUser <**> A.helper)
+         $ A.progDesc "Link a user to the entity, specifying a role"
+         )
 
 parserCreateLegalEntity :: A.Parser Command
 parserCreateLegalEntity = do
@@ -521,6 +527,16 @@ parserUpdateLegalEntity = do
   slug        <- argumentEntitySlug
   description <- A.argument A.str (A.metavar "TEXT" <> A.help "A description")
   pure $ UpdateLegalEntity $ Legal.Update slug (Just description)
+
+parserLegalLinkUser :: A.Parser Command
+parserLegalLinkUser = do
+  slug  <- argumentEntitySlug
+  uid  <- argumentUserId
+  role <-
+    (A.flag' Legal.Validator $ A.long "validator" <> A.help
+      "TODO Add a description for the validator flag"
+    )
+  pure $ LinkLegalEntityToUser slug uid role
 
 argumentEntityId = Legal.EntityId <$> A.argument A.str metavarEntityId
 

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -302,6 +302,8 @@ createUser db User.Signup {..} = do
           (User.UserCompletion2 Nothing Nothing)
           -- The very first user has plenty of rights:
           (if newId == firstUserId then firstUserRights else [])
+          -- TODO Define some mechanism to get the initial authorizations
+          [User.AuthorizedAsEmployee]
     emailId <- createEmail db Email.SignupConfirmationEmail
                  Email.systemEmailAddr
                  email

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -387,7 +387,7 @@ createBusiness db Business.Create {..} = do
  where
   transaction = do
     newId <- generateBusinessId db
-    let new = Business.Unit newId _createSlug _createName Nothing
+    let new = Business.Unit newId _createSlug _createName Nothing "TODO" [] [] []
     createBusinessFull db new >>= either STM.throwSTM pure
 
 createBusinessFull

--- a/src/Curiosity/Data/Business.hs
+++ b/src/Curiosity/Data/Business.hs
@@ -10,10 +10,13 @@ module Curiosity.Data.Business
   , Update(..)
   , UnitId(..)
   , unitIdPrefix
+  , Authorization(..)
+  , Scope(..)
   , Err(..)
   ) where
 
 import qualified Commence.Types.Wrapped        as W
+import qualified Curiosity.Data.User           as User
 import           Data.Aeson
 import qualified Text.Blaze.Html5              as H
 import           Web.FormUrlEncoded             ( FromForm(..)
@@ -45,11 +48,15 @@ instance FromForm Update where
 
 --------------------------------------------------------------------------------
 data Unit = Unit
-  { _entityId          :: UnitId
-  , _entitySlug        :: Text
+  { _entityId             :: UnitId
+  , _entitySlug           :: Text
     -- An identifier suitable for URLs
-  , _entityName        :: Text
-  , _entityDescription :: Maybe Text
+  , _entityName           :: Text
+  , _entityDescription    :: Maybe Text
+  , _entityType           :: Text
+  , _entityHolders        :: [User.UserId]
+  , _entityAuthorizations :: [Authorization]
+  , _entityScopes         :: [Scope]
   }
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
@@ -67,6 +74,16 @@ newtype UnitId = UnitId { unUnitId :: Text }
 
 unitIdPrefix :: Text
 unitIdPrefix = "BENT-"
+
+-- TODO Ask Roger the meaning of these.
+data Authorization = Bundle0 | Bundle1
+  deriving (Eq, Generic, Show)
+  deriving (FromJSON, ToJSON)
+
+-- TODO Ask Roger the meaning of these.
+data Scope = ScopeCreateQuotation | ScopeSendQuotation | ScopeCreateInvoice
+  deriving (Eq, Generic, Show)
+  deriving (FromJSON, ToJSON)
 
 data Err = Err
   { unErr :: Text

--- a/src/Curiosity/Data/Legal.hs
+++ b/src/Curiosity/Data/Legal.hs
@@ -12,6 +12,7 @@ module Curiosity.Data.Legal
   , entityIdPrefix
   , RegistrationName(..)
   , ActingUserId(..)
+  , ActingRole(..)
   , ActingUser(..)
   , EntityAndRole(..)
   , Authorization(..)
@@ -129,7 +130,7 @@ data ActingUserId = ActingUserId User.UserId ActingRole
   deriving (Eq, Generic, Show)
   deriving (FromJSON, ToJSON)
 
-data ActingRole = Titular | Director | Administrator
+data ActingRole = Titular | Director | Administrator | Validator
   deriving (Eq, Generic, Show)
   deriving (FromJSON, ToJSON)
 

--- a/src/Curiosity/Data/Legal.hs
+++ b/src/Curiosity/Data/Legal.hs
@@ -14,6 +14,7 @@ module Curiosity.Data.Legal
   , ActingUserId(..)
   , ActingUser(..)
   , EntityAndRole(..)
+  , Authorization(..)
   , Err(..)
   , encodeUBL
   , toUBL
@@ -71,6 +72,7 @@ data Entity = Entity
     -- ^ Public description. Similar to a user profile bio.
   , _entityUsersAndRoles :: [ActingUserId]
     -- ^ Users that can "act" within the entity, with some kind of associated rights.
+  , _entityAuthorizations :: [Authorization]
   }
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
@@ -137,6 +139,11 @@ data ActingUser = ActingUser User.UserProfile ActingRole
 -- | The inverse of `ActingUser`: an entity in which a user acts, with the role
 -- of the user.
 data EntityAndRole = EntityAndRole Entity ActingRole
+
+-- TODO Ask Roger the meaning of these.
+data Authorization = AuthorizedAsBuyer | AuthorizedAsSeller | AccountingAuthorized | OnlineAccountAuthorized
+  deriving (Eq, Generic, Show)
+  deriving (FromJSON, ToJSON)
 
 data Err = Err
   deriving (Eq, Exception, Show)

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -18,6 +18,7 @@ module Curiosity.Data.User
   , UserCompletion1(..)
   , UserCompletion2(..)
   , AccessRight(..)
+  , Authorization(..)
   , permissions
   , userProfileCreds
   , userProfileId
@@ -137,6 +138,7 @@ data UserProfile' creds userDisplayName userEmailAddr tosConsent = UserProfile
   , _userProfileCompletion1       :: UserCompletion1
   , _userProfileCompletion2       :: UserCompletion2
   , _userProfileRights            :: [AccessRight]
+  , _userProfileAuthorizations    :: [Authorization]
   }
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
@@ -231,6 +233,13 @@ newtype UserId = UserId { unUserId :: Text }
 
 userIdPrefix :: Text
 userIdPrefix = "USER-"
+
+-- TODO Ask Roger the meaning of these.
+-- | Those are in addition of AccessRight, maybe they should be combined
+-- together.
+data Authorization = AuthorizedAsEmployee | AuthorizedAsHolder | AuthorizedAsAdvisor | AuthorizedAsSuperAdvisor | AccountingAuthorized | OnlineAccountAuthorized
+  deriving (Eq, Generic, Show)
+  deriving (FromJSON, ToJSON)
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Business.hs
+++ b/src/Curiosity/Html/Business.hs
@@ -33,6 +33,28 @@ unitView unit hasEditButton = containerMedium $ do
     keyValuePair "ID"   (Business._entityId unit)
     keyValuePair "Name" (Business._entityName unit)
     maybe mempty (keyValuePair "Description") (Business._entityDescription unit)
+    keyValuePair "Type (industry class)" (Business._entityType unit)
+
+    title' "Holders" Nothing
+    H.ul $ mapM_ displayHolder $ Business._entityHolders unit
+
+    title' "Authorizations" Nothing
+    H.ul $ mapM_ displayAuthorization $ Business._entityAuthorizations unit
+
+    title' "Scopes" Nothing
+    H.ul $ mapM_ displayScope $ Business._entityScopes unit
+
+displayHolder holder =
+  H.li $ do
+    H.code . H.text $ User.unUserId holder
+
+displayAuthorization auth =
+  H.li $ do
+    H.code . H.text $ show auth
+
+displayScope scope =
+  H.li $ do
+    H.code . H.text $ show scope
 
 --------------------------------------------------------------------------------
 data CreateUnitPage = CreateUnitPage

--- a/src/Curiosity/Html/Legal.hs
+++ b/src/Curiosity/Html/Legal.hs
@@ -34,12 +34,20 @@ entityView entity users hasEditButton = containerMedium $ do
   H.dl ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short" $ do
     keyValuePair "ID"                (Legal._entityId entity)
     keyValuePair "Registration name" (Legal._entityName entity)
+    keyValuePair "Country"           ("BE (TODO)" :: Text) -- TODO
     keyValuePair "CBE number"        (Legal._entityCbeNumber entity)
     keyValuePair "VAT number"        (Legal._entityVatNumber entity)
     maybe mempty (keyValuePair "Description") (Legal._entityDescription entity)
 
+  title' "Authorizations" Nothing
+  H.ul $ mapM_ displayAuthorizations $ Legal._entityAuthorizations entity
+
   title' "Acting users" Nothing
   H.ul $ mapM_ displayActingUser users
+
+displayAuthorizations auth =
+  H.li $ do
+    H.code . H.text $ show auth
 
 displayActingUser (Legal.ActingUser u role) =
   H.li $ do

--- a/src/Curiosity/Html/Legal.hs
+++ b/src/Curiosity/Html/Legal.hs
@@ -40,12 +40,12 @@ entityView entity users hasEditButton = containerMedium $ do
     maybe mempty (keyValuePair "Description") (Legal._entityDescription entity)
 
   title' "Authorizations" Nothing
-  H.ul $ mapM_ displayAuthorizations $ Legal._entityAuthorizations entity
+  H.ul $ mapM_ displayAuthorization $ Legal._entityAuthorizations entity
 
   title' "Acting users" Nothing
   H.ul $ mapM_ displayActingUser users
 
-displayAuthorizations auth =
+displayAuthorization auth =
   H.li $ do
     H.code . H.text $ show auth
 

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -247,8 +247,16 @@ profileView profile entities hasEditButton =
             )
           keyValuePair "Rights"
                        (show . User._userProfileRights $ profile :: Text)
+
+    title' "Authorizations" Nothing
+    H.ul $ mapM_ displayAuthorizations $ User._userProfileAuthorizations profile
+
     title' "Related entities" Nothing
     H.ul $ mapM_ displayEntities entities
+
+displayAuthorizations auth =
+  H.li $ do
+    H.code . H.text $ show auth
 
 displayEntities (Legal.EntityAndRole entity role) =
   H.li $ do

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -249,16 +249,16 @@ profileView profile entities hasEditButton =
                        (show . User._userProfileRights $ profile :: Text)
 
     title' "Authorizations" Nothing
-    H.ul $ mapM_ displayAuthorizations $ User._userProfileAuthorizations profile
+    H.ul $ mapM_ displayAuthorization $ User._userProfileAuthorizations profile
 
     title' "Related entities" Nothing
-    H.ul $ mapM_ displayEntities entities
+    H.ul $ mapM_ displayEntitie entities
 
-displayAuthorizations auth =
+displayAuthorization auth =
   H.li $ do
     H.code . H.text $ show auth
 
-displayEntities (Legal.EntityAndRole entity role) =
+displayEntitie (Legal.EntityAndRole entity role) =
   H.li $ do
     H.a ! A.href (H.toValue $ "/entity/" <> Legal._entitySlug entity) $
       H.text . Legal.unRegistrationName $ Legal._entityName entity

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -839,6 +839,7 @@ createLegal db Legal.Create {..} = do
                            _createVatNumber
                            Nothing
                            []
+                           [Legal.AuthorizedAsBuyer] -- TODO Better logic for initial values.
     createLegalFull db new >>= either STM.throwSTM pure
 
 createLegalFull

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -114,7 +114,7 @@ import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Parse               as Command
 import qualified Data.Aeson.Text               as Aeson
 import qualified Data.ByteString.Lazy          as BS
-import           Data.List                      ( lookup )
+import           Data.List                      ( lookup, nub )
 import qualified Data.Map                      as M
 import qualified Data.Text                     as T
 import qualified Data.Text.Encoding            as TE
@@ -545,18 +545,22 @@ handleCommand runtime@Runtime {..} user command = do
             Left err -> pure (ExitFailure 1, [show err])
         Left err -> pure (ExitFailure 1, [show err])
     Command.UpdateLegalEntity input -> do
-      output <- runAppMSafe runtime . liftIO . STM.atomically $ updateLegal
-        _rDb
-        input
-      case output of
-        Right mid -> do
-          case mid of
-            Right () -> do
-              pure
-                ( ExitSuccess
-                , ["Legal entity updated: " <> Legal._updateSlug input]
-                )
-            Left err -> pure (ExitFailure 1, [show err])
+      mid <- runRunM runtime $ updateLegal' input
+      case mid of
+        Right () -> do
+          pure
+            ( ExitSuccess
+            , ["Legal entity updated: " <> Legal._updateSlug input]
+            )
+        Left err -> pure (ExitFailure 1, [show err])
+    Command.LinkLegalEntityToUser slug uid role -> do
+      mid <- runRunM runtime $ linkLegalToUser' slug uid role
+      case mid of
+        Right () -> do
+          pure
+            ( ExitSuccess
+            , ["Legal entity updated: " <> slug]
+            )
         Left err -> pure (ExitFailure 1, [show err])
     Command.CreateUser input -> do
       muid <- runRunM runtime $ createUser input
@@ -864,6 +868,33 @@ updateLegal db Legal.Update {..} = do
       modifyLegalEntities db replaceOlder
       pure $ Right ()
     Nothing -> pure . Left $ User.UserNotFound _updateSlug -- TODO
+
+updateLegal' :: Legal.Update -> RunM (Either User.Err ())
+updateLegal' update = do
+  db <- asks _rDb
+  liftIO . STM.atomically $ updateLegal db update
+
+linkLegalToUser :: Core.StmDb -> Text -> User.UserId -> Legal.ActingRole -> STM (Either User.Err ())
+linkLegalToUser db slug uid role = do
+  mentity <- selectEntityBySlug db slug
+  case mentity of
+    Just Legal.Entity {..} -> do
+      let replaceOlder entities =
+            [ if Legal._entitySlug e == slug
+                then e { Legal._entityUsersAndRoles =
+                           nub $ Legal.ActingUserId uid role : _entityUsersAndRoles
+                       }
+                else e
+            | e <- entities
+            ]
+      modifyLegalEntities db replaceOlder
+      pure $ Right ()
+    Nothing -> pure . Left $ User.UserNotFound slug -- TODO
+
+linkLegalToUser' :: Text -> User.UserId -> Legal.ActingRole -> RunM (Either User.Err ())
+linkLegalToUser' slug uid role = do
+  db <- asks _rDb
+  liftIO . STM.atomically $ linkLegalToUser db slug uid role
 
 modifyLegalEntities
   :: Core.StmDb


### PR DESCRIPTION
This PR is based on an email from Roger titled
'pour les visuels web des fiches "legal" "person", business unit"'
from 2022-08-27.

- Add some notion of legal entity authorization: This makes it possible to add a user, specifying a role, to a list of "acting" users within the entity. Maybe this should be called "contacts" instead.
- Add some notion of user profile authorization.
- Add some notion of business unit authorization, and also notions of Scope Code, Holders, and Activity types.