### PR TITLE
Add a procfile -based environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,23 @@ $ cabal build curiosity
 $ ./dist-newstyle/build/x86_64-linux/ghc-8.6.5/curiosity-0.1.0.0/x/curiosity/build/curiosity/cty serve
 ```
 
-And finally, we can build a binary with Nix:
+We can build a binary with Nix:
 
 ```
 $ nix-build -A curiosity
 $ ./result/bin/cty serve
 ```
+
+And finally, we can run a local dev environment containing curiosity and a Nginx reverse proxy using:
+
+```
+$ nix-build -A integration-tests.local-dev-environment
+$ ./result/bin/run-interactive-integration-env
+$ # Or alternatively from a nix-shell via an injected alias
+$ nix-shell
+$ interactive-integration-env
+```
+
 
 # Example REPL commands
 

--- a/README.md
+++ b/README.md
@@ -91,14 +91,12 @@ $ nix-build -A curiosity
 $ ./result/bin/cty serve
 ```
 
-And finally, we can run a local dev environment containing curiosity and a Nginx reverse proxy using:
+And finally, we can run a local dev environment containing curiosity and a
+Nginx reverse proxy using:
 
 ```
-$ nix-build -A integration-tests.local-dev-environment
-$ ./result/bin/run-interactive-integration-env
-$ # Or alternatively from a nix-shell via an injected alias
-$ nix-shell
-$ interactive-integration-env
+$ nix-build -A run
+$ result/bin/run-full-environment
 ```
 
 

--- a/content/documentation/environments.md
+++ b/content/documentation/environments.md
@@ -81,10 +81,11 @@ automatically.
 
 ## Environment variables
 
-When running `cty serve`, the location of the documentation and the example
-data files must be known by the application in order to serve them. Those
-locations can be passed by using the `--static-dir` and `--data-dir`
-command-line options. For convenience, the above environments contain two
-environment variables, `CURIOSITY_STATIC_DIR` and `CURIOSITY_DATA_DIR` that are
-set to the right values. Those environment variables take precedence over the
-command-line options.
+When running `cty serve`, the location of the documentation, the example
+data files, and the scenarios must be known by the application in order to
+serve them. Those locations can be passed by using the `--static-dir`,
+`--data-dir`, and `scenarios-dir` command-line options. For convenience, the
+above environments contain three environment variables, `CURIOSITY_STATIC_DIR`,
+`CURIOSITY_DATA_DIR`, and `CURIOSITY_SCENARIOS_DIR` that are set to the right
+values. Those environment variables take precedence over the command-line
+options.

--- a/default.nix
+++ b/default.nix
@@ -20,13 +20,17 @@ let
       ./machine/no-gui.nix
     ];
   };
-in rec
-  {
     # Build with nix-build -A <attr>
     # binaries + haddock are also available as binaries.all.
     binaries = nixpkgs.haskellPackages.curiosity;
-    haddock = nixpkgs.haskellPackages.curiosity.doc;
     content = (import ./content {}).html.all;
+    haddock = nixpkgs.haskellPackages.curiosity.doc;
+    run = import ./scripts/integration-tests {
+      inherit nixpkgs binaries haddock content;
+    };
+in rec
+  {
+    inherit nixpkgs binaries content haddock run;
     data = (import ./content {}).data;
     scenarios = (import ./content {}).scenarios;
     static = (import "${sources.design-hs}").static;

--- a/default.nix
+++ b/default.nix
@@ -20,19 +20,19 @@ let
       ./machine/no-gui.nix
     ];
   };
-    # Build with nix-build -A <attr>
-    # binaries + haddock are also available as binaries.all.
     binaries = nixpkgs.haskellPackages.curiosity;
     content = (import ./content {}).html.all;
+    data = (import ./content {}).data;
+    scenarios = (import ./content {}).scenarios;
     haddock = nixpkgs.haskellPackages.curiosity.doc;
     run = import ./scripts/integration-tests {
-      inherit nixpkgs binaries haddock content;
+      inherit nixpkgs binaries haddock content data scenarios;
     };
 in rec
   {
+    # Build with nix-build -A <attr>
+    # binaries + haddock are also available as binaries.all.
     inherit nixpkgs binaries content haddock run;
-    data = (import ./content {}).data;
-    scenarios = (import ./content {}).scenarios;
     static = (import "${sources.design-hs}").static;
     man-pages = (import ./man {}).man-pages;
     toplevel = os.config.system.build.toplevel;
@@ -50,15 +50,17 @@ in rec
                   # to set MANPATH below.
                   # I guess it would work if it was packaged with the binaries.
       ];
