### PR TITLE
Make profiles more complete

### DIFF
--- a/content/documentation/state-0.md
+++ b/content/documentation/state-0.md
@@ -27,6 +27,7 @@ file](https://github.com/hypered/curiosity/blob/main/scenarios/0.golden).
 ## Legal entities
 
 - [One S.A.](/entity/one)
+- [Two S.A.](/entity/two)
 
 ## Business units
 

--- a/content/documentation/state-0.md
+++ b/content/documentation/state-0.md
@@ -22,12 +22,16 @@ file](https://github.com/hypered/curiosity/blob/main/scenarios/0.golden).
 ## Users
 
 - [Alice](/alice)
+- [Charlie](/charlie)
+- [Chloe](/chloe)
 - [Mila](/mila)
 
 ## Legal entities
 
 - [One S.A.](/entity/one)
 - [Two S.A.](/entity/two)
+- [Three S.R.L.](/entity/three)
+- [Four S.R.L.](/entity/four)
 
 ## Business units
 

--- a/data/alice-with-bio.json
+++ b/data/alice-with-bio.json
@@ -10,6 +10,7 @@
   "_userProfileTosConsent": true,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
+  "_userProfileRegistrationDate": 0,
   "_userProfileRights": ["CanVerifyEmailAddr"],
   "_userProfileAuthorizations": []
 }

--- a/data/alice.json
+++ b/data/alice.json
@@ -8,6 +8,7 @@
   "_userProfileTosConsent": true,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
+  "_userProfileRegistrationDate": 60,
   "_userProfileRights": ["CanCreateContracts", "CanVerifyEmailAddr"],
   "_userProfileAuthorizations": ["AuthorizedAsEmployee"]
 }

--- a/data/bob-0.json
+++ b/data/bob-0.json
@@ -9,6 +9,7 @@
   "_userProfileTosConsent": true,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
+  "_userProfileRegistrationDate": 0,
   "_userProfileRights": [],
   "_userProfileAuthorizations": []
 }

--- a/data/bob-1.json
+++ b/data/bob-1.json
@@ -14,6 +14,7 @@
     "_userProfileAddrAndTelVerified": "2022-08-02"
   },
   "_userProfileCompletion2": {},
+  "_userProfileRegistrationDate": 0,
   "_userProfileRights": [],
   "_userProfileAuthorizations": []
 }

--- a/data/bob-2.json
+++ b/data/bob-2.json
@@ -17,6 +17,7 @@
     "_userProfileEId": "xxxx",
     "_userProfileEIdVerified": "2022-08-02"
   },
+  "_userProfileRegistrationDate": 0,
   "_userProfileRights": [],
   "_userProfileAuthorizations": []
 }

--- a/data/charlie.json
+++ b/data/charlie.json
@@ -9,6 +9,7 @@
   "_userProfileTosConsent": false,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
+  "_userProfileRegistrationDate": 0,
   "_userProfileRights": [],
   "_userProfileAuthorizations": []
 }

--- a/data/mila.json
+++ b/data/mila.json
@@ -8,6 +8,7 @@
   "_userProfileTosConsent": true,
   "_userProfileCompletion1": {},
   "_userProfileCompletion2": {},
+  "_userProfileRegistrationDate": 60,
   "_userProfileRights": [],
   "_userProfileAuthorizations": []
 }

--- a/data/one.json
+++ b/data/one.json
@@ -6,5 +6,6 @@
   "_entityVatNumber": "BE0100200300",
   "_entityUsersAndRoles": [],
   "_entityAuthorizations": [],
-  "_entityIsSupervised": true
+  "_entityIsSupervised": true,
+  "_entityIsHost": true
 }

--- a/data/one.json
+++ b/data/one.json
@@ -5,5 +5,6 @@
   "_entityCbeNumber": "100200300",
   "_entityVatNumber": "BE0100200300",
   "_entityUsersAndRoles": [],
-  "_entityAuthorizations": []
+  "_entityAuthorizations": [],
+  "_entityIsSupervised": true
 }

--- a/scenarios/init-entities.golden
+++ b/scenarios/init-entities.golden
@@ -18,3 +18,15 @@ Legal entity updated: two
 Legal entity updated: two
 11: entity set-host two
 Legal entity updated: two
+13: entity create three Three S.R.L. 100200500 BE0100200500
+Legal entity created: LENT-3
+14: entity update three Three S.R.L. is the first un-supervised legal entity of the prototype.
+Legal entity updated: three
+15: entity link-user three USER-3 --validator
+Legal entity updated: three
+17: entity create four Four S.R.L. 100200600 BE0100200600
+Legal entity created: LENT-4
+18: entity update four Four S.R.L. is the second un-supervised legal entity of the prototype.
+Legal entity updated: four
+19: entity link-user four USER-5 --validator
+Legal entity updated: four

--- a/scenarios/init-entities.golden
+++ b/scenarios/init-entities.golden
@@ -1,6 +1,6 @@
-1: legal create one One S.A. 100200300 BE0100200300
+1: entity create one One S.A. 100200300 BE0100200300
 Legal entity created: LENT-1
-2: legal update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
+2: entity update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
 Legal entity updated: one
-3: legal link-user one USER-1 --validator
+3: entity link-user one USER-1 --validator
 Legal entity updated: one

--- a/scenarios/init-entities.golden
+++ b/scenarios/init-entities.golden
@@ -6,3 +6,5 @@ Legal entity updated: one
 Legal entity updated: one
 4: entity set-supervised one
 Legal entity updated: one
+5: entity set-host one
+Legal entity updated: one

--- a/scenarios/init-entities.golden
+++ b/scenarios/init-entities.golden
@@ -4,3 +4,5 @@ Legal entity created: LENT-1
 Legal entity updated: one
 3: entity link-user one USER-1 --validator
 Legal entity updated: one
+4: entity set-supervised one
+Legal entity updated: one

--- a/scenarios/init-entities.golden
+++ b/scenarios/init-entities.golden
@@ -8,3 +8,13 @@ Legal entity updated: one
 Legal entity updated: one
 5: entity set-host one
 Legal entity updated: one
+7: entity create two Two S.A. 100200400 BE0100200400
+Legal entity created: LENT-2
+8: entity update two Two S.A. is the second legal entity of the prototype.
+Legal entity updated: two
+9: entity link-user two USER-1 --validator
+Legal entity updated: two
+10: entity set-supervised two
+Legal entity updated: two
+11: entity set-host two
+Legal entity updated: two

--- a/scenarios/init-entities.txt
+++ b/scenarios/init-entities.txt
@@ -3,3 +3,9 @@ entity update one "One S.A. is the main legal entity of the prototype. Unless re
 entity link-user one USER-1 --validator
 entity set-supervised one
 entity set-host one
+
+entity create two "Two S.A." 100200400 BE0100200400
+entity update two "Two S.A. is the second legal entity of the prototype."
+entity link-user two USER-1 --validator
+entity set-supervised two
+entity set-host two

--- a/scenarios/init-entities.txt
+++ b/scenarios/init-entities.txt
@@ -1,3 +1,4 @@
 entity create one "One S.A." 100200300 BE0100200300
 entity update one "One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One."
 entity link-user one USER-1 --validator
+entity set-supervised one

--- a/scenarios/init-entities.txt
+++ b/scenarios/init-entities.txt
@@ -1,3 +1,3 @@
-legal create one "One S.A." 100200300 BE0100200300
-legal update one "One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One."
-legal link-user one USER-1 --validator
+entity create one "One S.A." 100200300 BE0100200300
+entity update one "One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One."
+entity link-user one USER-1 --validator

--- a/scenarios/init-entities.txt
+++ b/scenarios/init-entities.txt
@@ -2,3 +2,4 @@ entity create one "One S.A." 100200300 BE0100200300
 entity update one "One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One."
 entity link-user one USER-1 --validator
 entity set-supervised one
+entity set-host one

--- a/scenarios/init-entities.txt
+++ b/scenarios/init-entities.txt
@@ -9,3 +9,11 @@ entity update two "Two S.A. is the second legal entity of the prototype."
 entity link-user two USER-1 --validator
 entity set-supervised two
 entity set-host two
+
+entity create three "Three S.R.L." 100200500 BE0100200500
+entity update three "Three S.R.L. is the first un-supervised legal entity of the prototype."
+entity link-user three USER-3 --validator
+
+entity create four "Four S.R.L." 100200600 BE0100200600
+entity update four "Four S.R.L. is the second un-supervised legal entity of the prototype."
+entity link-user four USER-5 --validator

--- a/scenarios/init-units.golden
+++ b/scenarios/init-units.golden
@@ -1,4 +1,4 @@
-1: business create alpha Alpha
+1: unit create alpha Alpha
 Business entity created: BENT-1
-2: business update alpha The first business unit of the prototype, Alpha is run by @mila.
+2: unit update alpha The first business unit of the prototype, Alpha is run by @mila.
 Business unit updated: alpha

--- a/scenarios/init-units.golden
+++ b/scenarios/init-units.golden
@@ -2,3 +2,5 @@
 Business entity created: BENT-1
 2: unit update alpha The first business unit of the prototype, Alpha is run by @mila.
 Business unit updated: alpha
+3: unit link-user alpha USER-4 --holder
+Business unit updated: alpha

--- a/scenarios/init-units.txt
+++ b/scenarios/init-units.txt
@@ -1,2 +1,3 @@
 unit create alpha Alpha
 unit update alpha "The first business unit of the prototype, Alpha is run by @mila."
+unit link-user alpha USER-4 --holder

--- a/scenarios/init-units.txt
+++ b/scenarios/init-units.txt
@@ -1,2 +1,2 @@
-business create alpha Alpha
-business update alpha "The first business unit of the prototype, Alpha is run by @mila."
+unit create alpha Alpha
+unit update alpha "The first business unit of the prototype, Alpha is run by @mila."

--- a/scenarios/init-users.golden
+++ b/scenarios/init-users.golden
@@ -10,3 +10,5 @@ User created: USER-3
 User created: USER-4
 9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
 User updated: USER-4
+11: user create chloe c chloe@example.com --accept-tos
+User created: USER-5

--- a/scenarios/init-users.txt
+++ b/scenarios/init-users.txt
@@ -7,3 +7,5 @@ user create charlie c charlie@example.com --accept-tos
 
 user create mila m mila@example.com --accept-tos
 user update USER-4 Mila "I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha."
+
+user create chloe c chloe@example.com --accept-tos

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -14,16 +14,16 @@ Resetting to the empty state.
 > 9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
 > User updated: USER-4
 3: run init-entities.txt
-> 1: legal create one One S.A. 100200300 BE0100200300
+> 1: entity create one One S.A. 100200300 BE0100200300
 > Legal entity created: LENT-1
-> 2: legal update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
+> 2: entity update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
 > Legal entity updated: one
-> 3: legal link-user one USER-1 --validator
+> 3: entity link-user one USER-1 --validator
 > Legal entity updated: one
 4: run init-units.txt
-> 1: business create alpha Alpha
+> 1: unit create alpha Alpha
 > Business entity created: BENT-1
-> 2: business update alpha The first business unit of the prototype, Alpha is run by @mila.
+> 2: unit update alpha The first business unit of the prototype, Alpha is run by @mila.
 > Business unit updated: alpha
 5: run init-form-simple-contracts.txt
 > 1: as mila

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -22,6 +22,8 @@ Resetting to the empty state.
 > Legal entity updated: one
 > 4: entity set-supervised one
 > Legal entity updated: one
+> 5: entity set-host one
+> Legal entity updated: one
 4: run init-units.txt
 > 1: unit create alpha Alpha
 > Business entity created: BENT-1

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -24,6 +24,16 @@ Resetting to the empty state.
 > Legal entity updated: one
 > 5: entity set-host one
 > Legal entity updated: one
+> 7: entity create two Two S.A. 100200400 BE0100200400
+> Legal entity created: LENT-2
+> 8: entity update two Two S.A. is the second legal entity of the prototype.
+> Legal entity updated: two
+> 9: entity link-user two USER-1 --validator
+> Legal entity updated: two
+> 10: entity set-supervised two
+> Legal entity updated: two
+> 11: entity set-host two
+> Legal entity updated: two
 4: run init-units.txt
 > 1: unit create alpha Alpha
 > Business entity created: BENT-1

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -20,6 +20,8 @@ Resetting to the empty state.
 > Legal entity updated: one
 > 3: entity link-user one USER-1 --validator
 > Legal entity updated: one
+> 4: entity set-supervised one
+> Legal entity updated: one
 4: run init-units.txt
 > 1: unit create alpha Alpha
 > Business entity created: BENT-1

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -13,6 +13,8 @@ Resetting to the empty state.
 > User created: USER-4
 > 9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
 > User updated: USER-4
