### PR TITLE
Document the concepts of queues and steps

### DIFF
--- a/content/documentation.md
+++ b/content/documentation.md
@@ -29,6 +29,7 @@ title: Curiosity
 - [Source code](/documentation/source)
 - [state-0](/documentation/state-0)
 - [Tests](/documentation/tests)
+- [Time](/documentation/time)
 - [UBL](/documentation/ubl)
 - [Validation rules](/documentation/validation)
 - [Views](/documentation/views)

--- a/content/documentation.md
+++ b/content/documentation.md
@@ -22,6 +22,7 @@ title: Curiosity
 - [Messages](/documentation/messages)
 - [Objects](/documentation/objects)
 - [Permissions](/documentation/permissions)
+- [Queues](/documentation/queues)
 - [Scenarios](/documentation/scenarios)
 - [Sitemap](/documentation/sitemap)
 - [Smart](/documentation/smart)

--- a/content/documentation/queues.md
+++ b/content/documentation/queues.md
@@ -71,3 +71,4 @@ used too.
 # See also
 
 - [Tests](/documentation/tests)
+- [Time](/documentation/time)

--- a/content/documentation/queues.md
+++ b/content/documentation/queues.md
@@ -1,0 +1,73 @@
+---
+title: Curiosity
+---
+
+# Queues
+
+In the [tests documentation page](/documentation/tests), we explain how
+Curiosity is using textual scripts and golden files to describe and tests the
+system's behavior. There, we can see how user commands affect the system by
+running them, and observing (parts of) the resulting state.
+
+An important part of the system behavior that we want to describe and test
+relates to automated processes: actions that the system can take autonomously,
+e.g. sending a confirmation email after a user has registered, or sending a
+reminder after some period of time.
+
+To make it possible to also describe and test that part of the system, we
+expose the concepts of _queues_ and _steps_.
+
+Queues, short for "task queues", are similar to to-do lists: they contain a
+list of tasks that can be taken off the queue and processed. We can image such
+queues for tasks that can be acted upon by humans, but here we're interested in
+tasks that the system can performs.
+
+Most of the time, queues are explicit construct into which tasks are written
+too. In Curiosity, we're being a bit more flexible and also visualise objects
+waiting for some actions as queues as well.
+
+For instance, sending an email is really adding a task "send email" to a
+specific queue called "email-to-send". The command `cty queue emails-to-send`
+shows the content of that queue.
+
+On the other hand, user profiles with unverified email adresses don't have a
+corresponding specific queue within the system, but can still be visualised
+with the `cty queue user-email-addr-to-verify`.
+
+To process queues, a command `cty step` is provided. Together with the the
+above commands, we can devise scenarios to describe and test automated
+processes.
+
+Consider the following scenario:
+[`signup-actions.txt`](https://github.com/hypered/curiosity/blob/main/scenarios/signup-actions.txt),
+reproduced here:
+
+<pre><code><!--# include virtual="/scenarios/signup-actions.txt" --></code></pre>
+
+Here is how it looks like when run with `cty run`:
+
+<pre><code>$ cty run scenarios/1.txt
+<!--# include virtual="/scenarios/signup-actions.golden" --></code></pre>
+
+And here it is as a nice table:
+
+<!--# include virtual="/partials/scenarios/signup-actions" -->
+
+This scenario shows that initially, queues are empty (there is no tasks that
+the system can take autonomously), and that creating a new user also creates
+some tasks: an email address has to be verified, and an email has to be sent.
+
+It also shows that it is possible to execute those tasks with the `step --all`
+command, or show what would be executed (but without actually doing so) with
+the `--dry` option. Notice, by visiting the "View" links, how the email starts
+with a state `EmailTodo`, then `EmailDone`.
+
+Note: with `cty run`, automated processes must be explicitely run with the
+`step` command. Within the web server,
+["threads"](https://en.wikipedia.org/wiki/Thread_(computing)) are taking care
+of those processes. They can be disabled, and the `step` command can then be
+used too.
+
+# See also
+
+- [Tests](/documentation/tests)

--- a/content/documentation/tests.md
+++ b/content/documentation/tests.md
@@ -137,3 +137,4 @@ pages when they are not.
 # See also
 
 - [Scenarios](/documentation/scenarios)
+- [Queues](/documentation/queues)

--- a/content/documentation/tests.md
+++ b/content/documentation/tests.md
@@ -138,3 +138,4 @@ pages when they are not.
 
 - [Scenarios](/documentation/scenarios)
 - [Queues](/documentation/queues)
+- [Time](/documentation/time)

--- a/content/documentation/time.md
+++ b/content/documentation/time.md
@@ -1,0 +1,50 @@
+---
+title: Curiosity
+---
+
+# Time
+
+In the [tests documentation page](/documentation/tests), we explain how
+Curiosity is using textual scripts and golden files to describe and tests the
+system's behavior. In the [queues documentation page](/documentation/queues),
+we show how the `queues` and `step` commands can be used to describe and test
+automated processes, by observing task queues and "stepping" through them.
+
+Some tasks however have to be delayed or be enqueued only in the future, e.g.
+when it's time to send a reminder to someone, after some time has passed.
+
+Again, with the goal of having scenarios that can describe and test a wide
+range of behaviours, it is necessary to simulate the advance of time.
+
+Here we show how the `time` command can be used to observe and manipulate a
+simulated time.
+
+Consider the following scenario:
+[`time.txt`](https://github.com/hypered/curiosity/blob/main/scenarios/time.txt),
+reproduced here:
+
+<pre><code><!--# include virtual="/scenarios/time.txt" --></code></pre>
+
+Here is how it looks like when run with `cty run`:
+
+<pre><code>$ cty run scenarios/1.txt
+<!--# include virtual="/scenarios/time.golden" --></code></pre>
+
+And here it is as a nice table:
+
+<!--# include virtual="/partials/scenarios/time" -->
+
+This scenario shows that initially, the time is set to 00:00:00 UTC on 1
+January 1970. Internally, the time is recorded as [Epoch
+time](https://en.wikipedia.org/wiki/Unix_time), and its initial value is 0.
+
+Then it shows that `time --step` and `time --step --minute` can be used to
+advance the time, either by one second, or until the "next minute".
+
+As often in our scenarios, we issue a command to observe (part of) the current
+state: `time`.
+
+# See also
+
+- [Tests](/documentation/tests)
+- [Queues](/documentation/queues)

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -80,6 +80,7 @@ common common-dependencies
     , blaze-markup
     , template-haskell
     , unix
+    , unix-time
   -- mixins: design-hs-lib hiding (Prelude)
   --       -- since cabal mixins are a half baked feature, hiding one module means hiding every other module.
   --       -- And then we have to explicity specify another mixin to be able to the modules we never intended to hide.

--- a/scenarios/signup-actions.golden
+++ b/scenarios/signup-actions.golden
@@ -1,0 +1,14 @@
+1: reset
+Resetting to the empty state.
+2: user create alice secret alice@example.com --accept-tos
+User created: USER-1
+3: queues
+Email addresses to verify:
+USER-1 alice
+Emails to send:
+EMAIL-1 alice@example.com
+4: step --all
+All steps done.
+5: queues
+Email addresses to verify:
+Emails to send:

--- a/scenarios/signup-actions.golden
+++ b/scenarios/signup-actions.golden
@@ -1,16 +1,23 @@
 1: reset
 Resetting to the empty state.
-2: user create alice secret alice@example.com --accept-tos
+2: queues
+Email addresses to verify:
+Emails to send:
+3: user create alice secret alice@example.com --accept-tos
 User created: USER-1
-3: queues
+4: queues
 Email addresses to verify:
 USER-1 alice
 Emails to send:
 EMAIL-1 alice@example.com
-4: step --all
+5: step --all --dry
 Setting user email addr. to verified: alice@example.com
 Sending email: EMAIL-1
 All steps done.
-5: queues
+6: step --all
+Setting user email addr. to verified: alice@example.com
+Sending email: EMAIL-1
+All steps done.
+7: queues
 Email addresses to verify:
 Emails to send:

--- a/scenarios/signup-actions.golden
+++ b/scenarios/signup-actions.golden
@@ -8,6 +8,8 @@ USER-1 alice
 Emails to send:
 EMAIL-1 alice@example.com
 4: step --all
+Setting user email addr. to verified: alice@example.com
+Sending email: EMAIL-1
 All steps done.
 5: queues
 Email addresses to verify:

--- a/scenarios/signup-actions.txt
+++ b/scenarios/signup-actions.txt
@@ -1,5 +1,7 @@
 reset
+queues
 user create alice secret alice@example.com --accept-tos
 queues
+step --all --dry
 step --all
 queues

--- a/scenarios/signup-actions.txt
+++ b/scenarios/signup-actions.txt
@@ -1,0 +1,5 @@
+reset
+user create alice secret alice@example.com --accept-tos
+queues
+step --all
+queues

--- a/scenarios/time.golden
+++ b/scenarios/time.golden
@@ -1,0 +1,10 @@
+1: reset
+Resetting to the empty state.
+2: time
+01/Jan/1970:01:00:00 +0100
+3: time --step
+01/Jan/1970:01:00:01 +0100
+4: time --step --minute
+01/Jan/1970:01:01:00 +0100
+5: time
+01/Jan/1970:01:01:00 +0100

--- a/scenarios/time.txt
+++ b/scenarios/time.txt
@@ -1,0 +1,5 @@
+reset
+time
+time --step
+time --step --minute
+time

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -98,6 +98,10 @@ data Command =
     -- "disabled".
     -- If True, execute all of them.
     -- If True, don't actually execute them but report what whould be done.
+  | Time Bool Bool
+    -- ^ Report or set the simulated time.
+    -- If True, advance the time by a second.
+    -- If True, advance the time to the next minute.
   | Log Text P.Conf
     -- Log a line of text to the logs.
   | ShowId Text
@@ -354,6 +358,12 @@ parser =
            "step"
            ( A.info (parserStep <**> A.helper)
            $ A.progDesc "Run the next automated action(s)"
+           )
+
+      <> A.command
+           "time"
+           ( A.info (parserTime <**> A.helper)
+           $ A.progDesc "Report or set the simulated time"
            )
 
       <> A.command
@@ -885,6 +895,11 @@ parserStep :: A.Parser Command
 parserStep = Step <$> A.switch
   (A.long "all" <> A.help "Execute all possible actions (default is one action).")
   <*> A.switch (A.long "dry" <> A.help "Don't actually execute actions, but report what would be done.")
+
+parserTime :: A.Parser Command
+parserTime = Time
+  <$> A.switch (A.long "step" <> A.help "Advance the time of 1 second.")
+  <*> A.switch (A.long "minute" <> A.help "Advance the time to the next minute.")
 
 parserLog :: A.Parser Command
 parserLog =

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -92,10 +92,11 @@ data Command =
     -- ^ View queue. The queues can be filters applied to objects, not
     -- necessarily explicit list in database.
   | ViewQueues Queues
-  | Step
+  | Step Bool
     -- ^ Execute the next automated action when using stepped (non-wallclock)
     -- mode, or mixed-mode, or the next automated action when the automation is
     -- "disabled".
+    -- If True, execute all of them.
   | Log Text P.Conf
     -- Log a line of text to the logs.
   | ShowId Text
@@ -350,8 +351,8 @@ parser =
 
       <> A.command
            "step"
-           ( A.info (pure Step <**> A.helper)
-           $ A.progDesc "Run the next automated action"
+           ( A.info (parserStep <**> A.helper)
+           $ A.progDesc "Run the next automated action(s)"
            )
 
       <> A.command
@@ -878,6 +879,10 @@ parserQueues =
             <> A.metavar "USERNAME"
             )
         )
+
+parserStep :: A.Parser Command
+parserStep = Step <$> A.switch
+  (A.long "all" <> A.help "Execute all possible actions (default is one action).")
 
 parserLog :: A.Parser Command
 parserLog =

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -92,11 +92,12 @@ data Command =
     -- ^ View queue. The queues can be filters applied to objects, not
     -- necessarily explicit list in database.
   | ViewQueues Queues
-  | Step Bool
+  | Step Bool Bool
     -- ^ Execute the next automated action when using stepped (non-wallclock)
     -- mode, or mixed-mode, or the next automated action when the automation is
     -- "disabled".
     -- If True, execute all of them.
+    -- If True, don't actually execute them but report what whould be done.
   | Log Text P.Conf
     -- Log a line of text to the logs.
   | ShowId Text
@@ -883,6 +884,7 @@ parserQueues =
 parserStep :: A.Parser Command
 parserStep = Step <$> A.switch
   (A.long "all" <> A.help "Execute all possible actions (default is one action).")
+  <*> A.switch (A.long "dry" <> A.help "Don't actually execute actions, but report what would be done.")
 
 parserLog :: A.Parser Command
 parserLog =

--- a/src/Curiosity/Data.hs
+++ b/src/Curiosity/Data.hs
@@ -39,6 +39,7 @@ import qualified Curiosity.Data.User           as User
 import           Data.Aeson
 import qualified Data.Text                     as T
 import qualified Network.HTTP.Types.Status     as S
+import           System.PosixCompat.Types       ( EpochTime )
 import qualified System.Random                 as Rand
 import qualified System.Random.Internal        as Rand
 import qualified System.Random.SplitMix        as SM
@@ -74,6 +75,10 @@ data Db (datastore :: Type -> Type) = Db
 
   , _dbRandomGenState   :: datastore (Word64, Word64)
     -- ^ The internal representation of a StdGen.
+  , _dbEpochTime        :: datastore EpochTime
+    -- ^ The internal time, possibly disconnected from the real wall clock.
+    -- This is used to simulate the advance of time for automated processes
+    -- triggered by the `step` command.
 
   , _dbFormCreateQuotationAll ::
       datastore (Map (User.UserName, Text) Quotation.CreateQuotationAll)
@@ -116,6 +121,8 @@ emptyHask = Db (pure 1)
                (pure mempty)
 
                (pure initialGenState)
+               (pure 0) -- 01/Jan/1970:01:00:00 +0100
+
                (pure mempty)
                (pure mempty)
                (pure mempty)

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -174,9 +174,13 @@ run (Command.CommandWithTarget (Command.ViewQueues queues) target (Command.User 
   = do
     case target of
       Command.MemoryTarget -> do
-        handleViewQueues P.defaultConf user queues
+        handleCommand P.defaultConf
+                      user
+                      (Command.ViewQueues queues)
       Command.StateFileTarget path -> do
-        handleViewQueues P.defaultConf { P._confDbFile = Just path } user queues
+        handleCommand P.defaultConf { P._confDbFile = Just path }
+                      user
+                      (Command.ViewQueues queues)
       Command.UnixDomainTarget _ -> do
         putStrLn @Text "TODO"
         exitFailure
@@ -249,19 +253,6 @@ handleViewQueue conf user name = do
 
 
 --------------------------------------------------------------------------------
-handleViewQueues conf user queues = do
-  case queues of
-    Command.CurrentUserQueues -> do
-      -- TODO Check first if the user has the necessary rights to handle this
-      -- queue.
-      handleViewQueue conf user Command.EmailAddrToVerify
-      handleViewQueue conf user Command.EmailsToSend
-    _ -> do
-      putStrLn @Text "TODO handleViewQueues"
-      exitFailure
-
-
---------------------------------------------------------------------------------
 handleShowId conf user i = do
   case T.splitOn "-" i of
     "USER" : _ -> do
@@ -282,7 +273,7 @@ handleCommand conf user command = do
 
   Rt.powerdown runtime
   -- TODO shutdown runtime, loggers, save state, ...
-  pure exitCode
+  exitWith exitCode
 
 handleError e
   |

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -5,6 +5,7 @@ module Curiosity.Run
 import qualified Commence.Runtime.Errors       as Errs
 import qualified Curiosity.Command             as Command
 import qualified Curiosity.Data                as Data
+import qualified Curiosity.Data.Email          as Email
 import qualified Curiosity.Data.User           as User
 import qualified Curiosity.Interpret           as Inter
 import qualified Curiosity.Parse               as P
@@ -240,6 +241,11 @@ handleViewQueue conf user name = do
       handleCommand conf
                     user
                     (Command.FilterUsers User.PredicateEmailAddrToVerify)
+    Command.EmailsToSend -> do
+      putStrLn @Text "Emails to send:"
+      handleCommand conf
+                    user
+                    (Command.FilterEmails Email.EmailsTodo)
 
 
 --------------------------------------------------------------------------------
@@ -249,6 +255,7 @@ handleViewQueues conf user queues = do
       -- TODO Check first if the user has the necessary rights to handle this
       -- queue.
       handleViewQueue conf user Command.EmailAddrToVerify
+      handleViewQueue conf user Command.EmailsToSend
     _ -> do
       putStrLn @Text "TODO handleViewQueues"
       exitFailure
@@ -275,7 +282,7 @@ handleCommand conf user command = do
 
   Rt.powerdown runtime
   -- TODO shutdown runtime, loggers, save state, ...
-  exitWith exitCode
+  pure exitCode
 
 handleError e
   |

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -185,14 +185,14 @@ run (Command.CommandWithTarget (Command.ViewQueues queues) target (Command.User 
         putStrLn @Text "TODO"
         exitFailure
 
-run (Command.CommandWithTarget (Command.Step isAll) target (Command.User user)) = do
+run (Command.CommandWithTarget (Command.Step isAll dryRun) target (Command.User user)) = do
   case target of
     Command.MemoryTarget -> do
-      handleCommand P.defaultConf user $ Command.Step isAll
+      handleCommand P.defaultConf user $ Command.Step isAll dryRun
     Command.StateFileTarget path -> do
       handleCommand P.defaultConf { P._confDbFile = Just path }
                     user
-                    (Command.Step isAll)
+                    (Command.Step isAll dryRun)
     Command.UnixDomainTarget _ -> do
       putStrLn @Text "TODO"
       exitFailure

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -181,14 +181,14 @@ run (Command.CommandWithTarget (Command.ViewQueues queues) target (Command.User 
         putStrLn @Text "TODO"
         exitFailure
 
-run (Command.CommandWithTarget Command.Step target (Command.User user)) = do
+run (Command.CommandWithTarget (Command.Step isAll) target (Command.User user)) = do
   case target of
     Command.MemoryTarget -> do
-      handleCommand P.defaultConf user Command.Step
+      handleCommand P.defaultConf user $ Command.Step isAll
     Command.StateFileTarget path -> do
       handleCommand P.defaultConf { P._confDbFile = Just path }
                     user
-                    Command.Step
+                    (Command.Step isAll)
     Command.UnixDomainTarget _ -> do
       putStrLn @Text "TODO"
       exitFailure

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -780,6 +780,13 @@ handleCommand runtime@Runtime {..} user command = do
             Left _ -> pure (ExitFailure 1, ["Key not found: " <> input])
         Nothing ->
           pure (ExitFailure 1, ["Username not found: " <> User.unUserName user])
+    Command.FilterEmails predicate -> do
+      records <- runRunM runtime $ filterEmails' predicate
+      let f Email.Email {..} =
+            let Email.EmailId i              = _emailId
+                User.UserEmailAddr recipient = _emailRecipient
+            in  i <> " " <> recipient
+      pure (ExitSuccess, map f records)
     Command.Step -> do
       let transaction _ _ = do
             users <- filterUsers _rDb User.PredicateEmailAddrToVerify

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -805,6 +805,17 @@ handleCommand runtime@Runtime {..} user command = do
                 User.UserEmailAddr recipient = _emailRecipient
             in  i <> " " <> recipient
       pure (ExitSuccess, map f records)
+    Command.ViewQueues queues -> do
+      -- TODO Check first if the user has the necessary rights to handle this
+      -- queue.
+      (_, output1) <- handleCommand runtime
+                        user
+                        (Command.FilterUsers User.PredicateEmailAddrToVerify)
+      (_, output2) <- handleCommand runtime
+                         user
+                         (Command.FilterEmails Email.EmailsTodo)
+      pure (ExitSuccess, ["Email addresses to verify:"] <> output1 <>
+        ["Emails to send:"] <> output2)
     Command.Step True -> do
       runRunM runtime $ do
         verifyEmailStep


### PR DESCRIPTION
- Add command to show emails to send:
  - This adds `queue emails-to-send`
  - And now `queues` reports also the emails to send
- Now step `--all` also send emails; it was only "verifying" emails (i.e. set users as having a verified email address).
- Add scenario for signup email and email verification. This shows that after a user is created, an email must be sent to that
user, and their email address must be verified. After running `step --all`, queues are empty. (Currently, email verification is just  setting the "verified" bit to true, without actually checking some one-time token.)
- Add a `--dry` option to the step command, to show what would happen, but without actually doing it.
- Add a `time` command with a small scenario and a documentation page.