-      # Setting the CURIOSITY_STATIC_DIR and CURIOSITY_DATA_DIR is not strictly
-      # necessary as this shell is usually run from the source repository, and
-      # the default paths will work (provided the _site/ directory has been
-      # built. But this makes the shell usable even without those conditions.
+      # Setting the CURIOSITY_STATIC_DIR, CURIOSITY_DATA_DIR, and
+      # CURIOSITY_SCENARIOS_DIR is not strictly necessary as this shell is
+      # usually run from the source repository, and the default paths will work
+      # (provided the _site/ directory has been built. But this makes the shell
+      # usable even without those conditions.
       shellHook = ''
         source <(cty             --bash-completion-script `which cty`)
         source <(cty-sock        --bash-completion-script `which cty-sock`)
         export CURIOSITY_STATIC_DIR=${content}
         export CURIOSITY_DATA_DIR=${data}
+        export CURIOSITY_SCENARIOS_DIR=${scenarios}
         export MANPATH=${man-pages}/share/man
       '';
     };

--- a/docker/default.nix
+++ b/docker/default.nix
@@ -38,6 +38,7 @@ nixpkgs.dockerTools.buildImage {
         "MANPATH=${man-pages}/share/man"
         "CURIOSITY_STATIC_DIR=${(import ../.).content}"
         "CURIOSITY_DATA_DIR=${(import ../.).data}"
+        "CURIOSITY_SCENARIOS_DIR=${(import ../.).scenarios}"
     ];
     ExposedPorts = {
       "9000/tcp" = {};

--- a/machine/configuration.nix
+++ b/machine/configuration.nix
@@ -53,6 +53,7 @@ in
     source <(cty-sock        --bash-completion-script `which cty-sock`)
     export CURIOSITY_STATIC_DIR=${(import ../.).content}
     export CURIOSITY_DATA_DIR=${(import ../.).data}
+    export CURIOSITY_SCENARIOS_DIR=${(import ../.).scenarios}
   '';
 
   users.users.curiosity = {

--- a/scripts/integration-tests/README.md
+++ b/scripts/integration-tests/README.md
@@ -1,0 +1,15 @@
+# Integration test scripts
+
+This integration test suite is meant to be used to generate an interactive
+integration test environment and to perform some integration tests on the CI.
+
+You can locally setup an interactive integration env using the
+`./interactive-integration-env` script. This script build and start a curiosity
+server and an Nginx reverse proxy.
+
+> ⚠️ Warning
+>
+> The `.sh` scripts living in this directory are not meant to be executed in
+> isolation. These scripts need to be glued to their dependencies via Nix. They
+> are living outside of `default.nix` for convenience reasons: it improves the
+> editor syntax color highlighting and linting support.

--- a/scripts/integration-tests/default.nix
+++ b/scripts/integration-tests/default.nix
@@ -1,0 +1,42 @@
+{
+  nixpkgs ? (import ../../.).nixpkgs,
+  binaries ? (import ../../.).binaries,
+  haddock ? (import ../../.).haddock,
+  content ? (import ../../.).content,
+  data ? (import ../../.).data,
+  system ? builtins.currentSystem,
+  lib ? nixpkgs.lib
+}:
+
+let
+  runCuriosity = nixpkgs.writers.writeBashBin "run-curiosity" ''
+    set -euo pipefail
+    PATH=${lib.strings.makeBinPath [ binaries ]}:$PATH
+    export CURIOSITY_STATIC_DIR=${content}
+    export CURIOSITY_DATA_DIR=${data}
+    ${builtins.readFile ./run-curiosity.sh}
+  '';
+  nginxConf = nixpkgs.substituteAll {
+    src = ./nginx.conf;
+    curiosityaddr = "http://127.0.0.1:9100";
+    # TODO: find a way to reference this folder without the explicit
+    #       0.1.0.0 version
+    curiosityhaddock = "${haddock.doc}/share/doc/curiosity-0.1.0.0/html";
+  };
+  runNginx = nixpkgs.writers.writeBashBin "run-nginx" ''
+    set -euo pipefail
+    PATH=${lib.strings.makeBinPath [ nixpkgs.nginx ]}:$PATH
+    NGINX_CONF="${nginxConf}"
+    ${builtins.readFile ./run-nginx.sh}
+  '';
+  procFile = nixpkgs.writeText "Procfile" ''
+    curiosity: ${runCuriosity}/bin/run-curiosity
+    nginx: ${runNginx}/bin/run-nginx
+  '';
+  run-full-environment = nixpkgs.writers.writeBashBin "run-full-environment" ''
+    set -euo pipefail
+    ${nixpkgs.hivemind}/bin/hivemind ${procFile}
+  '';
+in {
+  inherit run-full-environment;
+}

--- a/scripts/integration-tests/default.nix
+++ b/scripts/integration-tests/default.nix
@@ -4,6 +4,7 @@
   haddock ? (import ../../.).haddock,
   content ? (import ../../.).content,
   data ? (import ../../.).data,
+  scenarios ? (import ../../.).scenarios,
   system ? builtins.currentSystem,
   lib ? nixpkgs.lib
 }:
@@ -14,6 +15,7 @@ let
     PATH=${lib.strings.makeBinPath [ binaries ]}:$PATH
     export CURIOSITY_STATIC_DIR=${content}
     export CURIOSITY_DATA_DIR=${data}
+    export CURIOSITY_SCENARIOS_DIR=${scenarios}
     ${builtins.readFile ./run-curiosity.sh}
   '';
   nginxConf = nixpkgs.substituteAll {

--- a/scripts/integration-tests/nginx.conf
+++ b/scripts/integration-tests/nginx.conf
@@ -1,0 +1,50 @@
+daemon off;
+error_log stderr warn;
+pid @tmpdir@/nginx.pid;
+events {
+  worker_connections  1024;
+}
+http {
+        types_hash_max_size 4096;
+        default_type application/octet-stream;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        gzip on;
+        gzip_proxied any;
+        gzip_comp_level 5;
+        gzip_types
+        application/atom+xml
+        application/javascript
+        application/json
+        application/xml
+        application/xml+rss
+        image/svg+xml
+        text/css
+        text/javascript
+        text/plain
+        text/xml;
+        gzip_vary on;
+        client_max_body_size 10m;
+        server_tokens off;
+        server {
+                client_body_temp_path @tmpdir@;
+                proxy_temp_path @tmpdir@;
+                fastcgi_temp_path @tmpdir@;
+                uwsgi_temp_path @tmpdir@;
+                scgi_temp_path @tmpdir@;
+                access_log @tmpdir@/access.log;
+        	listen 0.0.0.0:8888;
+        	server_name localhost;
+        	location / {
+        		proxy_pass @curiosityaddr@;
+        	}
+        	location /documentation {
+        		proxy_pass @curiosityaddr@;
+        		ssi on;
+        	}
+        	location /haddock/ {
+                        alias @curiosityhaddock@/;
+#        		alias /nix/store/mmhksfkznr3b9rwb7zkllnn11qxzxpc1-curiosity-0.1.0.0-doc/share/doc/curiosity-0.1.0.0/html/;
+        	}
+        }
+}

--- a/scripts/integration-tests/nginx.conf
+++ b/scripts/integration-tests/nginx.conf
@@ -33,18 +33,17 @@ http {
                 uwsgi_temp_path @tmpdir@;
                 scgi_temp_path @tmpdir@;
                 access_log @tmpdir@/access.log;
-        	listen 0.0.0.0:8888;
-        	server_name localhost;
-        	location / {
-        		proxy_pass @curiosityaddr@;
-        	}
-        	location /documentation {
-        		proxy_pass @curiosityaddr@;
-        		ssi on;
-        	}
-        	location /haddock/ {
+                listen 0.0.0.0:8888;
+                server_name localhost;
+                location / {
+                        proxy_pass @curiosityaddr@;
+                }
+                location /documentation {
+                        proxy_pass @curiosityaddr@;
+                        ssi on;
+                }
+                location /haddock/ {
                         alias @curiosityhaddock@/;
-#        		alias /nix/store/mmhksfkznr3b9rwb7zkllnn11qxzxpc1-curiosity-0.1.0.0-doc/share/doc/curiosity-0.1.0.0/html/;
-        	}
+                }
         }
 }

--- a/scripts/integration-tests/readme.md
+++ b/scripts/integration-tests/readme.md
@@ -1,0 +1,9 @@
+# Integration Tests Scripts
+
+This integration test suite is meant to be used to generate an interactive integration test environment and to perform some integration tests on the CI.
+
+You can locally setup an interactive integration env using the `./interactive-integration-env` script. This script build and start a curiosity server and an Nginx reverse proxy.
+
+> ⚠️ Warning
+>
+> The `.sh` scripts living in this directory are not meant to be executed in isolation. These scripts need to be glued to their dependencies via Nix. They are living outside of `default.nix` for convenience reasons: it improves the editor syntax color highlighting and linting support.

--- a/scripts/integration-tests/readme.md
+++ b/scripts/integration-tests/readme.md
@@ -1,9 +1,0 @@
-# Integration Tests Scripts
-
-This integration test suite is meant to be used to generate an interactive integration test environment and to perform some integration tests on the CI.
-
-You can locally setup an interactive integration env using the `./interactive-integration-env` script. This script build and start a curiosity server and an Nginx reverse proxy.
-
-> ⚠️ Warning
->
-> The `.sh` scripts living in this directory are not meant to be executed in isolation. These scripts need to be glued to their dependencies via Nix. They are living outside of `default.nix` for convenience reasons: it improves the editor syntax color highlighting and linting support.

--- a/scripts/integration-tests/run-curiosity.sh
+++ b/scripts/integration-tests/run-curiosity.sh
@@ -1,0 +1,19 @@
+if ! command -v cty; then
+    scriptdir=$(realpath -s "$0" | xargs dirname)
+    echo "Missing cty."
+    echo "Did you read $scriptdir/readme.md ?"
+    exit 1
+fi
+
+echo "[+] Setting up the curiosity runtime env"
+rundir=$(mktemp -d -t "curiosity.XXXXXXXXXX")
+echo "[+] Curiosity runtime dir: $rundir"
+trap 'rm -rf -- "$rundir"' EXIT
+cd "$rundir"
+
+# Init curiosity env
+cty init
+
+# Start server
+echo "[+] Starting the curiosity server"
+cty serve --server-port 9100

--- a/scripts/integration-tests/run-nginx.sh
+++ b/scripts/integration-tests/run-nginx.sh
@@ -1,0 +1,16 @@
+if [[ -z $NGINX_CONF ]]; then
+    scriptdir=$(realpath -s "$0" | xargs dirname)
+    echo "Missing static files."
+    echo "Did you read $scriptdir/readme.md ?"
+    exit 1
+fi
+rundir=$(mktemp -d -t "curiosity-nginx.XXXXXXXXXX")
+echo "[+] Nginx runtime dir: $rundir"
+trap 'rm -rf -- "$rundir"' EXIT
+cd "$rundir"
+cp "$NGINX_CONF" nginx.conf
+mkdir -p nginx-cache
+sed -i "s~@tmpdir@~$rundir/nginx-cache~g" nginx.conf
+echo "[+] Starting nginx on port 8888"
+echo "[+] Home page: http://127.0.0.1:8888"
+nginx -c "$rundir"/nginx.conf

--- a/scripts/run-full-environment.sh
+++ b/scripts/run-full-environment.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+
 scriptdir=$(dirname $0)
 $(nix-build "$scriptdir"/integration-tests --no-out-link -A run-full-environment)/bin/run-full-environment

--- a/scripts/run-full-environment.sh
+++ b/scripts/run-full-environment.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+scriptdir=$(dirname $0)
+$(nix-build "$scriptdir"/integration-tests --no-out-link -A run-full-environment)/bin/run-full-environment

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -77,11 +77,13 @@ run (Command.CommandWithTarget (Command.Serve conf serverConf) target _) = do
   -- Allow to set the static and data directories through environment
   -- variable. This is useful to bake the correct values in a Docker image
   -- or a virtual machine image, instead of having the user provide them.
-  mstaticDir <- lookupEnv "CURIOSITY_STATIC_DIR"
-  mdataDir   <- lookupEnv "CURIOSITY_DATA_DIR"
+  mstaticDir   <- lookupEnv "CURIOSITY_STATIC_DIR"
+  mdataDir     <- lookupEnv "CURIOSITY_DATA_DIR"
+  mscenariosDir <- lookupEnv "CURIOSITY_SCENARIOS_DIR"
   let serverConf' =
         maybe identity (\a c -> c { P._serverDataDir = a }) mdataDir
           . maybe identity (\a c -> c { P._serverStaticDir = a }) mstaticDir
+          . maybe identity (\a c -> c { P._serverScenariosDir = a }) mscenariosDir
           $ serverConf
 
   case target of


### PR DESCRIPTION
This is a rebased and slightly modified version of https://github.com/hypered/curiosity/pull/86

This is a first step towards writing an integration test suite.

We set up an environment running the curiosity server behind a Nginx proxy. This environment is mostly provisioned using the various nix build artifacts.

While this setup do not provides an isolation level comparable to a VM-based one, it's much more lightweight.

We had to cut some corners on the Nginx side. We did not find a satisfactory solution to extract the configuration file from a NixOS machine description. We're instead using a template text file.

We expose this script via a new target in the top-level default.nix, via a script file living in `/scripts/integration-tests/` and via a `nix-shell` bash alias.