+> 11: user create chloe c chloe@example.com --accept-tos
+> User created: USER-5
 3: run init-entities.txt
 > 1: entity create one One S.A. 100200300 BE0100200300
 > Legal entity created: LENT-1
@@ -34,6 +36,18 @@ Resetting to the empty state.
 > Legal entity updated: two
 > 11: entity set-host two
 > Legal entity updated: two
+> 13: entity create three Three S.R.L. 100200500 BE0100200500
+> Legal entity created: LENT-3
+> 14: entity update three Three S.R.L. is the first un-supervised legal entity of the prototype.
+> Legal entity updated: three
+> 15: entity link-user three USER-3 --validator
+> Legal entity updated: three
+> 17: entity create four Four S.R.L. 100200600 BE0100200600
+> Legal entity created: LENT-4
+> 18: entity update four Four S.R.L. is the second un-supervised legal entity of the prototype.
+> Legal entity updated: four
+> 19: entity link-user four USER-5 --validator
+> Legal entity updated: four
 4: run init-units.txt
 > 1: unit create alpha Alpha
 > Business entity created: BENT-1

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -25,6 +25,8 @@ Resetting to the empty state.
 > Business entity created: BENT-1
 > 2: unit update alpha The first business unit of the prototype, Alpha is run by @mila.
 > Business unit updated: alpha
+> 3: unit link-user alpha USER-4 --holder
+> Business unit updated: alpha
 5: run init-form-simple-contracts.txt
 > 1: as mila
 > Modifying default user.

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -64,6 +64,9 @@ data Command =
   | CreateLegalEntity Legal.Create
   | UpdateLegalEntity Legal.Update
   | LinkLegalEntityToUser Text User.UserId Legal.ActingRole
+  | UpdateLegalEntityIsSupervised Text Bool
+    -- ^ Make a legal entity as 'supervised' (True) or 'not supervised'
+    -- (False).
   | CreateUser User.Signup
   | SelectUser Bool User.UserId Bool
     -- ^ Show a given user. If True, use Haskell format instead of JSON. If
@@ -551,6 +554,16 @@ parserLegal =
          ( A.info (parserLegalEntityLinkUser <**> A.helper)
          $ A.progDesc "Link a user to the entity, specifying a role"
          )
+    <> A.command
+         "set-supervised"
+         ( A.info (parserUpdateLegalEntityIsSupervised True <**> A.helper)
+         $ A.progDesc "Mark the entity as 'supervised'"
+         )
+    <> A.command
+         "unset-supervised"
+         ( A.info (parserUpdateLegalEntityIsSupervised False <**> A.helper)
+         $ A.progDesc "Mark the entity as 'not supervised'"
+         )
 
 parserCreateLegalEntity :: A.Parser Command
 parserCreateLegalEntity = do
@@ -583,6 +596,11 @@ parserLegalEntityLinkUser = do
       "TODO Add a description for the validator flag"
     )
   pure $ LinkLegalEntityToUser slug uid role
+
+parserUpdateLegalEntityIsSupervised :: Bool -> A.Parser Command
+parserUpdateLegalEntityIsSupervised b = do
+  slug <- argumentEntitySlug
+  pure $ UpdateLegalEntityIsSupervised slug b
 
 argumentEntityId = Legal.EntityId <$> A.argument A.str metavarEntityId
 

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -15,11 +15,12 @@ module Curiosity.Command
   ) where
 
 import qualified Commence.Runtime.Storage      as S
+import qualified Curiosity.Data                as Data
 import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Email          as Email
 import qualified Curiosity.Data.Employment     as Employment
-import qualified Curiosity.Data.Legal          as Legal
 import qualified Curiosity.Data.Invoice        as Invoice
+import qualified Curiosity.Data.Legal          as Legal
 import qualified Curiosity.Data.Order          as Order
 import qualified Curiosity.Data.Quotation      as Quotation
 import qualified Curiosity.Data.SimpleContract as SimpleContract
@@ -35,9 +36,9 @@ import qualified Options.Applicative           as A
 data Command =
     Layout
     -- ^ Display the routing layout of the web server.
-  | Init
+  | Init Data.SteppingMode
     -- ^ Initialise a new, empty state file.
-  | Reset P.Conf
+  | Reset
     -- ^ Set the state file to the empty state.
   | Repl P.Conf
     -- ^ Run a REPL.
@@ -378,10 +379,22 @@ parserLayout :: A.Parser Command
 parserLayout = pure Layout
 
 parserInit :: A.Parser Command
-parserInit = pure Init
+parserInit =
+  Init
+    <$> (   (A.flag' Data.Normal $ A.long "normal" <> A.help
+              "Select normal stepping mode (default)."
+            )
+        <|> (A.flag' Data.Stepped $ A.long "stepped" <> A.help
+              "Select stepped stepping mode."
+            )
+        <|> (A.flag' Data.Mixed $ A.long "mixed" <> A.help
+              "Select mixed stepping mode."
+            )
+        <|> (pure Data.Normal)
+        )
 
 parserReset :: A.Parser Command
-parserReset = Reset <$> P.confParser
+parserReset = pure Reset
 
 parserRepl :: A.Parser Command
 parserRepl = Repl <$> P.confParser
@@ -390,26 +403,29 @@ parserServe :: A.Parser Command
 parserServe = Serve <$> P.confParser <*> P.serverParser
 
 parserRun :: A.Parser Command
-parserRun = Run <$> P.confParser <*> A.argument
-  A.str
-  (A.metavar "FILE" <> A.action "file" <> A.help "Script to run.")
-  <*>
-      (   (A.flag' (RunOutput False False) $ A.long "silent" <> A.help
-           "Don't display traces, nor the final state."
-          )
-      <|> (A.flag' (RunOutput False True) $ A.long "final-only" <> A.help
-           "Don't display traces, but display the final state."
+parserRun =
+  Run
+    <$> P.confParser
+    <*> A.argument
+          A.str
+          (A.metavar "FILE" <> A.action "file" <> A.help "Script to run.")
+    <*> (   (A.flag' (RunOutput False False) $ A.long "silent" <> A.help
+              "Don't display traces, nor the final state."
+            )
+        <|> (A.flag' (RunOutput False True) $ A.long "final-only" <> A.help
+              "Don't display traces, but display the final state."
            -- Showing the final state ensures that the effect of the commands
            -- are applied.
-          )
-      <|> (A.flag' (RunOutput True True) $ A.long "final" <> A.help
-           "Display both traces and the final state."
-          )
-      <|> (A.flag (RunOutput True False) (RunOutput True False) $ A.long "traces-only"
-           <> A.help
-           "Display traces but not the final state. This is the default."
-          )
-      )
+            )
+        <|> (A.flag' (RunOutput True True) $ A.long "final" <> A.help
+              "Display both traces and the final state."
+            )
+        <|> (  A.flag (RunOutput True False) (RunOutput True False)
+            $  A.long "traces-only"
+            <> A.help
+                 "Display traces but not the final state. This is the default."
+            )
+        )
 
 parserParse :: A.Parser Command
 parserParse = Parse <$> (parserCommand <|> parserFileName <|> parserObject)
@@ -544,7 +560,7 @@ parserUpdateLegalEntity = do
 
 parserLegalLinkUser :: A.Parser Command
 parserLegalLinkUser = do
