### PR TITLE
Add a cty user invite command

### DIFF
--- a/data/alice-with-bio.json
+++ b/data/alice-with-bio.json
@@ -1,6 +1,7 @@
 {
   "_userProfileId": "USER-1",
   "_userProfileCreds": {
+    "tag": "Credentials",
     "_userCredsName": "alice",
     "_userCredsPassword": "a"
   },

--- a/data/alice.json
+++ b/data/alice.json
@@ -1,6 +1,7 @@
 {
   "_userProfileId": "USER-1",
   "_userProfileCreds": {
+    "tag": "Credentials",
     "_userCredsName": "alice",
     "_userCredsPassword": "a"
   },

--- a/data/bob-0.json
+++ b/data/bob-0.json
@@ -1,6 +1,7 @@
 {
   "_userProfileId": "USER-2",
   "_userProfileCreds": {
+    "tag": "Credentials",
     "_userCredsName": "bob",
     "_userCredsPassword": "secret"
   },

--- a/data/bob-1.json
+++ b/data/bob-1.json
@@ -1,6 +1,7 @@
 {
   "_userProfileId": "USER-2",
   "_userProfileCreds": {
+    "tag": "Credentials",
     "_userCredsName": "bob",
     "_userCredsPassword": "secret"
   },

--- a/data/bob-2.json
+++ b/data/bob-2.json
@@ -1,6 +1,7 @@
 {
   "_userProfileId": "USER-2",
   "_userProfileCreds": {
+    "tag": "Credentials",
     "_userCredsName": "bob",
     "_userCredsPassword": "secret"
   },

--- a/data/charlie.json
+++ b/data/charlie.json
@@ -1,6 +1,7 @@
 {
   "_userProfileId": "USER-3",
   "_userProfileCreds": {
+    "tag": "Credentials",
     "_userCredsName": "charlie",
     "_userCredsPassword": "secret"
   },

--- a/data/mila.json
+++ b/data/mila.json
@@ -1,6 +1,7 @@
 {
   "_userProfileId": "USER-4",
   "_userProfileCreds": {
+    "tag": "Credentials",
     "_userCredsName": "mila",
     "_userCredsPassword": "m"
   },

--- a/scenarios/0.golden
+++ b/scenarios/0.golden
@@ -1,6 +1,6 @@
 1: reset
 Resetting to the empty state.
-3: user create alice secret alice@example.com --accept-tos
+3: user signup alice secret alice@example.com --accept-tos
 User created: USER-1
 4: user get USER-1 --short
 USER-1 alice

--- a/scenarios/0.txt
+++ b/scenarios/0.txt
@@ -1,5 +1,5 @@
 reset                    # Make sure to start from a known state
 # Create an initial user
-user create alice secret alice@example.com --accept-tos
+user signup alice secret alice@example.com --accept-tos
 user get USER-1 --short  # Display the created user
 quit                     # Exit the script, not required at the end

--- a/scenarios/1.golden
+++ b/scenarios/1.golden
@@ -1,4 +1,4 @@
 1: reset
 Resetting to the empty state.
-3: user create about secret alice@example.com --accept-tos
+3: user signup about secret alice@example.com --accept-tos
 UsernameBlocked

--- a/scenarios/1.txt
+++ b/scenarios/1.txt
@@ -1,3 +1,3 @@
 reset
 # Shows that a user called "about" cannot be created
-user create about secret alice@example.com --accept-tos
+user signup about secret alice@example.com --accept-tos

--- a/scenarios/2.golden
+++ b/scenarios/2.golden
@@ -2,9 +2,9 @@
 Resetting to the empty state.
 5: as alice
 Modifying default user.
-6: user create alice secret alice@example.com --accept-tos
+6: user signup alice secret alice@example.com --accept-tos
 User created: USER-1
-7: user create bob secret bob@example.com --accept-tos
+7: user signup bob secret bob@example.com --accept-tos
 User created: USER-2
 8: user do set-email-addr-as-verified bob
 User successfully updated.
@@ -14,9 +14,9 @@ EmailAddrAlreadyVerified
 Resetting to the empty state.
 12: as bob
 Modifying default user.
-13: user create alice secret alice@example.com --accept-tos
+13: user signup alice secret alice@example.com --accept-tos
 User created: USER-1
-14: user create bob secret bob@example.com --accept-tos
+14: user signup bob secret bob@example.com --accept-tos
 User created: USER-2
 15: user do set-email-addr-as-verified alice
 MissingRight CanVerifyEmailAddr

--- a/scenarios/2.txt
+++ b/scenarios/2.txt
@@ -3,13 +3,13 @@
 
 reset
 as alice
-user create alice secret alice@example.com --accept-tos
-user create bob secret bob@example.com --accept-tos
+user signup alice secret alice@example.com --accept-tos
+user signup bob secret bob@example.com --accept-tos
 user do set-email-addr-as-verified bob  # Will succeed.
 user do set-email-addr-as-verified bob  # This is already done.
 
 reset
 as bob
-user create alice secret alice@example.com --accept-tos
-user create bob secret bob@example.com --accept-tos
+user signup alice secret alice@example.com --accept-tos
+user signup bob secret bob@example.com --accept-tos
 user do set-email-addr-as-verified alice  # Will fail: missing right.

--- a/scenarios/example.golden
+++ b/scenarios/example.golden
@@ -1,6 +1,6 @@
 1: user get USER-1 --short
 No such user.
-2: user create alice secret alice@example.com
+2: user signup alice secret alice@example.com
 User created: USER-1
 3: user get USER-1 --short
 USER-1 alice

--- a/scenarios/example.txt
+++ b/scenarios/example.txt
@@ -1,3 +1,3 @@
 user get USER-1 --short
-user create alice secret alice@example.com
+user signup alice secret alice@example.com
 user get USER-1 --short

--- a/scenarios/init-users.golden
+++ b/scenarios/init-users.golden
@@ -1,14 +1,14 @@
-2: user create alice a alice@example.com --accept-tos
+2: user signup alice a alice@example.com --accept-tos
 User created: USER-1
 3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
 User updated: USER-1
-5: user create bob b bob@example.com --accept-tos
+5: user signup bob b bob@example.com --accept-tos
 User created: USER-2
-6: user create charlie c charlie@example.com --accept-tos
+6: user signup charlie c charlie@example.com --accept-tos
 User created: USER-3
-8: user create mila m mila@example.com --accept-tos
+8: user signup mila m mila@example.com --accept-tos
 User created: USER-4
 9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
 User updated: USER-4
-11: user create chloe c chloe@example.com --accept-tos
+11: user signup chloe c chloe@example.com --accept-tos
 User created: USER-5

--- a/scenarios/init-users.txt
+++ b/scenarios/init-users.txt
@@ -1,11 +1,11 @@
 # Initialize a state with four users.
-user create alice a alice@example.com --accept-tos
+user signup alice a alice@example.com --accept-tos
 user update USER-1 Alice "Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !"
 
-user create bob b bob@example.com --accept-tos
-user create charlie c charlie@example.com --accept-tos
+user signup bob b bob@example.com --accept-tos
+user signup charlie c charlie@example.com --accept-tos
 
-user create mila m mila@example.com --accept-tos
+user signup mila m mila@example.com --accept-tos
 user update USER-4 Mila "I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha."
 
-user create chloe c chloe@example.com --accept-tos
+user signup chloe c chloe@example.com --accept-tos

--- a/scenarios/invite-actions.golden
+++ b/scenarios/invite-actions.golden
@@ -1,0 +1,9 @@
+1: reset
+Resetting to the empty state.
+2: user invite alice@example.com
+User created: USER-1
+3: queues
+Email addresses to verify:
+USER-1 /
+Emails to send:
+EMAIL-1 alice@example.com

--- a/scenarios/invite-actions.txt
+++ b/scenarios/invite-actions.txt
@@ -1,0 +1,3 @@
+reset
+user invite alice@example.com
+queues

--- a/scenarios/quotation-flow.golden
+++ b/scenarios/quotation-flow.golden
@@ -1,12 +1,12 @@
 1: reset
 Resetting to the empty state.
-2: user create alice a alice@example.com --accept-tos
+2: user signup alice a alice@example.com --accept-tos
 User created: USER-1
-4: user create susie s susie@example.com --accept-tos
+4: user signup susie s susie@example.com --accept-tos
 User created: USER-2
 5: user update USER-2 Susie I'm Susie, the Seller in the quotation-flow scenario.
 User updated: USER-2
-7: user create charlie c charlie@example.com --accept-tos
+7: user signup charlie c charlie@example.com --accept-tos
 User created: USER-3
 8: user update USER-3 Charlie I'm Charlie, a Client in the quotation-flow scenario.
 User updated: USER-3

--- a/scenarios/quotation-flow.txt
+++ b/scenarios/quotation-flow.txt
@@ -1,10 +1,10 @@
 reset
-user create alice a alice@example.com --accept-tos
+user signup alice a alice@example.com --accept-tos
 
-user create susie s susie@example.com --accept-tos
+user signup susie s susie@example.com --accept-tos
 user update USER-2 Susie "I'm Susie, the Seller in the quotation-flow scenario."
 
-user create charlie c charlie@example.com --accept-tos
+user signup charlie c charlie@example.com --accept-tos
 user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 
 as susie

--- a/scenarios/signup-actions.golden
+++ b/scenarios/signup-actions.golden
@@ -3,7 +3,7 @@ Resetting to the empty state.
 2: queues
 Email addresses to verify:
 Emails to send:
-3: user create alice secret alice@example.com --accept-tos
+3: user signup alice secret alice@example.com --accept-tos
 User created: USER-1
 4: queues
 Email addresses to verify:

--- a/scenarios/signup-actions.txt
+++ b/scenarios/signup-actions.txt
@@ -1,6 +1,6 @@
 reset
 queues
-user create alice secret alice@example.com --accept-tos
+user signup alice secret alice@example.com --accept-tos
 queues
 step --all --dry
 step --all

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -1,19 +1,19 @@
 1: reset
 Resetting to the empty state.
 2: run init-users.txt
-> 2: user create alice a alice@example.com --accept-tos
+> 2: user signup alice a alice@example.com --accept-tos
 > User created: USER-1
 > 3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
 > User updated: USER-1
-> 5: user create bob b bob@example.com --accept-tos
+> 5: user signup bob b bob@example.com --accept-tos
 > User created: USER-2
-> 6: user create charlie c charlie@example.com --accept-tos
+> 6: user signup charlie c charlie@example.com --accept-tos
 > User created: USER-3
-> 8: user create mila m mila@example.com --accept-tos
+> 8: user signup mila m mila@example.com --accept-tos
 > User created: USER-4
 > 9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
 > User updated: USER-4
-> 11: user create chloe c chloe@example.com --accept-tos
+> 11: user signup chloe c chloe@example.com --accept-tos
 > User created: USER-5
 3: run init-entities.txt
 > 1: entity create one One S.A. 100200300 BE0100200300

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -70,6 +70,7 @@ data Command =
   | UpdateLegalEntityIsHost Text Bool
     -- ^ Make a legal entity as 'host' (True) or 'not host' (False).
   | Signup User.Signup
+  | Invite User.Invite
   | SelectUser Bool User.UserId Bool
     -- ^ Show a given user. If True, use Haskell format instead of JSON. If
     -- True, show only the user ID and username.
@@ -641,6 +642,9 @@ parserUser = A.subparser
       "signup"
       (A.info (parserSignup <**> A.helper) $ A.progDesc "Create a new user")
   <> A.command
+      "invite"
+      (A.info (parserInvite <**> A.helper) $ A.progDesc "Invite a new user")
+  <> A.command
        "delete"
        (A.info (parserDeleteUser <**> A.helper) $ A.progDesc "Delete a user")
   <> A.command
@@ -683,6 +687,11 @@ parserSignup = do
     <> A.help "Indicate if the user being created consents to the TOS."
     )
   pure $ Signup $ User.Signup username password email tosConsent
+
+parserInvite :: A.Parser Command
+parserInvite = do
+  email <- A.argument A.str (A.metavar "EMAIL" <> A.help "An email address")
+  pure $ Invite $ User.Invite email
 
 parserDeleteUser :: A.Parser Command
 parserDeleteUser = UpdateUser . User.UserDelete <$> argumentUserId

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -69,7 +69,7 @@ data Command =
     -- (False).
   | UpdateLegalEntityIsHost Text Bool
     -- ^ Make a legal entity as 'host' (True) or 'not host' (False).
-  | CreateUser User.Signup
+  | Signup User.Signup
   | SelectUser Bool User.UserId Bool
     -- ^ Show a given user. If True, use Haskell format instead of JSON. If
     -- True, show only the user ID and username.
@@ -638,8 +638,8 @@ metavarEntitySlug = A.metavar "SLUG" <> A.completer complete <> A.help
 parserUser :: A.Parser Command
 parserUser = A.subparser
   (  A.command
-      "create"
-      (A.info (parserCreateUser <**> A.helper) $ A.progDesc "Create a new user")
+      "signup"
+      (A.info (parserSignup <**> A.helper) $ A.progDesc "Create a new user")
   <> A.command
        "delete"
        (A.info (parserDeleteUser <**> A.helper) $ A.progDesc "Delete a user")
@@ -673,8 +673,8 @@ parserUsers = do
         )
   pure $ FilterUsers predicate
 
-parserCreateUser :: A.Parser Command
-parserCreateUser = do
+parserSignup :: A.Parser Command
+parserSignup = do
   username   <- A.argument A.str (A.metavar "USERNAME" <> A.help "A username")
   password   <- A.argument A.str (A.metavar "PASSWORD" <> A.help "A password")
   email <- A.argument A.str (A.metavar "EMAIL" <> A.help "An email address")
@@ -682,7 +682,7 @@ parserCreateUser = do
     (  A.long "accept-tos"
     <> A.help "Indicate if the user being created consents to the TOS."
     )
-  pure $ CreateUser $ User.Signup username password email tosConsent
+  pure $ Signup $ User.Signup username password email tosConsent
 
 parserDeleteUser :: A.Parser Command
 parserDeleteUser = UpdateUser . User.UserDelete <$> argumentUserId

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -71,6 +71,10 @@ emailIdPrefix = "EMAIL-"
 data EmailTemplate =
     SignupConfirmationEmail
     -- ^ An email sent upon signup (see `Curiosity.Data.User.Signup`).
+  | InviteEmail Text -- TODO Proper Text wrapper.
+    -- ^ An email sent to invite a user. Their user profile was already created
+    -- (in particular with an email address), and the email gives them a token
+    -- (that serves as credentials).
   | QuotationEmail
     -- ^ An email sent when a quotation form is successfully submitted to the
     -- system (see `Curiosity.Data.Quotation.SubmitQuotation`).
@@ -82,6 +86,7 @@ data EmailTemplate =
 emailTemplateName :: EmailTemplate -> Text
 emailTemplateName t = case t of
   SignupConfirmationEmail -> "SignupConfirmation"
+  InviteEmail _ -> "Invite"
   QuotationEmail -> "Quotation"
   InvoiceEmail -> "Invoice"
   InvoiceReminderEmail -> "InvoiceReminder"

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -64,7 +64,7 @@ signup
   -> User.UserEmailAddr
   -> Run (Either User.Err (User.UserId, Email.EmailId))
 signup username password email =
-  ask >>= (Run . lift . flip Core.createUser input)
+  ask >>= (Run . lift . flip Core.signupUser input)
   where input = User.Signup username password email True
 
 can :: User.UserProfile -> Syntax.Name -> Run Bool

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -456,7 +456,7 @@ handleCommand runtime@Runtime {..} user command = do
             , ["Legal entity updated: " <> slug]
             )
         Left err -> pure (ExitFailure 1, [show err])
-    Command.CreateUser input -> do
+    Command.Signup input -> do
       muid <- stepRunM runtime $ createUser input
       case muid of
         Right (User.UserId uid) ->
@@ -1619,7 +1619,7 @@ filterUsers' predicate = do
   liftIO . STM.atomically $ filterUsers db predicate
 
 createUser :: User.Signup -> RunM (Either User.Err User.UserId)
-createUser input = ML.localEnv (<> "Command" <> "CreateUser") $ do
+createUser input = ML.localEnv (<> "Command" <> "Signup") $ do
   ML.info "Creating user..."
   db   <- asks _rDb
   muid <- liftIO . STM.atomically $ Core.createUser db input

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -23,7 +23,7 @@ module Curiosity.Runtime
   , selectUserByUsernameResolved
   , filterUsers
   , filterUsers'
-  , createUser
+  , signupUser
   -- * High-level entity operations
   , selectEntityBySlug
   , selectEntityBySlugResolved
@@ -457,7 +457,13 @@ handleCommand runtime@Runtime {..} user command = do
             )
         Left err -> pure (ExitFailure 1, [show err])
     Command.Signup input -> do
-      muid <- stepRunM runtime $ createUser input
+      muid <- stepRunM runtime $ signupUser input
+      case muid of
+        Right (User.UserId uid) ->
+          pure (ExitSuccess, ["User created: " <> uid])
+        Left err -> pure (ExitFailure 1, [show err])
+    Command.Invite input -> do
+      muid <- stepRunM runtime $ inviteUser input
       case muid of
         Right (User.UserId uid) ->
           pure (ExitSuccess, ["User created: " <> uid])
@@ -490,7 +496,10 @@ handleCommand runtime@Runtime {..} user command = do
       profiles <- runRunM runtime $ filterUsers' predicate
       let f User.UserProfile {..} =
             let User.UserId   i = _userProfileId
-                User.UserName n = User._userCredsName _userProfileCreds
+                n = case _userProfileCreds of
+                      User.Credentials {..} ->
+                        let User.UserName n = _userCredsName in n
+                      User.InviteToken _ -> "/"
             in  i <> " " <> n
       pure (ExitSuccess, map f profiles)
     Command.UpdateUser input -> do
@@ -1618,11 +1627,25 @@ filterUsers' predicate = do
   db <- asks _rDb
   liftIO . STM.atomically $ filterUsers db predicate
 
-createUser :: User.Signup -> RunM (Either User.Err User.UserId)
-createUser input = ML.localEnv (<> "Command" <> "Signup") $ do
+signupUser :: User.Signup -> RunM (Either User.Err User.UserId)
+signupUser input = ML.localEnv (<> "Command" <> "Signup") $ do
   ML.info "Creating user..."
   db   <- asks _rDb
-  muid <- liftIO . STM.atomically $ Core.createUser db input
+  muid <- liftIO . STM.atomically $ Core.signupUser db input
+  case muid of
+    Right (User.UserId uid, Email.EmailId eid) -> do
+      ML.info $ "User created: " <> uid
+      ML.info $ "Signup confirmation email enqueued: " <> eid
+      pure . Right $ User.UserId uid
+    Left err -> do
+      ML.info $ "Failed to create user: " <> show err
+      pure $ Left err
+
+inviteUser :: User.Invite -> RunM (Either User.Err User.UserId)
+inviteUser input = ML.localEnv (<> "Command" <> "Signup") $ do
+  ML.info "Creating user..."
+  db   <- asks _rDb
+  muid <- liftIO . STM.atomically $ Core.inviteUser db input
   case muid of
     Right (User.UserId uid, Email.EmailId eid) -> do
       ML.info $ "User created: " <> uid

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -917,7 +917,7 @@ handleSignup input@User.Signup {..} =
   ML.localEnv (<> "HTTP" <> "Signup")
     $   do
           ML.info $ "Signing up new user: " <> show username <> "..."
-          withRuntime $ Rt.createUser input
+          withRuntime $ Rt.signupUser input
     >>= \case
           Right uid -> do
             ML.info

--- a/tests/Curiosity/RuntimeSpec.hs
+++ b/tests/Curiosity/RuntimeSpec.hs
@@ -37,7 +37,7 @@ spec = do
       runtime <- bootDbAndLogFile emptyHask "/tmp/curiosity-test-xxx-3.log"
       let db = _rDb runtime
           input = Signup "alice" "secret" "alice@example.com" True
-      Right (uid, eid) <- atomically $ createUser db input
+      Right (uid, eid) <- atomically $ signupUser db input
       Just profile <- atomically $ selectUserById db uid
 
       uid `shouldBe` "USER-1"
@@ -49,6 +49,6 @@ spec = do
       runtime <- bootDbAndLogFile emptyHask "/tmp/curiosity-test-xxx-4.log"
       let db = _rDb runtime
           input = Signup "smartcoop" "secret" "smartcoop@example.com" True
-      muser <- atomically $ createUser db input
+      muser <- atomically $ signupUser db input
 
       muser `shouldBe` Left UsernameBlocked

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -126,7 +126,7 @@ spec = do
         mapM_
           go
           [ ("init --stepped", Data.emptyHask)
-          , ("user create alice a alice@example.com --accept-tos", aliceState)
+          , ("user signup alice a alice@example.com --accept-tos", aliceState)
           , ("step-email"    , aliceState')
           , ("reset"         , Data.emptyHask)
           ]


### PR DESCRIPTION
This PR changes the user profile data type so that having a username / password is optional. Instead, it is possible to be "invited" (a token is used to authenticate instead). Accepting the invitation (and providing a username and a password) is not yet implemented. The invitation command is `cty user invite`.

To make things clearer, `cty user create` is renamed to `cty user signup`.