-  slug  <- argumentEntitySlug
+  slug <- argumentEntitySlug
   uid  <- argumentUserId
   role <-
     (A.flag' Legal.Validator $ A.long "validator" <> A.help
@@ -622,10 +638,19 @@ parserDeleteUser = UpdateUser . User.UserDelete <$> argumentUserId
 
 parserUpdateUser :: A.Parser Command
 parserUpdateUser = do
-  uid  <- argumentUserId
-  name <- A.argument A.str (A.metavar "NAME" <> A.help "A display name")
-  bio  <- A.argument A.str (A.metavar "TEXT" <> A.help "A bio")
-  pure $ UpdateUser . User.UserUpdate uid $ User.Update (Just name) (Just bio)
+  uid      <- argumentUserId
+  name     <- A.argument A.str (A.metavar "NAME" <> A.help "A display name")
+  bio      <- A.argument A.str (A.metavar "TEXT" <> A.help "A bio")
+  mtwitter <- A.option
+    A.auto
+    (  A.long "twitter"
+    <> A.value Nothing
+    <> A.help "Twitter username."
+    <> A.metavar "USERNAME"
+    )
+  pure $ UpdateUser . User.UserUpdate uid $ User.Update (Just name)
+                                                        (Just bio)
+                                                        mtwitter
 
 parserGetUser :: A.Parser Command
 parserGetUser =
@@ -671,18 +696,17 @@ parserCreateEmployment =
   pure $ CreateEmployment Employment.emptyCreateContractAll
 
 parserQuotation :: A.Parser Command
-parserQuotation =
-  A.subparser
-    $  A.command
-         "sign"
-         ( A.info (parserSignQuotation <**> A.helper)
-         $ A.progDesc "Accept (sign) a quotation"
-         )
+parserQuotation = A.subparser $ A.command
+  "sign"
+  ( A.info (parserSignQuotation <**> A.helper)
+  $ A.progDesc "Accept (sign) a quotation"
+  )
 
 parserSignQuotation :: A.Parser Command
 parserSignQuotation = do
-  id <- A.argument A.str
-                   (A.metavar "QUOTATION-ID" <> A.help "A quotation identifier.")
+  id <- A.argument
+    A.str
+    (A.metavar "QUOTATION-ID" <> A.help "A quotation identifier.")
   pure $ SignQuotation id
 
 parserInvoice :: A.Parser Command
@@ -747,8 +771,8 @@ parserFormQuotation =
 
 parserFormNewQuotation :: A.Parser Command
 parserFormNewQuotation = do
-  client <-
-    A.option (A.eitherReader (Right . User.UserName . T.pack))
+  client <- A.option
+    (A.eitherReader (Right . User.UserName . T.pack))
     (A.long "client" <> A.help "Client username." <> A.metavar "USERNAME")
   pure $ FormNewQuotation $ Quotation.CreateQuotationAll (Just client)
 
@@ -845,24 +869,23 @@ parserFormValidateSimpleContract = do
 -- The advantage compared to a metavar and a completer is that there is a help
 -- text.
 parserQueue :: A.Parser Command
-parserQueue = ViewQueue <$> A.subparser (
-  A.command
-  "user-email-addr-to-verify"
-  ( A.info (pure EmailAddrToVerify <**> A.helper)
-  $ A.progDesc
-      "Show users with an email address that need verification. \
+parserQueue = ViewQueue <$> A.subparser
+  (  A.command
+      "user-email-addr-to-verify"
+      ( A.info (pure EmailAddrToVerify <**> A.helper)
+      $ A.progDesc
+          "Show users with an email address that need verification. \
       \Use `cty user do set-email-addr-as-verified` to mark an email address \
       \as verified."
-  )
-  <>
-  A.command
-  "emails-to-send"
-  ( A.info (pure EmailsToSend <**> A.helper)
-  $ A.progDesc
-      "Show users with an email address that need verification. \
+      )
+  <> A.command
+       "emails-to-send"
+       ( A.info (pure EmailsToSend <**> A.helper)
+       $ A.progDesc
+           "Show users with an email address that need verification. \
       \Use `cty user do set-email-addr-as-verified` to mark an email address \
       \as verified."
-  )
+       )
   )
 
 parserQueues :: A.Parser Command
@@ -892,14 +915,23 @@ parserQueues =
         )
 
 parserStep :: A.Parser Command
-parserStep = Step <$> A.switch
-  (A.long "all" <> A.help "Execute all possible actions (default is one action).")
-  <*> A.switch (A.long "dry" <> A.help "Don't actually execute actions, but report what would be done.")
+parserStep =
+  Step
+    <$> A.switch
+          (  A.long "all"
+          <> A.help "Execute all possible actions (default is one action)."
+          )
+    <*> A.switch
+          (A.long "dry" <> A.help
+            "Don't actually execute actions, but report what would be done."
+          )
 
 parserTime :: A.Parser Command
-parserTime = Time
-  <$> A.switch (A.long "step" <> A.help "Advance the time of 1 second.")
-  <*> A.switch (A.long "minute" <> A.help "Advance the time to the next minute.")
+parserTime =
+  Time
+    <$> A.switch (A.long "step" <> A.help "Advance the time of 1 second.")
+    <*> A.switch
+          (A.long "minute" <> A.help "Advance the time to the next minute.")
 
 parserLog :: A.Parser Command
 parserLog =

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -58,8 +58,8 @@ data Command =
     -- ^ Kill the thread processing enqueued emails.
   | StepEmail
     -- ^ Run one iteration of the email processing loop.
-  | CreateBusinessEntity Business.Create
-  | UpdateBusinessEntity Business.Update
+  | CreateBusinessUnit Business.Create
+  | UpdateBusinessUnit Business.Update
   | CreateLegalEntity Legal.Create
   | UpdateLegalEntity Legal.Update
   | LinkLegalEntityToUser Text User.UserId Legal.ActingRole
@@ -284,13 +284,13 @@ parser =
            )
 
       <> A.command
-           "business"
-           ( A.info (parserBusiness <**> A.helper)
-           $ A.progDesc "Commands related to business entities"
+           "unit"
+           ( A.info (parserUnit <**> A.helper)
+           $ A.progDesc "Commands related to business units"
            )
 
       <> A.command
-           "legal"
+           "entity"
            ( A.info (parserLegal <**> A.helper)
            $ A.progDesc "Commands related to legal entities"
            )
@@ -473,33 +473,33 @@ parserStopEmail = pure StopEmail
 parserStepEmail :: A.Parser Command
 parserStepEmail = pure StepEmail
 
-parserBusiness :: A.Parser Command
-parserBusiness =
+parserUnit :: A.Parser Command
+parserUnit =
   A.subparser
     $  A.command
          "create"
-         ( A.info (parserCreateBusinessEntity <**> A.helper)
-         $ A.progDesc "Create a new business entity"
+         ( A.info (parserCreateBusinessUnit <**> A.helper)
+         $ A.progDesc "Create a new business unit"
          )
     <> A.command
          "update"
-         ( A.info (parserUpdateBusinessEntity <**> A.helper)
+         ( A.info (parserUpdateBusinessUnit <**> A.helper)
          $ A.progDesc "Update a business unit"
          )
 
-parserCreateBusinessEntity :: A.Parser Command
-parserCreateBusinessEntity = do
+parserCreateBusinessUnit :: A.Parser Command
+parserCreateBusinessUnit = do
   slug <- A.argument
     A.str
     (A.metavar "SLUG" <> A.help "An identifier suitable for URLs")
   name <- A.argument A.str (A.metavar "NAME" <> A.help "A name")
-  pure $ CreateBusinessEntity $ Business.Create slug name
+  pure $ CreateBusinessUnit $ Business.Create slug name
 
-parserUpdateBusinessEntity :: A.Parser Command
-parserUpdateBusinessEntity = do
+parserUpdateBusinessUnit :: A.Parser Command
+parserUpdateBusinessUnit = do
   slug        <- argumentUnitSlug
   description <- A.argument A.str (A.metavar "TEXT" <> A.help "A description")
-  pure $ UpdateBusinessEntity $ Business.Update slug (Just description)
+  pure $ UpdateBusinessUnit $ Business.Update slug (Just description)
 
 argumentUnitId = Legal.EntityId <$> A.argument A.str metavarUnitId
 

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -67,6 +67,8 @@ data Command =
   | UpdateLegalEntityIsSupervised Text Bool
     -- ^ Make a legal entity as 'supervised' (True) or 'not supervised'
     -- (False).
+  | UpdateLegalEntityIsHost Text Bool
+    -- ^ Make a legal entity as 'host' (True) or 'not host' (False).
   | CreateUser User.Signup
   | SelectUser Bool User.UserId Bool
     -- ^ Show a given user. If True, use Haskell format instead of JSON. If
@@ -564,6 +566,16 @@ parserLegal =
          ( A.info (parserUpdateLegalEntityIsSupervised False <**> A.helper)
          $ A.progDesc "Mark the entity as 'not supervised'"
          )
+    <> A.command
+         "set-host"
+         ( A.info (parserUpdateLegalEntityIsHost True <**> A.helper)
+         $ A.progDesc "Mark the entity as 'host'"
+         )
+    <> A.command
+         "unset-host"
+         ( A.info (parserUpdateLegalEntityIsHost False <**> A.helper)
+         $ A.progDesc "Mark the entity as 'not host'"
+         )
 
 parserCreateLegalEntity :: A.Parser Command
 parserCreateLegalEntity = do
@@ -601,6 +613,11 @@ parserUpdateLegalEntityIsSupervised :: Bool -> A.Parser Command
 parserUpdateLegalEntityIsSupervised b = do
   slug <- argumentEntitySlug
   pure $ UpdateLegalEntityIsSupervised slug b
+
+parserUpdateLegalEntityIsHost :: Bool -> A.Parser Command
+parserUpdateLegalEntityIsHost b = do
+  slug <- argumentEntitySlug
+  pure $ UpdateLegalEntityIsHost slug b
 
 argumentEntityId = Legal.EntityId <$> A.argument A.str metavarEntityId
 

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -317,6 +317,7 @@ createUser db User.Signup {..} = do
           (if newId == firstUserId then firstUserRights else [])
           -- TODO Define some mechanism to get the initial authorizations
           [User.AuthorizedAsEmployee]
+          Nothing
     emailId <- createEmail db Email.SignupConfirmationEmail
                  Email.systemEmailAddr
                  email

--- a/src/Curiosity/Data/Business.hs
+++ b/src/Curiosity/Data/Business.hs
@@ -10,6 +10,7 @@ module Curiosity.Data.Business
   , Update(..)
   , UnitId(..)
   , unitIdPrefix
+  , ActingRole(..)
   , Authorization(..)
   , Scope(..)
   , Err(..)
@@ -74,6 +75,10 @@ newtype UnitId = UnitId { unUnitId :: Text }
 
 unitIdPrefix :: Text
 unitIdPrefix = "BENT-"
+
+data ActingRole = Dummy | Holder
+  deriving (Eq, Generic, Show)
+  deriving (FromJSON, ToJSON)
 
 -- TODO Ask Roger the meaning of these.
 data Authorization = Bundle0 | Bundle1

--- a/src/Curiosity/Data/Legal.hs
+++ b/src/Curiosity/Data/Legal.hs
@@ -74,6 +74,10 @@ data Entity = Entity
   , _entityUsersAndRoles :: [ActingUserId]
     -- ^ Users that can "act" within the entity, with some kind of associated rights.
   , _entityAuthorizations :: [Authorization]
+  , _entityIsSupervised   :: Bool
+    -- ^ Whether the entity has its accounting done by the group operating
+    -- Curiosity. Maybe this should be something like
+    -- IsSupervisedBy :: Maybe GroupId.
   }
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)

--- a/src/Curiosity/Data/Legal.hs
+++ b/src/Curiosity/Data/Legal.hs
@@ -78,6 +78,8 @@ data Entity = Entity
     -- ^ Whether the entity has its accounting done by the group operating
     -- Curiosity. Maybe this should be something like
     -- IsSupervisedBy :: Maybe GroupId.
+  , _entityIsHost         :: Bool
+    -- ^ Whether the entity can hosts contracts from business units.
   }
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -34,6 +34,8 @@ module Curiosity.Data.User
   , userProfileTelephoneNbr
   , userProfileCompletion1
   , userProfileCompletion2
+  , userProfileRegistrationDate
+  , userProfileTwitterUsername
   , userProfileRights
   , userProfileAuthorizations
   , userProfileAdvisors
@@ -115,13 +117,18 @@ instance FromForm Login where
 
 -- | Represents the input data to update a user profile.
 data Update = Update
-  { _updateDisplayName :: Maybe UserDisplayName
-  , _updateBio         :: Maybe Text
+  { _updateDisplayName     :: Maybe UserDisplayName
+  , _updateBio             :: Maybe Text
+  , _updateTwitterUsername :: Maybe Text
   }
   deriving (Eq, Show, Generic)
 
 instance FromForm Update where
-  fromForm f = Update <$> parseMaybe "display-name" f <*> parseMaybe "bio" f
+  fromForm f =
+    Update
+      <$> parseMaybe "display-name"     f
+      <*> parseMaybe "bio"              f
+      <*> parseMaybe "twitter-username" f
 
 
 --------------------------------------------------------------------------------
@@ -142,6 +149,8 @@ data UserProfile' creds userDisplayName userEmailAddr tosConsent = UserProfile
   , _userProfileTosConsent        :: tosConsent
   , _userProfileCompletion1       :: UserCompletion1
   , _userProfileCompletion2       :: UserCompletion2
+  , _userProfileRegistrationDate  :: EpochTime
+  , _userProfileTwitterUsername   :: Maybe Text
   , _userProfileRights            :: [AccessRight]
   , _userProfileAuthorizations    :: [Authorization]
   , _userProfileAdvisors          :: Maybe Advisors

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -35,6 +35,7 @@ module Curiosity.Data.User
   , userProfileCompletion1
   , userProfileCompletion2
   , userProfileRights
+  , userProfileAuthorizations
   , UserId(..)
   , UserName(..)
   , UserDisplayName(..)

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -36,11 +36,13 @@ module Curiosity.Data.User
   , userProfileCompletion2
   , userProfileRights
   , userProfileAuthorizations
+  , userProfileAdvisors
   , UserId(..)
   , UserName(..)
   , UserDisplayName(..)
   , UserEmailAddr(..)
   , Password(..)
+  , Advisors(..)
   , Predicate(..)
   , applyPredicate
   , SetUserEmailAddrAsVerified(..)
@@ -66,6 +68,7 @@ import qualified Data.Text.Lazy                as LT
 import qualified Network.HTTP.Types            as HTTP
 import qualified Servant.Auth.Server           as SAuth
 import qualified Smart.Server.Page.Navbar      as Nav
+import           System.PosixCompat.Types       ( EpochTime )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
@@ -141,6 +144,7 @@ data UserProfile' creds userDisplayName userEmailAddr tosConsent = UserProfile
   , _userProfileCompletion2       :: UserCompletion2
   , _userProfileRights            :: [AccessRight]
   , _userProfileAuthorizations    :: [Authorization]
+  , _userProfileAdvisors          :: Maybe Advisors
   }
   deriving (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
@@ -242,6 +246,14 @@ userIdPrefix = "USER-"
 data Authorization = AuthorizedAsEmployee | AuthorizedAsHolder | AuthorizedAsAdvisor | AuthorizedAsSuperAdvisor | AccountingAuthorized | OnlineAccountAuthorized
   deriving (Eq, Generic, Show)
   deriving (FromJSON, ToJSON)
+
+-- | Represents the user current advisor and past advisors.
+data Advisors = Advisors
+  { _userAdvisorsCurrent :: UserId
+  , _userAdvisorsPast    :: [(EpochTime, EpochTime, UserId)] -- From, to, user ID
+  }
+  deriving (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -53,7 +53,7 @@ state :: Run HaskDb
 state = ask >>= (Run . lift . Core.readFullStmDbInHask')
 
 reset :: Run ()
-reset = ask >>= (Run . lift . Core.reset)
+reset = ask >>= (Run . lift . flip Core.reset 0)
 
 user :: User.UserName -> Run (Maybe User.UserProfile)
 user username = ask >>= (Run . lift . flip Core.selectUserByUsername username)

--- a/src/Curiosity/Form/Signup.hs
+++ b/src/Curiosity/Form/Signup.hs
@@ -11,7 +11,7 @@ import           Smart.Html.Shared.Html.Icons
 import qualified Smart.Html.Shared.Types       as HTypes
 import           Text.Blaze                     ( customAttribute )
 import qualified Text.Blaze.Html5              as H
-import           Text.Blaze.Html5               ( (!) )
+import           Text.Blaze.Html5               ( (!), Html )
 import qualified Text.Blaze.Html5.Attributes   as A
 
 
@@ -147,7 +147,7 @@ instance H.ToMarkup SignupResultPage where
     withText msg =
       H.toMarkup @Dsl.HtmlCanvas $ Dsl.SingletonCanvas (HTypes.Title $ msg)
 
-withMessage :: Text -> H.Html -> H.Html
+withMessage :: Text -> Html -> Html
 withMessage title msg = do
   H.header
     $

--- a/src/Curiosity/Html/Business.hs
+++ b/src/Curiosity/Html/Business.hs
@@ -32,7 +32,9 @@ unitView unit hasEditButton = containerMedium $ do
   H.dl ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short" $ do
     keyValuePair "ID"   (Business._entityId unit)
     keyValuePair "Name" (Business._entityName unit)
-    maybe mempty (keyValuePair "Description") (Business._entityDescription unit)
+    maybe mempty
+          (keyValuePair "Description" . linkifyAts)
+          (Business._entityDescription unit)
     keyValuePair "Type (industry class)" (Business._entityType unit)
 
     title' "Holders" Nothing
@@ -44,17 +46,14 @@ unitView unit hasEditButton = containerMedium $ do
     title' "Scopes" Nothing
     H.ul $ mapM_ displayScope $ Business._entityScopes unit
 
-displayHolder holder =
-  H.li $ do
-    H.code . H.text $ User.unUserId holder
+displayHolder holder = H.li $ do
+  H.code . H.text $ User.unUserId holder
 
-displayAuthorization auth =
-  H.li $ do
-    H.code . H.text $ show auth
+displayAuthorization auth = H.li $ do
+  H.code . H.text $ show auth
 
-displayScope scope =
-  H.li $ do
-    H.code . H.text $ show scope
+displayScope scope = H.li $ do
+  H.code . H.text $ show scope
 
 --------------------------------------------------------------------------------
 data CreateUnitPage = CreateUnitPage

--- a/src/Curiosity/Html/Email.hs
+++ b/src/Curiosity/Html/Email.hs
@@ -11,6 +11,7 @@ import qualified Curiosity.Data.Email          as Email
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
 import qualified Smart.Html.Misc               as Misc
+import           Text.Blaze.Html5               ( Html )
 import qualified Text.Blaze.Html5              as H
 
 
@@ -30,7 +31,7 @@ instance H.ToMarkup EmailPage where
 
 --------------------------------------------------------------------------------
 -- | Display emails.
-panelSentEmails :: [Email.Email] -> H.Html
+panelSentEmails :: [Email.Email] -> Html
 panelSentEmails emails =
   panel' "Emails" $ Misc.table "emails" titles display emails
  where

--- a/src/Curiosity/Html/Employment.hs
+++ b/src/Curiosity/Html/Employment.hs
@@ -16,7 +16,7 @@ import           Curiosity.Html.Misc
 import qualified Smart.Html.Misc               as Misc
 import           Smart.Html.Panel               ( Panel(..) )
 import qualified Text.Blaze.Html5              as H
-import           Text.Blaze.Html5               ( (!) )
+import           Text.Blaze.Html5               ( (!), Html )
 import qualified Text.Blaze.Html5.Attributes   as A
 
 
@@ -160,7 +160,7 @@ groupExpenses mkey expenses submitUrl = do
     :: Text
     -> Int
     -> Employment.AddExpense
-    -> ([Text], [(H.Html, Text, Text)], Maybe Text)
+    -> ([Text], [(Html, Text, Text)], Maybe Text)
   display key i Employment.AddExpense {..} =
     ( [show _addExpenseAmount]
     , [ ( Misc.divIconDelete
@@ -176,7 +176,7 @@ groupEmployment = do
   inputText "Student / au cachet" "TODO"            Nothing Nothing
   inputText "Interim"             "interim"         Nothing Nothing
 
-formKeyValue :: Text -> Text -> H.Html
+formKeyValue :: Text -> Text -> Html
 formKeyValue label value = H.div ! A.class_ "o-form-group" $ do
   H.label ! A.class_ "o-form-group__label" $ H.text label
   H.div
@@ -304,6 +304,6 @@ instance H.ToMarkup ConfirmContractPage where
     titles = ["Amount"]
     display
       :: Employment.AddExpense
-      -> ([Text], [(H.Html, Text, Text)], Maybe Text)
+      -> ([Text], [(Html, Text, Text)], Maybe Text)
     display Employment.AddExpense {..} =
       ([show _addExpenseAmount], [], Nothing)

--- a/src/Curiosity/Html/Homepage.hs
+++ b/src/Curiosity/Html/Homepage.hs
@@ -19,7 +19,7 @@ import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Misc               as Misc
 import qualified Smart.Html.Render             as Render
 import qualified Text.Blaze.Html5              as H
-import           Text.Blaze.Html5               ( (!) )
+import           Text.Blaze.Html5               ( (!), Html )
 import qualified Text.Blaze.Html5.Attributes   as A
 
 
@@ -62,7 +62,7 @@ instance H.ToMarkup WelcomePage where
 
             panelSentEmails welcomePageEmails
 
-panelEmailAddrToVerify :: [User.UserProfile] -> H.Html
+panelEmailAddrToVerify :: [User.UserProfile] -> Html
 panelEmailAddrToVerify profiles =
   panel' "Email addresses to verify" $ Misc.table "addr" titles display profiles
  where
@@ -80,7 +80,7 @@ panelEmailAddrToVerify profiles =
         , (Just $ "/" <> n)
         )
 
-panelQuotationForms :: [(Text, Quotation.CreateQuotationAll)] -> H.Html
+panelQuotationForms :: [(Text, Quotation.CreateQuotationAll)] -> Html
 panelQuotationForms forms =
   panel' "Quotation forms" $ Misc.table "quotation-forms" titles display forms
  where

--- a/src/Curiosity/Html/Legal.hs
+++ b/src/Curiosity/Html/Legal.hs
@@ -38,6 +38,7 @@ entityView entity users hasEditButton = containerMedium $ do
     keyValuePair "CBE number"        (Legal._entityCbeNumber entity)
     keyValuePair "VAT number"        (Legal._entityVatNumber entity)
     maybe mempty (keyValuePair "Description") (Legal._entityDescription entity)
+    keyValuePair "Supervised" (Legal._entityIsSupervised entity)
 
   title' "Authorizations" Nothing
   H.ul $ mapM_ displayAuthorization $ Legal._entityAuthorizations entity

--- a/src/Curiosity/Html/Legal.hs
+++ b/src/Curiosity/Html/Legal.hs
@@ -39,6 +39,7 @@ entityView entity users hasEditButton = containerMedium $ do
     keyValuePair "VAT number"        (Legal._entityVatNumber entity)
     maybe mempty (keyValuePair "Description") (Legal._entityDescription entity)
     keyValuePair "Supervised" (Legal._entityIsSupervised entity)
+    keyValuePair "Host" (Legal._entityIsHost entity)
 
   title' "Authorizations" Nothing
   H.ul $ mapM_ displayAuthorization $ Legal._entityAuthorizations entity

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -98,7 +98,7 @@ containerLarge content =
     ! A.class_ "u-spacer-bottom-xl"
     $ content
 
-keyValuePair :: H.ToMarkup a => Text -> a -> H.Html
+keyValuePair :: H.ToMarkup a => Text -> a -> Html
 keyValuePair key value = H.div ! A.class_ "c-key-value-item" $ do
   H.dt ! A.class_ "c-key-value-item__key" $ H.toHtml key
   H.dd ! A.class_ "c-key-value-item__value" $ H.toHtml value
@@ -393,7 +393,7 @@ editButton lnk =
 --------------------------------------------------------------------------------
 -- | Turn \@mentions into links. This is used for texts appearing in Bios and
 -- Descriptions of user and business unit profiles.
-linkifyAts :: Text -> H.Html
+linkifyAts :: Text -> Html
 linkifyAts = mapM_ f . T.words
  where
   f word | "@" `T.isPrefixOf` word = do
@@ -403,7 +403,7 @@ linkifyAts = mapM_ f . T.words
     " "
   f word = H.text word >> " "
 
-linkEmail :: Text -> H.Html
+linkEmail :: Text -> Html
 linkEmail s = H.a ! A.href (H.toValue $ "mailto:" <> s) $ H.text s
 
 

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -39,6 +39,7 @@ module Curiosity.Html.Misc
 
   -- Links
   , linkifyAts
+  , linkEmail
 
   -- Keep here:
   , renderView
@@ -401,6 +402,9 @@ linkifyAts = mapM_ f . T.words
     H.text rest
     " "
   f word = H.text word >> " "
+
+linkEmail :: Text -> H.Html
+linkEmail s = H.a ! A.href (H.toValue $ "mailto:" <> s) $ H.text s
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -35,8 +35,10 @@ module Curiosity.Html.Misc
 
   -- View
   , editButton
-
   , iconError
+
+  -- Links
+  , linkifyAts
 
   -- Keep here:
   , renderView
@@ -51,13 +53,14 @@ import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Navbar          ( navbar
                                                 , navbarWebsite
                                                 )
+import qualified Data.Text                     as T
 import qualified Smart.Html.Dsl                as Dsl
 import qualified Smart.Html.Render             as Render
-import           Smart.Html.Shared.Html.Icons   ( divIconAdd
+import           Smart.Html.Shared.Html.Icons   ( OSvgIconDiv(..)
+                                                , divIconAdd
                                                 , divIconCheck
                                                 , svgIconCircleError
                                                 , svgIconEdit
-                                                , OSvgIconDiv(..)
                                                 )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!)
@@ -346,7 +349,9 @@ buttonSecondary submitUrl label =
     ! A.formmethod "POST"
     $ H.span
     ! A.class_ "c-button__content"
-    $ H.span ! A.class_ "c-button__label" $ H.text label
+    $ H.span
+    ! A.class_ "c-button__label"
+    $ H.text label
 
 buttonSecondaryDisabled label =
   H.button
@@ -354,7 +359,9 @@ buttonSecondaryDisabled label =
     ! A.disabled "disabled"
     $ H.span
     ! A.class_ "c-button__content"
-    $ H.span ! A.class_ "c-button__label" $ H.text label
+    $ H.span
+    ! A.class_ "c-button__label"
+    $ H.text label
 
 buttonAdd submitUrl label =
   H.button
@@ -383,8 +390,21 @@ editButton lnk =
 
 
 --------------------------------------------------------------------------------
-iconError =
-  Just $ OSvgIconDiv @"circle-error" svgIconCircleError
+-- | Turn \@mentions into links. This is used for texts appearing in Bios and
+-- Descriptions of user and business unit profiles.
+linkifyAts :: Text -> H.Html
+linkifyAts = mapM_ f . T.words
+ where
+  f word | "@" `T.isPrefixOf` word = do
+    let (word', rest) = T.breakOn "." word
+    H.a ! A.href (H.toValue $ "/" <> T.tail word') $ H.text word'
+    H.text rest
+    " "
+  f word = H.text word >> " "
+
+
+--------------------------------------------------------------------------------
+iconError = Just $ OSvgIconDiv @"circle-error" svgIconCircleError
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -40,6 +40,7 @@ module Curiosity.Html.Misc
   -- Links
   , linkifyAts
   , linkEmail
+  , linkTwitter
 
   -- Keep here:
   , renderView
@@ -405,6 +406,10 @@ linkifyAts = mapM_ f . T.words
 
 linkEmail :: Text -> Html
 linkEmail s = H.a ! A.href (H.toValue $ "mailto:" <> s) $ H.text s
+
+linkTwitter :: Text -> Html
+linkTwitter s =
+  H.a ! A.href (H.toValue $ "https://twitter.com/" <> s) $ H.text ("@" <> s)
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Order.hs
+++ b/src/Curiosity/Html/Order.hs
@@ -11,6 +11,7 @@ import qualified Curiosity.Data.Order          as Order
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
 import qualified Smart.Html.Misc               as Misc
+import           Text.Blaze.Html5               ( Html )
 import qualified Text.Blaze.Html5              as H
 
 
@@ -30,7 +31,7 @@ instance H.ToMarkup OrderPage where
 
 --------------------------------------------------------------------------------
 -- | Display orders.
-panelOrders :: [Order.Order] -> H.Html
+panelOrders :: [Order.Order] -> Html
 panelOrders orders =
   panel' "Orders" $ Misc.table "orders" titles display orders
  where

--- a/src/Curiosity/Html/Quotation.hs
+++ b/src/Curiosity/Html/Quotation.hs
@@ -19,7 +19,7 @@ import qualified Smart.Html.Misc               as Misc
 import           Smart.Html.Panel               ( Panel(..) )
 import           Smart.Html.Shared.Types        ( Body(..) )
 import qualified Text.Blaze.Html5              as H
-import           Text.Blaze.Html5               ( (!) )
+import           Text.Blaze.Html5               ( (!), Html )
 import qualified Text.Blaze.Html5.Attributes   as A
 
 
@@ -39,7 +39,7 @@ instance H.ToMarkup QuotationPage where
 
 --------------------------------------------------------------------------------
 -- | Display quotations.
-panelQuotations :: [Quotation.Quotation] -> H.Html
+panelQuotations :: [Quotation.Quotation] -> Html
 panelQuotations quotations =
   panel' "Quotations" $ Misc.table "quotations" titles display quotations
  where

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -30,7 +30,7 @@ import           Smart.Html.Panel               ( Panel(..) )
 import           Smart.Html.Shared.Html.Icons
 import           Smart.Html.Shared.Types        ( Body(..) )
 import qualified Text.Blaze.Html5              as H
-import           Text.Blaze.Html5               ( (!) )
+import           Text.Blaze.Html5               ( (!), Html )
 import qualified Text.Blaze.Html5.Attributes   as A
 
 
@@ -208,7 +208,7 @@ groupDates editDateBaseUrl removeDateBaseUrl mkey dates submitUrl = do
     :: Text
     -> Int
     -> SimpleContract.AddDate
-    -> ([Text], [(H.Html, Text, Text)], Maybe Text)
+    -> ([Text], [(Html, Text, Text)], Maybe Text)
   display key i SimpleContract.AddDate {..} =
     ( [_addDateDate]
     , [ ( Misc.divIconDelete
@@ -310,7 +310,7 @@ groupExpenses editExpenseBaseUrl removeExpenseBaseUrl mkey expenses submitUrl = 
     :: Text
     -> Int
     -> SimpleContract.AddExpense
-    -> ([Text], [(H.Html, Text, Text)], Maybe Text)
+    -> ([Text], [(Html, Text, Text)], Maybe Text)
   display key i SimpleContract.AddExpense {..} =
     ( [show _addExpenseAmount]
     , [ ( Misc.divIconDelete
@@ -675,7 +675,7 @@ instance H.ToMarkup ConfirmSimpleContractPage where
     titles = ["Amount"]
     display
       :: SimpleContract.AddExpense
-      -> ([Text], [(H.Html, Text, Text)], Maybe Text)
+      -> ([Text], [(Html, Text, Text)], Maybe Text)
     display SimpleContract.AddExpense {..} =
       ([show _addExpenseAmount], [], Nothing)
 

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -163,11 +163,28 @@ profileView profile entities hasEditButton =
     title' "Authorizations" Nothing
     H.ul $ mapM_ displayAuthorization $ User._userProfileAuthorizations profile
 
+    title' "Advisors" Nothing
+    displayAdvisors $ User._userProfileAdvisors profile
+
     title' "Related entities" Nothing
     H.ul $ mapM_ displayEntitie entities
 
 displayAuthorization auth = H.li $ do
   H.code . H.text $ show auth
+
+displayAdvisors Nothing                     = "No current or past advisors."
+
+displayAdvisors (Just (User.Advisors {..})) = do
+  "Current advisor: "
+  H.text . User.unUserId $ _userAdvisorsCurrent
+  "Past advisors:"
+  H.ul $ mapM_
+    (\(from, to, id) -> H.li
+      (  H.text (User.unUserId id)
+      >> H.text (" (From " <> show from <> ", to " <> show to <> ")")
+      )
+    )
+    _userAdvisorsPast
 
 displayEntitie (Legal.EntityAndRole entity role) = H.li $ do
   H.a
@@ -222,3 +239,6 @@ publicProfileView profile =
           maybe mempty
                 (keyValuePair "Bio" . linkifyAts)
                 (User._userProfileBio profile)
+
+    title' "Advisors" Nothing
+    displayAdvisors $ User._userProfileAdvisors profile

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -3,7 +3,7 @@ Module: Curiosity.Html.User
 Description: Profile pages (view and edit).
 -}
 module Curiosity.Html.User
-  ( ProfilePage(..)
+  ( EditProfilePage(..)
   , ProfileView(..)
   , PublicProfileView(..)
   ) where
@@ -29,13 +29,13 @@ import qualified Text.Blaze.Html5.Attributes   as A
 
 
 --------------------------------------------------------------------------------
-data ProfilePage = ProfilePage
+data EditProfilePage = EditProfilePage
   { _profilePageUserProfile      :: User.UserProfile
   , _profilePageSubmitURL        :: H.AttributeValue
   }
 
-instance H.ToMarkup ProfilePage where
-  toMarkup (ProfilePage profile submitUrl) =
+instance H.ToMarkup EditProfilePage where
+  toMarkup (EditProfilePage profile submitUrl) =
     renderForm profile $ groupLayout $ do
       title "User profile"
       disabledText

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -115,7 +115,11 @@ profileView profile entities hasEditButton =
             $ maybe "" identity (User._userProfileDisplayName profile)
           keyValuePair "Bio"
             $ maybe "" linkifyAts (User._userProfileBio profile)
-          keyValuePair "Email address" (User._userProfileEmailAddr profile)
+          keyValuePair
+            "Email address"
+            (linkEmail . User.unUserEmailAddr $ User._userProfileEmailAddr
+              profile
+            )
           keyValuePair
             "Email addr. verified"
             (show $ User._userProfileEmailAddrVerified profile :: Text)

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -30,8 +30,8 @@ import qualified Text.Blaze.Html5.Attributes   as A
 
 --------------------------------------------------------------------------------
 data EditProfilePage = EditProfilePage
-  { _profilePageUserProfile      :: User.UserProfile
-  , _profilePageSubmitURL        :: H.AttributeValue
+  { _profilePageUserProfile :: User.UserProfile
+  , _profilePageSubmitURL   :: H.AttributeValue
   }
 
 instance H.ToMarkup EditProfilePage where
@@ -75,9 +75,9 @@ instance H.ToMarkup EditProfilePage where
 
 --------------------------------------------------------------------------------
 data ProfileView = ProfileView
-  { _profileViewUserProfile   :: User.UserProfile
+  { _profileViewUserProfile      :: User.UserProfile
   , _profileViewEntitiesAndRoles :: [Legal.EntityAndRole]
-  , _profileViewHasEditButton :: Maybe H.AttributeValue
+  , _profileViewHasEditButton    :: Maybe H.AttributeValue
   }
 
 instance H.ToMarkup ProfileView where
@@ -93,7 +93,8 @@ instance H.ToMarkup ProfileView where
             . User.unUserName
             . User._userCredsName
             $ User._userProfileCreds profile
-          withSideMenuFullScroll menu $ profileView profile entities hasEditButton
+          withSideMenuFullScroll menu
+            $ profileView profile entities hasEditButton
 
 menu :: SideMenu
 menu = SideMenuWithActive []
@@ -164,15 +165,16 @@ profileView profile entities hasEditButton =
     title' "Related entities" Nothing
     H.ul $ mapM_ displayEntitie entities
 
-displayAuthorization auth =
-  H.li $ do
-    H.code . H.text $ show auth
+displayAuthorization auth = H.li $ do
+  H.code . H.text $ show auth
 
-displayEntitie (Legal.EntityAndRole entity role) =
-  H.li $ do
-    H.a ! A.href (H.toValue $ "/entity/" <> Legal._entitySlug entity) $
-      H.text . Legal.unRegistrationName $ Legal._entityName entity
-    H.code . H.text $ show role
+displayEntitie (Legal.EntityAndRole entity role) = H.li $ do
+  H.a
+    ! A.href (H.toValue $ "/entity/" <> Legal._entitySlug entity)
+    $ H.text
+    . Legal.unRegistrationName
+    $ Legal._entityName entity
+  H.code . H.text $ show role
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -113,7 +113,8 @@ profileView profile entities hasEditButton =
           keyValuePair @Text "Password" ""
           keyValuePair "Display name"
             $ maybe "" identity (User._userProfileDisplayName profile)
-          keyValuePair "Bio" $ maybe "" identity (User._userProfileBio profile)
+          keyValuePair "Bio"
+            $ maybe "" linkifyAts (User._userProfileBio profile)
           keyValuePair "Email address" (User._userProfileEmailAddr profile)
           keyValuePair
             "Email addr. verified"
@@ -218,4 +219,6 @@ publicProfileView profile =
           maybe mempty
                 (keyValuePair "Display name")
                 (User._userProfileDisplayName profile)
-          maybe mempty (keyValuePair "Bio") (User._userProfileBio profile)
+          maybe mempty
+                (keyValuePair "Bio" . linkifyAts)
+                (User._userProfileBio profile)

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -16,13 +16,9 @@ import qualified Smart.Html.Dsl                as Dsl
 import           Smart.Html.Layout
 import qualified Smart.Html.Misc               as Misc
 import qualified Smart.Html.Render             as Render
-import           Smart.Html.Shared.Html.Icons   ( svgIconAdd
-                                                , svgIconArrowRight
-                                                )
 import           Smart.Html.SideMenu            ( SideMenu(..)
                                                 , SideMenuItem(..)
                                                 )
-import           Text.Blaze                     ( customAttribute )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -66,6 +66,26 @@ instance H.ToMarkup EditProfilePage where
                    "email-addr"
                    (Just . H.toValue . User._userProfileEmailAddr $ profile)
         $ Just "Your email address is private."
+      disabledText
+          "Registered since"
+          "registered-since"
+          ( Just
+          . H.toValue @Text
+          . show
+          . User._userProfileRegistrationDate
+          $ profile
+          )
+        $ Nothing
+      inputText
+          "Twitter username"
+          "twitter-username"
+          ( Just
+          . H.toValue
+          . maybe "" identity
+          . User._userProfileTwitterUsername
+          $ profile
+          )
+        $ Nothing
       submitButton submitUrl "Update profile"
 
 
@@ -157,6 +177,12 @@ profileView profile entities hasEditButton =
             . User._userProfileCompletion2
             $ profile :: Text
             )
+          keyValuePair
+            "Registered since"
+            (H.text . show . User._userProfileRegistrationDate $ profile)
+          maybe mempty
+                (keyValuePair "Twitter" . linkTwitter)
+                (User._userProfileTwitterUsername profile)
           keyValuePair "Rights"
                        (show . User._userProfileRights $ profile :: Text)
 
@@ -239,6 +265,12 @@ publicProfileView profile =
           maybe mempty
                 (keyValuePair "Bio" . linkifyAts)
                 (User._userProfileBio profile)
+          keyValuePair
+            "Registered since"
+            (H.text . show . User._userProfileRegistrationDate $ profile)
+          maybe mempty
+                (keyValuePair "Twitter" . linkTwitter)
+                (User._userProfileTwitterUsername profile)
 
     title' "Advisors" Nothing
     displayAdvisors $ User._userProfileAdvisors profile

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -72,98 +72,8 @@ instance H.ToMarkup ProfilePage where
         $ Just "Your email address is private."
       submitButton submitUrl "Update profile"
 
--- Partial re-creation of
--- https://design.smart.coop/prototypes/old-desk/contract-create-1.html
--- TODO Move to smart-design-hs and refactor.
-contractCreate1 =
-  containerMedium
-    $ H.div
-    ! A.class_ "o-form-group-layout o-form-group-layout--horizontal"
-    $ do
-        H.div ! A.class_ "o-form-group" $ do
-          H.label ! A.class_ "o-form-group__label" ! A.for "project" $ "Project"
-          H.div
-            ! A.class_
-                "o-form-group__controls o-form-group__controls--full-width"
-            $ do
-                H.button
-                  ! A.class_ "c-select-custom"
-                  ! customAttribute "aria-haspopup"       "listbox"
-                  ! customAttribute "data-menu"           "projects"
-                  ! customAttribute "data-menu-samewidth" "true"
-                  ! customAttribute "aria-expanded"       "false"
-                  $ H.div
-                  ! A.class_ "c-select-custom__value"
-                  $ "Select project"
-                H.ul
-                  ! A.class_ "c-menu c-menu--select-custom"
-                  ! A.role "listbox"
-                  ! A.id "projects"
-                  $ do
-                      H.li
-                        ! A.class_ "c-menu__item"
-                        ! A.role "option"
-                        $ H.div
-                        ! A.class_ "c-menu__label"
-                        $ "Project 1"
-                      H.li
-                        ! A.class_ "c-menu__item"
-                        ! A.role "option"
-                        $ H.div
-                        ! A.class_ "c-menu__label"
-                        $ "Project 2"
-                      H.li
-                        ! A.class_ "c-menu__item"
-                        ! A.role "option"
-                        $ H.div
-                        ! A.class_ "c-menu__label"
-                        $ "Project 3"
-                      H.li ! A.class_ "c-menu__divider" $ ""
-                      H.li
-                        ! A.class_ "c-menu__item"
-                        $ H.div
-                        ! A.class_ "c-menu__label"
-                        $ do
-                            H.div
-                              ! A.class_ "o-svg-icon o-svg-icon-add  "
-                              $ H.toMarkup svgIconAdd
-                            H.span "Add new project"
-                H.p
-                  ! A.class_ "c-form-help-text"
-                  $ "Enter an existing project or create new one"
-        H.div ! A.class_ "o-form-group" $ do
-          H.label
-            ! A.class_ "o-form-group__label"
-            ! A.for "description"
-            $ "Description"
-          H.div
-            ! A.class_
-                "o-form-group__controls o-form-group__controls--full-width"
-            $ do
-                H.textarea
-                  ! A.class_ "c-textarea"
-                  ! A.rows "5"
-                  ! A.id "description"
-                  $ ""
-                H.p
-                  ! A.class_ "c-form-help-text"
-                  $ "Describe your work (minimum 10 characters)"
-        H.div
-          ! A.class_ "o-form-group"
-          $ H.div
-          ! A.class_ "u-spacer-left-auto"
-          $ H.button
-          ! A.class_ "c-button c-button--primary"
-          ! A.type_ "button"
-          $ H.span
-          ! A.class_ "c-button__content"
-          $ do
-              H.span ! A.class_ "c-button__label" $ "Next"
-              H.div
-                ! A.class_ "o-svg-icon o-svg-icon-arrow-right  "
-                $ H.toMarkup svgIconArrowRight
 
-
+--------------------------------------------------------------------------------
 data ProfileView = ProfileView
   { _profileViewUserProfile   :: User.UserProfile
   , _profileViewEntitiesAndRoles :: [Legal.EntityAndRole]
@@ -264,6 +174,8 @@ displayEntitie (Legal.EntityAndRole entity role) =
       H.text . Legal.unRegistrationName $ Legal._entityName entity
     H.code . H.text $ show role
 
+
+--------------------------------------------------------------------------------
 data PublicProfileView = PublicProfileView
   { _publicProfileViewUserProfile   :: (Maybe User.UserProfile)
     -- ^ The logged in user, if any
@@ -305,30 +217,3 @@ publicProfileView profile =
                 (keyValuePair "Display name")
                 (User._userProfileDisplayName profile)
           maybe mempty (keyValuePair "Bio") (User._userProfileBio profile)
-
--- TODO Move to smart-design-hs and refactor.
-contractCreate1Confirm =
-  containerMedium $ H.div ! A.class_ "u-spacer-bottom-xl" $ do
-    H.div
-      ! A.class_ "u-spacer-bottom-l"
-      $ H.div
-      ! A.class_ "c-navbar c-navbar--unpadded c-navbar--bordered-bottom"
-      $ H.div
-      ! A.class_ "c-toolbar"
-      $ do
-          H.div
-            ! A.class_ "c-toolbar__left"
-            $ H.h3
-            ! A.class_ "c-h3 u-m-b-0"
-            $ "General information"
-          editButton "#"
-    H.dl
-      ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
-      $ do
-          keyValuePair @Text "Worker" "Manfred"
-          keyValuePair @Text
-            "Work setting"
-            "The work is mainly performed in places and at times freely chosen"
-          keyValuePair @Text "Compensation budget" "1000.00 EUR"
-          keyValuePair @Text "Project" "Unspecified"
-          keyValuePair @Text "Description" "Some description."

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -174,7 +174,7 @@ interpretLines runtime user dir content nesting acc0 accumulate = go user acc0 0
         case result of
           A.Success command -> do
             case command of
-              Command.Reset _ -> do
+              Command.Reset -> do
                 Rt.runRunM runtime $ Rt.reset
                 st <- Rt.runRunM runtime Rt.state
                 let t = trace' ["Resetting to the empty state."] ExitSuccess [] st

--- a/src/Curiosity/Parse.hs
+++ b/src/Curiosity/Parse.hs
@@ -24,8 +24,9 @@ import qualified Servant.Auth.Server           as SAuth
 --------------------------------------------------------------------------------
 -- | Application config.
 data Conf = Conf
-  { _confLogging :: ML.LoggingConf -- ^ Logging configuration.
-  , _confDbFile  :: Maybe FilePath
+  { _confLogging      :: ML.LoggingConf
+    -- ^ Logging configuration.
+  , _confDbFile       :: Maybe FilePath
     -- ^ An optional filepath to write the DB to, or read it from. If the file
     -- is absent, it will be created on server exit, with the latest DB state
     -- written to it.
@@ -49,7 +50,8 @@ data ServerConf = ServerConf
 --------------------------------------------------------------------------------
 defaultConf :: Conf
 defaultConf =
-  let _confDbFile = Nothing in Conf { _confLogging = defaultLoggingConf, .. }
+  let _confDbFile = Nothing
+  in Conf { _confLogging = defaultLoggingConf, .. }
 
 defaultLoggingConf :: ML.LoggingConf
 defaultLoggingConf = mkLoggingConf "./curiosity.log"

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -373,7 +373,7 @@ handleCommand runtime@Runtime {..} user command = do
     Command.StepEmail -> do
       stepRunM runtime emailStep
       pure (ExitSuccess, ["Email queue processed."])
-    Command.CreateBusinessEntity input -> do
+    Command.CreateBusinessUnit input -> do
       output <-
         runAppMSafe runtime . liftIO . STM.atomically $ Core.createBusiness
           _rDb
@@ -385,7 +385,7 @@ handleCommand runtime@Runtime {..} user command = do
               pure (ExitSuccess, ["Business entity created: " <> id])
             Left err -> pure (ExitFailure 1, [show err])
         Left err -> pure (ExitFailure 1, [show err])
-    Command.UpdateBusinessEntity input -> do
+    Command.UpdateBusinessUnit input -> do
       output <-
         runAppMSafe runtime . liftIO . STM.atomically $ Core.updateBusiness
           _rDb

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -761,7 +761,8 @@ createLegal db Legal.Create {..} = do
                            _createVatNumber
                            Nothing
                            []
-                           [Legal.AuthorizedAsBuyer] -- TODO Better logic for initial values.
+                           -- TODO Better logic for initial values.
+                           [Legal.AuthorizedAsBuyer, Legal.AuthorizedAsSeller]
                            False
                            False
     createLegalFull db new >>= either STM.throwSTM pure

--- a/src/Curiosity/Runtime/IO/AppM.hs
+++ b/src/Curiosity/Runtime/IO/AppM.hs
@@ -91,14 +91,15 @@ instance S.DBStorage AppM STM User.UserProfile where
       deleteUser _ =
         modifyUserProfiles id (filter $ (/= id) . S.dbId) _dbUserProfiles
 
-    User.UserUpdate id (User.Update mname mbio) ->
+    User.UserUpdate id (User.Update mname mbio mtwitter) ->
       S.dbSelect @AppM @STM db (User.SelectUserById id) <&> headMay >>= maybe
         (pure . User.userNotFound $ show id)
         (fmap Right . updateUser)
      where
       updateUser _ = modifyUserProfiles id replaceOlder _dbUserProfiles
       change =
-        set User.userProfileBio mbio . set User.userProfileDisplayName mname
+        set User.userProfileBio mbio . set User.userProfileDisplayName mname .
+          set User.userProfileTwitterUsername mtwitter
       replaceOlder users =
         [ if S.dbId u == id then change u else u | u <- users ]
 

--- a/src/Curiosity/Runtime/Type.hs
+++ b/src/Curiosity/Runtime/Type.hs
@@ -11,14 +11,14 @@ module Curiosity.Runtime.Type
 import qualified Commence.Multilogging         as ML
 import           Control.Lens
 import qualified Curiosity.Core                as Core
-import qualified Curiosity.Parse               as Command
+import qualified Curiosity.Parse               as Parse
 
 
 --------------------------------------------------------------------------------
 -- | The runtime, a central product type that should contain all our runtime
 -- supporting values: the STM state, loggers, and processing threads.
 data Runtime = Runtime
-  { _rConf    :: Command.Conf -- ^ The application configuration.
+  { _rConf    :: Parse.Conf -- ^ The application configuration.
   , _rDb      :: Core.StmDb -- ^ The Storage.
   , _rLoggers :: ML.AppNameLoggers -- ^ Multiple loggers to log over.
   , _rThreads :: Threads -- ^ Additional threads running e.g. async tasks.

--- a/src/Curiosity/Runtime/Type.hs
+++ b/src/Curiosity/Runtime/Type.hs
@@ -4,6 +4,7 @@ module Curiosity.Runtime.Type
   , rConf
   , rDb
   , rLoggers
+  , rThreads
   , Threads(..)
   ) where
 

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -123,7 +123,7 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
 
              :<|> "forms" :> "login" :> Get '[B.HTML] Login.Page
              :<|> "forms" :> "signup" :> Get '[B.HTML] Signup.Page
-             :<|> "forms" :> "profile" :> Get '[B.HTML] Pages.ProfilePage
+             :<|> "forms" :> "profile" :> Get '[B.HTML] Pages.EditProfilePage
 
              :<|> "forms" :> "new" :> "quotation"
                   :> Get '[B.HTML] Pages.CreateQuotationPage
@@ -991,7 +991,7 @@ type Private = H.UserAuthentication :> (
              :<|>  "settings" :> "profile.json"
                    :> Get '[JSON] User.UserProfile
              :<|>  "settings" :> "profile" :> "edit"
-                   :> Get '[B.HTML] Pages.ProfilePage
+                   :> Get '[B.HTML] Pages.EditProfilePage
 
              :<|> "new" :> "entity" :> Get '[B.HTML] Pages.CreateEntityPage
              :<|> "new" :> "unit" :> Get '[B.HTML] Pages.CreateUnitPage
@@ -1085,7 +1085,7 @@ showProfileAsJson
 showProfileAsJson = pure
 
 showEditProfilePage profile =
-  pure $ Pages.ProfilePage profile "/a/set-user-profile"
+  pure $ Pages.EditProfilePage profile "/a/set-user-profile"
 
 showCreateEntityPage
   :: ServerC m => User.UserProfile -> m Pages.CreateEntityPage
@@ -1273,10 +1273,10 @@ handleSubmitQuotation input@(Quotation.SubmitQuotation key) profile =
 -- The \`document` -prefixed functions display the same page as the \`show`
 -- -prefixed one.
 
-documentEditProfilePage :: ServerC m => FilePath -> m Pages.ProfilePage
+documentEditProfilePage :: ServerC m => FilePath -> m Pages.EditProfilePage
 documentEditProfilePage dataDir = do
   profile <- readJson $ dataDir </> "alice.json"
-  pure $ Pages.ProfilePage profile "/echo/update-profile"
+  pure $ Pages.EditProfilePage profile "/echo/update-profile"
 
 echoUpdateProfile :: ServerC m => User.Update -> m Pages.EchoPage
 echoUpdateProfile input = pure $ Pages.EchoPage $ show input

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -86,14 +86,14 @@ import           Servant.API.WebSocket
 import qualified Servant.Auth.Server           as SAuth
 import qualified Servant.Auth.Server.Internal.Cookie
                                                as SAuth.Cookie
-import qualified Servant.HTML.Blaze            as B
+import           Servant.HTML.Blaze             ( HTML )
 import qualified Servant.Server                as Server
 import           Smart.Server.Page              ( PageEither )
 import qualified Smart.Server.Page             as SS.P
 import           System.FilePath                ( (</>)
                                                 , takeBaseName
                                                 )
-import           Text.Blaze.Html5               ( (!) )
+import           Text.Blaze.Html5               ( (!), Html )
 import qualified Text.Blaze.Html5              as H
 import qualified Text.Blaze.Html5.Attributes   as A
 import qualified Text.Blaze.Renderer.Text      as R
@@ -113,144 +113,144 @@ import           WaiAppStatic.Types             ( ss404Handler
 --------------------------------------------------------------------------------
 -- brittany-disable-next-binding
 -- | This is the main Servant API definition for Curiosity.
-type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
+type App = H.UserAuthentication :> Get '[HTML] (PageEither
                Pages.LandingPage
                Pages.WelcomePage
              )
 
              -- Non-authenticated forms, for documentation purpose.
 
-             :<|> "forms" :> "login" :> Get '[B.HTML] Login.Page
-             :<|> "forms" :> "signup" :> Get '[B.HTML] Signup.Page
-             :<|> "forms" :> "profile" :> Get '[B.HTML] Pages.EditProfilePage
+             :<|> "forms" :> "login" :> Get '[HTML] Login.Page
+             :<|> "forms" :> "signup" :> Get '[HTML] Signup.Page
+             :<|> "forms" :> "profile" :> Get '[HTML] Pages.EditProfilePage
 
              :<|> "forms" :> "new" :> "quotation"
-                  :> Get '[B.HTML] Pages.CreateQuotationPage
+                  :> Get '[HTML] Pages.CreateQuotationPage
              :<|> "forms" :> "edit" :> "quotation"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.CreateQuotationPage
+                  :> Get '[HTML] Pages.CreateQuotationPage
              :<|> "forms" :> "edit" :> "quotation" :> "confirm"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.ConfirmQuotationPage
+                  :> Get '[HTML] Pages.ConfirmQuotationPage
 
              :<|> "forms" :> "new" :> "contract"
-                  :> Get '[B.HTML] Pages.CreateContractPage
+                  :> Get '[HTML] Pages.CreateContractPage
              :<|> "forms" :> "edit" :> "contract"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.CreateContractPage
+                  :> Get '[HTML] Pages.CreateContractPage
              :<|> "forms" :> "edit" :> "contract" :> "add-expense"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.AddExpensePage
+                  :> Get '[HTML] Pages.AddExpensePage
              :<|> "forms" :> "edit" :> "contract" :> "edit-expense"
                   :> Capture "key" Text
                   :> Capture "idx" Int
-                  :> Get '[B.HTML] Pages.AddExpensePage
+                  :> Get '[HTML] Pages.AddExpensePage
              :<|> "forms" :> "edit" :> "contract" :> "remove-expense"
                   :> Capture "key" Text
                   :> Capture "idx" Int
-                  :> Get '[B.HTML] Pages.RemoveExpensePage
+                  :> Get '[HTML] Pages.RemoveExpensePage
              :<|> "forms" :> "edit" :> "contract" :> "confirm"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.ConfirmContractPage
+                  :> Get '[HTML] Pages.ConfirmContractPage
 
              :<|> "forms" :> "new" :> "simple-contract"
-                  :> Get '[B.HTML] Pages.CreateSimpleContractPage
+                  :> Get '[HTML] Pages.CreateSimpleContractPage
              :<|> "forms" :> "edit" :> "simple-contract"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.CreateSimpleContractPage
+                  :> Get '[HTML] Pages.CreateSimpleContractPage
              :<|> "forms" :> "edit" :> "simple-contract" :> "select-role"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.SelectRolePage
+                  :> Get '[HTML] Pages.SelectRolePage
              :<|> "forms" :> "edit" :> "simple-contract" :> "confirm-role"
                   :> Capture "key" Text
                   :> Capture "role" Text
-                  :> Get '[B.HTML] Pages.ConfirmRolePage
+                  :> Get '[HTML] Pages.ConfirmRolePage
              :<|> "forms" :> "edit" :> "simple-contract" :> "add-date"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.AddDatePage
+                  :> Get '[HTML] Pages.AddDatePage
              :<|> "forms" :> "edit" :> "simple-contract" :> "edit-date"
                   :> Capture "key" Text
                   :> Capture "idx" Int
-                  :> Get '[B.HTML] Pages.AddDatePage
+                  :> Get '[HTML] Pages.AddDatePage
              :<|> "forms" :> "edit" :> "simple-contract" :> "remove-date"
                   :> Capture "key" Text
                   :> Capture "idx" Int
-                  :> Get '[B.HTML] Pages.RemoveDatePage
+                  :> Get '[HTML] Pages.RemoveDatePage
              :<|> "forms" :> "edit" :> "simple-contract" :> "select-vat"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.SelectVATPage
+                  :> Get '[HTML] Pages.SelectVATPage
              :<|> "forms" :> "edit" :> "simple-contract" :> "confirm-vat"
                   :> Capture "key" Text
                   :> Capture "rate" Int
-                  :> Get '[B.HTML] Pages.ConfirmVATPage
+                  :> Get '[HTML] Pages.ConfirmVATPage
              :<|> "forms" :> "edit" :> "simple-contract" :> "add-expense"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.SimpleContractAddExpensePage
+                  :> Get '[HTML] Pages.SimpleContractAddExpensePage
              :<|> "forms" :> "edit" :> "simple-contract" :> "edit-expense"
                   :> Capture "key" Text
                   :> Capture "idx" Int
-                  :> Get '[B.HTML] Pages.SimpleContractAddExpensePage
+                  :> Get '[HTML] Pages.SimpleContractAddExpensePage
              :<|> "forms" :> "edit" :> "simple-contract" :> "remove-expense"
                   :> Capture "key" Text
                   :> Capture "idx" Int
-                  :> Get '[B.HTML] Pages.SimpleContractRemoveExpensePage
+                  :> Get '[HTML] Pages.SimpleContractRemoveExpensePage
              :<|> "forms" :> "edit" :> "simple-contract" :> "confirm-simple-contract"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.ConfirmSimpleContractPage
+                  :> Get '[HTML] Pages.ConfirmSimpleContractPage
 
              :<|> "views" :> "profile"
                   :> Capture "filename" FilePath
-                  :> Get '[B.HTML] Pages.ProfileView
+                  :> Get '[HTML] Pages.ProfileView
              :<|> "views" :> "entity"
                   :> Capture "filename" FilePath
-                  :> Get '[B.HTML] Pages.EntityView
+                  :> Get '[HTML] Pages.EntityView
              :<|> "views" :> "unit"
                   :> Capture "filename" FilePath
-                  :> Get '[B.HTML] Pages.UnitView
+                  :> Get '[HTML] Pages.UnitView
              :<|> "views" :> "contract"
                   :> Capture "filename" FilePath
-                  :> Get '[B.HTML] Pages.ContractView
+                  :> Get '[HTML] Pages.ContractView
              :<|> "views" :> "invoice"
                   :> Capture "filename" FilePath
-                  :> Get '[B.HTML] Pages.InvoiceView
+                  :> Get '[HTML] Pages.InvoiceView
 
-             :<|> "messages" :> "signup" :> Get '[B.HTML] Signup.SignupResultPage
+             :<|> "messages" :> "signup" :> Get '[HTML] Signup.SignupResultPage
 
-             :<|> "run" :> H.UserAuthentication :> Get '[B.HTML] Pages.RunPage
+             :<|> "run" :> H.UserAuthentication :> Get '[HTML] Pages.RunPage
              :<|> "a" :> "run" :> H.UserAuthentication
                   :> ReqBody '[FormUrlEncoded] Data.Command
-                  :> Post '[B.HTML] Pages.EchoPage
+                  :> Post '[HTML] Pages.EchoPage
 
              :<|> "scenarios" :> Raw
 
-             :<|> "state" :> Get '[B.HTML] Pages.EchoPage
+             :<|> "state" :> Get '[HTML] Pages.EchoPage
              :<|> "state.json"
                   :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] HaskDb)
 
              :<|> "emails"
-                  :> H.UserAuthentication :>  Get '[B.HTML] Pages.EmailPage
+                  :> H.UserAuthentication :>  Get '[HTML] Pages.EmailPage
              :<|> "emails.json"
                   :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] [Email.Email])
 
              :<|> "quotations"
-                  :> H.UserAuthentication :>  Get '[B.HTML] Pages.QuotationPage
+                  :> H.UserAuthentication :>  Get '[HTML] Pages.QuotationPage
              :<|> "quotations.json"
                   :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] [Quotation.Quotation])
 
              :<|> "orders"
-                  :> H.UserAuthentication :>  Get '[B.HTML] Pages.OrderPage
+                  :> H.UserAuthentication :>  Get '[HTML] Pages.OrderPage
              :<|> "orders.json"
                   :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] [Order.Order])
 
              :<|> "echo" :> "login"
                   :> ReqBody '[FormUrlEncoded] User.Login
-                  :> Post '[B.HTML] Pages.EchoPage
+                  :> Post '[HTML] Pages.EchoPage
              :<|> "echo" :> "signup"
                   :> ReqBody '[FormUrlEncoded] User.Signup
-                  :> Post '[B.HTML] Pages.EchoPage
+                  :> Post '[HTML] Pages.EchoPage
              :<|> "echo" :> "update-profile"
                   :> ReqBody '[FormUrlEncoded] User.Update
-                  :> Post '[B.HTML] Pages.EchoPage
+                  :> Post '[HTML] Pages.EchoPage
 
              -- Quotation
              :<|> "echo" :> "new-quotation"
@@ -266,7 +266,7 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                                             )
              :<|> "echo" :> "submit-quotation"
                   :> ReqBody '[FormUrlEncoded] Quotation.SubmitQuotation
-                  :> Post '[B.HTML] Pages.EchoPage
+                  :> Post '[HTML] Pages.EchoPage
 
              -- Contract
              :<|> "echo" :> "new-contract"
@@ -312,7 +312,7 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                                             )
              :<|> "echo" :> "submit-contract"
                   :> ReqBody '[FormUrlEncoded] Employment.SubmitContract
-                  :> Post '[B.HTML] Pages.EchoPage
+                  :> Post '[HTML] Pages.EchoPage
 
              -- Simple conctract
              :<|> "echo" :> "new-simple-contract"
@@ -422,30 +422,30 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
                                             )
              :<|> "echo" :> "submit-simple-contract"
                   :> ReqBody '[FormUrlEncoded] SimpleContract.SubmitContract
-                  :> Post '[B.HTML] Pages.EchoPage
+                  :> Post '[HTML] Pages.EchoPage
 
              :<|> Partials
 
-             :<|> "login" :> Get '[B.HTML] Login.Page
-             :<|> "signup" :> Get '[B.HTML] Signup.Page
+             :<|> "login" :> Get '[HTML] Login.Page
+             :<|> "signup" :> Get '[HTML] Signup.Page
 
              :<|> "action" :> "set-email-addr-as-verified"
                   :> Capture "username" User.UserName
-                  :> Get '[B.HTML] Pages.SetUserEmailAddrAsVerifiedPage
+                  :> Get '[HTML] Pages.SetUserEmailAddrAsVerifiedPage
              :<|> "action" :> "set-quotation-as-signed"
                   :> Capture "quotation-id" Quotation.QuotationId
-                  :> Get '[B.HTML] Pages.SetQuotationAsSignedPage
+                  :> Get '[HTML] Pages.SetQuotationAsSignedPage
 
              :<|> Public
              :<|> Private
              :<|> "data" :> Raw
              :<|> "ubl" :> Capture "schema" Text
                   :> Capture "filename" FilePath :> Get '[JSON] Value
-             :<|> "errors" :> "500" :> Get '[B.HTML, JSON] Text
-             :<|> "alice+" :> Get '[B.HTML] Pages.ProfileView
+             :<|> "errors" :> "500" :> Get '[HTML, JSON] Text
+             :<|> "alice+" :> Get '[HTML] Pages.ProfileView
              :<|> "entity" :> H.UserAuthentication
                   :> Capture "name" Text
-                  :> Get '[B.HTML] Pages.EntityView
+                  :> Get '[HTML] Pages.EntityView
              :<|> WebSocketApi
              -- Catchall for user profiles and business units. This also serves
              -- static files (documentation), and a custom 404 when no user or
@@ -453,36 +453,36 @@ type App = H.UserAuthentication :> Get '[B.HTML] (PageEither
              :<|> Capture "namespace" Text :> Raw
 
 -- brittany-disable-next-binding
-type NamespaceAPI = Get '[B.HTML] (PageEither Pages.PublicProfileView Pages.UnitView)
+type NamespaceAPI = Get '[HTML] (PageEither Pages.PublicProfileView Pages.UnitView)
 
 -- brittany-disable-next-binding
 type Partials =
   -- static data
-       "partials" :> "username-blocklist" :> Get '[B.HTML] H.Html
+       "partials" :> "username-blocklist" :> Get '[HTML] Html
   :<|> "partials" :> "username-blocklist.json" :> Get '[JSON] [User.UserName]
 
-  :<|> "partials" :> "roles" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "roles" :> Get '[HTML] Html
   :<|> "partials" :> "roles.json" :> Get '[JSON] [SimpleContract.Role0]
 
-  :<|> "partials" :> "countries" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "countries" :> Get '[HTML] Html
   :<|> "partials" :> "countries.json" :> Get '[JSON] [(Text, Text)]
 
-  :<|> "partials" :> "vat-rates" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "vat-rates" :> Get '[HTML] Html
   :<|> "partials" :> "vat-rates.json" :> Get '[JSON] [(Text, Text)]
 
-  :<|> "partials" :> "permissions" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "permissions" :> Get '[HTML] Html
   :<|> "partials" :> "permissions.json" :> Get '[JSON] [User.AccessRight]
 
-  :<|> "partials" :> "scenarios" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "scenarios" :> Get '[HTML] Html
   :<|> "partials" :> "scenarios.json" :> Get '[JSON] [FilePath]
 
   :<|> "partials" :> "scenarios"
-       :> Capture "name" FilePath :> Get '[B.HTML] H.Html
+       :> Capture "name" FilePath :> Get '[HTML] Html
   :<|> "partials" :> "scenarios"
        :> Capture "name" FilePath
        :> Capture "nbr" Int
        :> "state"
-       :> Get '[B.HTML] H.Html
+       :> Get '[HTML] Html
   :<|> "partials" :> "scenarios"
        :> Capture "name" FilePath
        :> Capture "nbr" Int
@@ -490,7 +490,7 @@ type Partials =
        :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] HaskDb)
 
   -- live data
-  :<|> "partials" :> "legal-entities" :> Get '[B.HTML] H.Html
+  :<|> "partials" :> "legal-entities" :> Get '[HTML] Html
   :<|> "partials" :> "legal-entities.json" :> Get '[JSON] [Legal.Entity]
 
 -- | This is the main Servant server definition, corresponding to @App@.
@@ -796,7 +796,7 @@ showSetQuotationAsignedPage id =
 
 
 --------------------------------------------------------------------------------
-partialUsernameBlocklist :: ServerC m => m H.Html
+partialUsernameBlocklist :: ServerC m => m Html
 partialUsernameBlocklist =
   pure . H.ul $ mapM_ (H.li . H.code . H.toHtml) User.usernameBlocklist
 
@@ -805,7 +805,7 @@ partialUsernameBlocklistAsJson = pure User.usernameBlocklist
 
 
 --------------------------------------------------------------------------------
-partialRoles :: ServerC m => m H.Html
+partialRoles :: ServerC m => m Html
 partialRoles = pure . H.ul $ mapM_ displayRole0 SimpleContract.roles
  where
   displayRole0 (SimpleContract.Role0 title roles1) = do
@@ -827,7 +827,7 @@ partialRolesAsJson = pure SimpleContract.roles
 
 
 --------------------------------------------------------------------------------
-partialCountries :: ServerC m => m H.Html
+partialCountries :: ServerC m => m Html
 partialCountries = pure . H.ul $ mapM_ displayCountry Country.countries
  where
   displayCountry (value, label) = H.li $ do
@@ -839,7 +839,7 @@ partialCountriesAsJson = pure Country.countries
 
 
 --------------------------------------------------------------------------------
-partialVatRates :: ServerC m => m H.Html
+partialVatRates :: ServerC m => m Html
 partialVatRates = pure . H.ul $ mapM_ displayVatRate SimpleContract.vatRates
  where
   displayVatRate (value, label) = H.li $ do
@@ -851,7 +851,7 @@ partialVatRatesAsJson = pure SimpleContract.vatRates
 
 
 --------------------------------------------------------------------------------
-partialPermissions :: ServerC m => m H.Html
+partialPermissions :: ServerC m => m Html
 partialPermissions = pure . H.ul $ mapM_ displayPermission User.permissions
   where displayPermission p = H.li $ H.code . H.text $ show p
 
@@ -860,7 +860,7 @@ partialPermissionsAsJson = pure User.permissions
 
 
 --------------------------------------------------------------------------------
-partialLegalEntities :: ServerC m => m H.Html
+partialLegalEntities :: ServerC m => m Html
 partialLegalEntities = do
   db       <- asks Rt._rDb
   entities <- liftIO . atomically $ Rt.readLegalEntities db
@@ -893,7 +893,7 @@ echoLogin = pure . Pages.EchoPage . show
 -- | A publicly available login page.
 type Public =    "a" :> "signup"
                  :> ReqBody '[FormUrlEncoded] User.Signup
-                 :> Post '[B.HTML] Signup.SignupResultPage
+                 :> Post '[HTML] Signup.SignupResultPage
             :<|> "a" :> "login"
                  :> ReqBody '[FormUrlEncoded] User.Login
                  :> Verb 'POST 303 '[JSON] ( Headers CAuth.PostAuthHeaders
@@ -986,24 +986,24 @@ handleLogin conf jwtSettings input =
 -- | The private API with authentication.
 type Private = H.UserAuthentication :> (
                    "settings" :> "profile"
-                   :> Get '[B.HTML] Pages.ProfileView
+                   :> Get '[HTML] Pages.ProfileView
              :<|>  "settings" :> "profile.json"
                    :> Get '[JSON] User.UserProfile
              :<|>  "settings" :> "profile" :> "edit"
-                   :> Get '[B.HTML] Pages.EditProfilePage
+                   :> Get '[HTML] Pages.EditProfilePage
 
-             :<|> "new" :> "entity" :> Get '[B.HTML] Pages.CreateEntityPage
-             :<|> "new" :> "unit" :> Get '[B.HTML] Pages.CreateUnitPage
-             :<|> "new" :> "quotation" :> Get '[B.HTML] Pages.CreateQuotationPage
-             :<|> "new" :> "contract" :> Get '[B.HTML] Pages.CreateContractPage
-             :<|> "new" :> "invoice" :> Get '[B.HTML] Pages.CreateInvoicePage
+             :<|> "new" :> "entity" :> Get '[HTML] Pages.CreateEntityPage
+             :<|> "new" :> "unit" :> Get '[HTML] Pages.CreateUnitPage
+             :<|> "new" :> "quotation" :> Get '[HTML] Pages.CreateQuotationPage
+             :<|> "new" :> "contract" :> Get '[HTML] Pages.CreateContractPage
+             :<|> "new" :> "invoice" :> Get '[HTML] Pages.CreateInvoicePage
 
              :<|> "edit" :> "quotation"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.CreateQuotationPage
+                  :> Get '[HTML] Pages.CreateQuotationPage
              :<|> "edit" :> "quotation" :> "confirm"
                   :> Capture "key" Text
-                  :> Get '[B.HTML] Pages.ConfirmQuotationPage
+                  :> Get '[HTML] Pages.ConfirmQuotationPage
 
              :<|>  "a" :>"set-user-profile"
                    :> ReqBody '[FormUrlEncoded] User.Update
@@ -1015,10 +1015,10 @@ type Private = H.UserAuthentication :> (
                                                             )
              :<|> "a" :> "set-email-addr-as-verified"
                    :> ReqBody '[FormUrlEncoded] User.SetUserEmailAddrAsVerified
-                   :> Post '[B.HTML] Pages.ActionResult
+                   :> Post '[HTML] Pages.ActionResult
              :<|> "a" :> "set-quotation-as-signed"
                    :> ReqBody '[FormUrlEncoded] Quotation.SetQuotationAsSigned
-                   :> Post '[B.HTML] Pages.ActionResult
+                   :> Post '[HTML] Pages.ActionResult
 
              :<|> "a" :> "new-quotation"
                   :> ReqBody '[FormUrlEncoded] Quotation.CreateQuotationAll
@@ -1033,7 +1033,7 @@ type Private = H.UserAuthentication :> (
                                             )
              :<|> "a" :> "submit-quotation"
                   :> ReqBody '[FormUrlEncoded] Quotation.SubmitQuotation
-                  :> Post '[B.HTML] Pages.EchoPage
+                  :> Post '[HTML] Pages.EchoPage
   )
 
 privateT :: forall m . ServerC m => Parse.ServerConf -> ServerT Private m
@@ -2503,7 +2503,7 @@ handleRun authResult (Data.Command cmd) = withMaybeUser
 
 -- | Show the state after a specific command, given as its number within the
 -- script.
-partialScenarioState :: ServerC m => FilePath -> FilePath -> Int -> m H.Html
+partialScenarioState :: ServerC m => FilePath -> FilePath -> Int -> m Html
 partialScenarioState scenariosDir name nbr = do
   let path = scenariosDir </> name <> ".txt"
   ts <- liftIO $ Inter.handleRun' path
@@ -2523,7 +2523,7 @@ partialScenarioStateAsJson scenariosDir name nbr = do
       db  = Inter.traceState $ ts' !! nbr -- TODO Proper input validation
   pure $ JP.PrettyJSON db
 
-partialScenarios :: ServerC m => FilePath -> m H.Html
+partialScenarios :: ServerC m => FilePath -> m Html
 partialScenarios scenariosDir = do
   names <- listScenarioNames scenariosDir
   pure . H.ul $ mapM_ displayScenario names
@@ -2537,7 +2537,7 @@ partialScenarios scenariosDir = do
 partialScenariosAsJson :: ServerC m => FilePath -> m [FilePath]
 partialScenariosAsJson = listScenarioNames
 
-partialScenario :: ServerC m => FilePath -> FilePath -> m H.Html
+partialScenario :: ServerC m => FilePath -> FilePath -> m Html
 partialScenario scenariosDir name = do
   let path = scenariosDir </> name <> ".txt"
   ts <- liftIO $ Inter.handleRun' path

--- a/src/Curiosity/Server/Helpers.hs
+++ b/src/Curiosity/Server/Helpers.hs
@@ -13,7 +13,7 @@ import           Commence.Server.Auth           ( PostAuthHeaders )
 import qualified Curiosity.Data.User           as User
 import           Servant.API
 import qualified Servant.Auth.Server           as SAuth
-import qualified Servant.HTML.Blaze            as B
+import           Servant.HTML.Blaze             ( HTML )
 import qualified Smart.Server.Page             as SS.P
 
 
@@ -24,7 +24,7 @@ type PostUserPage pageData = UserPage Post pageData
 
 -- | A convenient alias to denote a GET endpoint to get a user-authenticated page.
 type UserPage method pageData
-  = method '[B.HTML] (SS.P.Page 'SS.P.Authd User.UserProfile pageData)
+  = method '[HTML] (SS.P.Page 'SS.P.Authd User.UserProfile pageData)
 
 -- brittany-disable-next-binding
 -- | Simple user authentication.

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -31,35 +31,27 @@ spec = do
             `shouldBe` username
     mapM_
       go
-      [ ("alice.json"  , "alice")
-      , ("alice-with-bio.json"  , "alice")
-      , ("bob-0.json"  , "bob")
-      , ("bob-1.json"  , "bob")
-      , ("bob-2.json"  , "bob")
-      , ("charlie.json", "charlie")
+      [ ("alice.json"         , "alice")
+      , ("alice-with-bio.json", "alice")
+      , ("bob-0.json"         , "bob")
+      , ("bob-1.json"         , "bob")
+      , ("bob-2.json"         , "bob")
+      , ("charlie.json"       , "charlie")
       ]
 
   -- Same here.
   describe "Legal entity JSON parser" $ do
     let go (filename, slug) = it ("Parses " <> filename) $ do
           Right (result :: Legal.Entity) <- parseFile $ "data/" </> filename
-          Legal._entitySlug result
-            `shouldBe` slug
-    mapM_
-      go
-      [ ("one.json"  , "one")
-      ]
+          Legal._entitySlug result `shouldBe` slug
+    mapM_ go [("one.json", "one")]
 
   -- Same here.
   describe "Business unit JSON parser" $ do
     let go (filename, slug) = it ("Parses " <> filename) $ do
           Right (result :: Business.Unit) <- parseFile $ "data/" </> filename
-          Business._entitySlug result
-            `shouldBe` slug
-    mapM_
-      go
-      [ ("alpha.json", "alpha")
-      ]
+          Business._entitySlug result `shouldBe` slug
+    mapM_ go [("alpha.json", "alpha")]
 
   -- TODO Check that all the files in data/ are in one of the above lists.
 
@@ -73,9 +65,11 @@ spec = do
             x `shouldBe` command
     mapM_
       go
-      [ ("init"      , Command.Init)
-      , ("state"     , Command.State False)
-      , ("state --hs", Command.State True)
+      [ ("init"          , Command.Init Data.Normal)
+      , ("init --normal" , Command.Init Data.Normal)
+      , ("init --stepped", Command.Init Data.Stepped)
+      , ("state"         , Command.State False)
+      , ("state --hs"    , Command.State True)
       ]
 
   describe "Command-line interface execution" $ do
@@ -105,24 +99,35 @@ spec = do
               , Data._dbUserProfiles = Identity [alice]
               , Data._dbNextEmailId  = C.CounterValue 2
               , Data._dbEmails       = Identity
-                  [Email.Email "EMAIL-1" Email.SignupConfirmationEmail
-                    Email.systemEmailAddr "alice@example.com" Email.EmailTodo]
+                                         [ Email.Email "EMAIL-1"
+                                                       Email.SignupConfirmationEmail
+                                                       Email.systemEmailAddr
+                                                       "alice@example.com"
+                                                       Email.EmailTodo
+                                         ]
+              , Data._dbEpochTime    = 60
               }
-        -- The same state, but with the email set to DONE.
+        -- The same state, but with the email set to DONE, and the time
+        -- advanced a bit.
         let aliceState' = Data.emptyHask
               { Data._dbNextUserId   = C.CounterValue 2
               , Data._dbUserProfiles = Identity [alice]
               , Data._dbNextEmailId  = C.CounterValue 2
               , Data._dbEmails       = Identity
-                  [Email.Email "EMAIL-1" Email.SignupConfirmationEmail
-                    Email.systemEmailAddr "alice@example.com" Email.EmailDone]
+                                         [ Email.Email "EMAIL-1"
+                                                       Email.SignupConfirmationEmail
+                                                       Email.systemEmailAddr
+                                                       "alice@example.com"
+                                                       Email.EmailDone
+                                         ]
+              , Data._dbEpochTime    = 120
               }
         mapM_
           go
-          [ ("init" , Data.emptyHask)
+          [ ("init --stepped", Data.emptyHask)
           , ("user create alice a alice@example.com --accept-tos", aliceState)
-          , ("step-email", aliceState')
-          , ("reset", Data.emptyHask)
+          , ("step-email"    , aliceState')
+          , ("reset"         , Data.emptyHask)
           ]
 
 

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -37,6 +37,7 @@ spec = do
       , ("bob-1.json"         , "bob")
       , ("bob-2.json"         , "bob")
       , ("charlie.json"       , "charlie")
+      , ("mila.json"          , "mila")
       ]
 
   -- Same here.


### PR DESCRIPTION
This PR enriches user profiles, legal entities, ...

- Turns `@` mentions into link within user profile bios or legal entities
- Make email addresses clickable
- Show advisors in user profile
- Add a registration date to the user profile
- Allow to link a user to a business unit
- Rename `cty business` to `cty unit`, and `cty legal` to `cty entity`
- Add a` IsSupervised` flag to entities, meaning their accounting is managed by the group operating Curiosity
- Add a `IsHost` flag to entities, meaning they can "host" business units
- Add additional users and entities to `state-0`