### PR TITLE
Improve documentation, display individual emails

### DIFF
--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -79,6 +79,7 @@ common common-dependencies
     , blaze-html
     , blaze-markup
     , template-haskell
+    , time
     , unix
     , unix-time
   -- mixins: design-hs-lib hiding (Prelude)

--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -19,6 +19,10 @@ in
     virtualHosts."smartcoop.sh" = {
       locations = {
         "/".proxyPass = "http://127.0.0.1:9100";
+        "/about" = {
+          proxyPass = "http://127.0.0.1:9100";
+          extraConfig = "ssi on;";
+        };
         "/documentation" = {
           proxyPass = "http://127.0.0.1:9100";
           extraConfig = "ssi on;";

--- a/scripts/integration-tests/nginx.conf
+++ b/scripts/integration-tests/nginx.conf
@@ -38,6 +38,10 @@ http {
                 location / {
                         proxy_pass @curiosityaddr@;
                 }
+                location /about {
+                        proxy_pass @curiosityaddr@;
+                        ssi on;
+                }
                 location /documentation {
                         proxy_pass @curiosityaddr@;
                         ssi on;

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -11,78 +11,7 @@
 </head>
 
 <body class="u-maximize-height">
-    <header id="header">
-        <div class="o-container">
-            <div class="c-navbar c-navbar--bordered-bottom c-navbar--main">
-                <div class="c-toolbar">
-                    <div class="c-toolbar__left">
-                        <div class="c-toolbar__item">
-                            <div class="c-brand c-brand--small">
-                                <a href="/">
-                                    <img src="/static/images/logo.svg" alt="Smart" />
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="c-toolbar__right">
-                        <div class="c-toolbar__item">
-                            <!-- Nav for desktop-->
-                            <nav class="c-design-system-nav">
-                                <button class="c-button c-button--borderless c-button--icon c-design-system-nav-open" type="button" id="c-design-system-nav-open">
-                                    <span class="c-button__content">
-                                        <div class="o-svg-icon o-svg-icon-menu  ">
-                                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M4 7C4 6.44772 4.44772 6 5 6H19C19.5523 6 20 6.44772 20 7C20 7.55228 19.5523 8 19 8H5C4.44772 8 4 7.55228 4 7ZM4 12C4 11.4477 4.44772 11 5 11H19C19.5523 11 20 11.4477 20 12C20 12.5523 19.5523 13 19 13H5C4.44772 13 4 12.5523 4 12ZM4 17C4 16.4477 4.44772 16 5 16H19C19.5523 16 20 16.4477 20 17C20 17.5523 19.5523 18 19 18H5C4.44772 18 4 17.5523 4 17Z" fill="#595959" />
-                                            </svg>
-                                        </div>
-                                        <div class="u-sr-accessible">Open menu
-                                        </div>
-                                    </span>
-                                </button>
-                                <button class="c-button c-button--borderless c-button--icon c-design-system-nav-close" type="button" id="c-design-system-nav-close">
-                                    <span class="c-button__content">
-                                        <div class="o-svg-icon o-svg-icon-close  ">
-                                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M5.29289 5.2929C5.68342 4.90237 6.31658 4.90237 6.70711 5.2929L12 10.5858L17.2929 5.2929C17.6834 4.90237 18.3166 4.90237 18.7071 5.2929C19.0976 5.68342 19.0976 6.31659 18.7071 6.70711L13.4142 12L18.7071 17.2929C19.0976 17.6834 19.0976 18.3166 18.7071 18.7071C18.3166 19.0976 17.6834 19.0976 17.2929 18.7071L12 13.4142L6.70711 18.7071C6.31658 19.0976 5.68342 19.0976 5.29289 18.7071C4.90237 18.3166 4.90237 17.6834 5.29289 17.2929L10.5858 12L5.29289 6.70711C4.90237 6.31659 4.90237 5.68342 5.29289 5.2929Z" fill="#595959" />
-                                            </svg>
-                                        </div>
-                                        <div class="u-sr-accessible">Close menu
-                                        </div>
-                                    </span>
-                                </button>
-                                <div class="c-design-system-nav__mobile">
-                                    <ul>
-                                        <li>
-                                            <a href="/documentation">Documentation</a>
-                                        </li>
-                                        <li>
-                                            <a href="/login">Login</a>
-                                        </li>
-                                        <li>
-                                            <a href="/signup">Sign up</a>
-                                        </li>
-                                    </ul>
-                                </div>
-                                <div class="c-design-system-nav__desktop">
-                                    <ul class="c-pill-navigation">
-                                        <li class="c-pill-navigation__item">
-                                            <a href="/documentation">Documentation</a>
-                                        </li>
-                                        <li class="c-pill-navigation__item">
-                                            <a href="/login">Login</a>
-                                        </li>
-                                        <li class="c-pill-navigation__item">
-                                            <a href="/signup">Sign up</a>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </nav>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
+    <!--# include virtual="/partials/nav" -->
     <div class="o-container o-container--medium">
         <div class="o-container-vertical">
             <div class="c-display">

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -19,6 +19,7 @@ module Curiosity.Data.Email
   , EmailTemplate(..)
   , emailTemplateName
   , displayEmailBody
+  , displayEmailTitle
   , EmailState(..)
   , Predicate(..)
   , applyPredicate
@@ -92,6 +93,14 @@ emailTemplateName = \case
   QuotationEmail -> "Quotation"
   InvoiceEmail -> "Invoice"
   InvoiceReminderEmail -> "InvoiceReminder"
+
+displayEmailTitle :: EmailTemplate -> Text
+displayEmailTitle = \case
+  SignupConfirmationEmail -> "Signup confirmation"
+  InviteEmail _ -> "Invitation"
+  QuotationEmail -> "Quotation"
+  InvoiceEmail -> "Invoice"
+  InvoiceReminderEmail -> "Reminder"
 
 displayEmailBody :: EmailTemplate -> Text
 displayEmailBody = \case

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -18,6 +18,7 @@ module Curiosity.Data.Email
   , emailIdPrefix
   , EmailTemplate(..)
   , emailTemplateName
+  , displayEmailBody
   , EmailState(..)
   , Predicate(..)
   , applyPredicate
@@ -30,6 +31,7 @@ import           Data.Aeson
 import qualified Text.Blaze.Html5              as H
 import           Web.FormUrlEncoded             ( FromForm(..)
                                                 )
+import           Web.HttpApiData                ( FromHttpApiData(..) )
 
 --------------------------------------------------------------------------------
 systemEmailAddr :: User.UserEmailAddr
@@ -57,7 +59,7 @@ newtype EmailId = EmailId { unEmailId :: Text }
                         , H.ToMarkup
                         , H.ToValue
                         ) via Text
-               deriving FromForm via W.Wrapped "email-id" Text
+               deriving (FromHttpApiData, FromForm) via W.Wrapped "email-id" Text
 
 emailIdPrefix :: Text
 emailIdPrefix = "EMAIL-"
@@ -84,12 +86,20 @@ data EmailTemplate =
   deriving anyclass (ToJSON, FromJSON)
 
 emailTemplateName :: EmailTemplate -> Text
-emailTemplateName t = case t of
+emailTemplateName = \case
   SignupConfirmationEmail -> "SignupConfirmation"
   InviteEmail _ -> "Invite"
   QuotationEmail -> "Quotation"
   InvoiceEmail -> "Invoice"
   InvoiceReminderEmail -> "InvoiceReminder"
+
+displayEmailBody :: EmailTemplate -> Text
+displayEmailBody = \case
+  SignupConfirmationEmail -> "Hi, thank you for registering."
+  InviteEmail token -> "Hi, you've been invited to Curiosity. Here is a token: " <> token
+  QuotationEmail -> "Hi, here is a quotation."
+  InvoiceEmail -> "Hi, here is an invoice."
+  InvoiceReminderEmail -> "Hi, we didn't receive any payment for an invoice."
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Email.hs
+++ b/src/Curiosity/Html/Email.hs
@@ -76,16 +76,19 @@ panelEmail Email.Email {..} =
             (Email.unEmailId _emailId)
           keyValuePair
             "Template"
-            (Email.emailTemplateName _emailTemplate)
+            (H.code . H.text $ Email.emailTemplateName _emailTemplate)
           keyValuePair
             "Sender"
-            (User.unUserEmailAddr _emailSender)
+            (linkEmail $ User.unUserEmailAddr _emailSender)
           keyValuePair
             "Recipient"
-            (User.unUserEmailAddr _emailRecipient)
+            (linkEmail $ User.unUserEmailAddr _emailRecipient)
           keyValuePair
             "State"
-            (displayEmailState _emailState)
+            (H.code . H.text $ displayEmailState _emailState)
+          keyValuePair
+            "Title"
+            (Email.displayEmailTitle _emailTemplate)
           keyValuePair
             "Body"
             (Email.displayEmailBody _emailTemplate)

--- a/src/Curiosity/Html/Email.hs
+++ b/src/Curiosity/Html/Email.hs
@@ -3,7 +3,8 @@ Module: Curiosity.Html.Email
 Description: Page and components to display emails.
 -}
 module Curiosity.Html.Email
-  ( EmailPage(..)
+  ( EmailsPage(..)
+  , EmailPage(..)
   , panelSentEmails
   ) where
 
@@ -11,22 +12,38 @@ import qualified Curiosity.Data.Email          as Email
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
 import qualified Smart.Html.Misc               as Misc
+import           Text.Blaze.Html5               ( (!) )
 import           Text.Blaze.Html5               ( Html )
 import qualified Text.Blaze.Html5              as H
+import qualified Text.Blaze.Html5.Attributes   as A
 
 
 --------------------------------------------------------------------------------
--- | The page displaye at @/emails@ to show all enqueued emails.
-data EmailPage = EmailPage
-  { _emailPageUser   :: Maybe User.UserProfile
+-- | The page is served at @/emails@ to show all enqueued emails.
+data EmailsPage = EmailsPage
+  { _emailsPageUser   :: Maybe User.UserProfile
     -- ^ The logged-in user, if any.
-  , _emailPageEmails :: [Email.Email]
+  , _emailsPageEmails :: [Email.Email]
     -- ^ All enqueued emails.
   }
 
-instance H.ToMarkup EmailPage where
-  toMarkup (EmailPage mprofile emails) =
+instance H.ToMarkup EmailsPage where
+  toMarkup (EmailsPage mprofile emails) =
     renderView' mprofile $ panelSentEmails emails
+
+
+--------------------------------------------------------------------------------
+-- | The page is served at @/emails/<id>@ to show a specific email.
+data EmailPage = EmailPage
+  { _emailPageUser   :: Maybe User.UserProfile
+    -- ^ The logged-in user, if any.
+  , _emailPageEmail :: Email.Email
+    -- ^ The email to display.
+  }
+
+instance H.ToMarkup EmailPage where
+  toMarkup (EmailPage mprofile email) =
+    renderView' mprofile $ panelEmail email
 
 
 --------------------------------------------------------------------------------
@@ -41,10 +58,39 @@ panelSentEmails emails =
       , Email.emailTemplateName _emailTemplate
       , User.unUserEmailAddr _emailSender
       , User.unUserEmailAddr _emailRecipient
-      , case _emailState of
-          Email.EmailTodo -> "TODO"
-          Email.EmailDone -> "DONE"
+      , displayEmailState _emailState
       ]
     , []
-    , Nothing
+    , (Just $ "/emails/" <> Email.unEmailId _emailId)
     )
+
+-- | Display an email.
+panelEmail :: Email.Email -> Html
+panelEmail Email.Email {..} =
+  panel' "Email" $
+    H.dl
+      ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
+      $ do
+          keyValuePair
+            "ID"
+            (Email.unEmailId _emailId)
+          keyValuePair
+            "Template"
+            (Email.emailTemplateName _emailTemplate)
+          keyValuePair
+            "Sender"
+            (User.unUserEmailAddr _emailSender)
+          keyValuePair
+            "Recipient"
+            (User.unUserEmailAddr _emailRecipient)
+          keyValuePair
+            "State"
+            (displayEmailState _emailState)
+          keyValuePair
+            "Body"
+            (Email.displayEmailBody _emailTemplate)
+
+displayEmailState =
+  \case 
+    Email.EmailTodo -> "TODO"
+    Email.EmailDone -> "DONE"

--- a/src/Curiosity/Html/Homepage.hs
+++ b/src/Curiosity/Html/Homepage.hs
@@ -45,12 +45,7 @@ instance H.ToMarkup WelcomePage where
       $ H.div
       ! A.class_ "c-app-layout u-scroll-vertical"
       $ do
-          H.header
-            $ H.toMarkup
-            . navbar
-            . User.unUserName
-            . User._userCredsName
-            $ User._userProfileCreds welcomePageUser
+          header $ Just welcomePageUser
           H.main ! A.class_ "u-scroll-wrapper" $ do
             maybe (pure ()) panelEmailAddrToVerify welcomePageEmailAddrToVerify
 

--- a/src/Curiosity/Html/Misc.hs
+++ b/src/Curiosity/Html/Misc.hs
@@ -124,10 +124,10 @@ renderView content =
     $ H.div
     ! A.class_ "c-app-layout u-scroll-vertical"
     $ do
-        H.header $ H.toMarkup . navbar $ "TODO username"
+        H.toMarkup . navbar $ "TODO username"
         fullScroll content
 
-header mprofile = H.header $ case mprofile of
+header mprofile = case mprofile of
   Just profile ->
     H.toMarkup
       . navbar

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -12,6 +12,9 @@ import qualified Curiosity.Data.Legal          as Legal
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Html.Misc
 import           Curiosity.Html.Navbar          ( navbar )
+import qualified Data.Text                     as T
+import           Data.Time.Clock.POSIX          ( posixSecondsToUTCTime )
+import           Data.Time.Format.ISO8601       ( iso8601Show )
 import qualified Smart.Html.Dsl                as Dsl
 import           Smart.Html.Layout
 import qualified Smart.Html.Misc               as Misc
@@ -19,10 +22,10 @@ import qualified Smart.Html.Render             as Render
 import           Smart.Html.SideMenu            ( SideMenu(..)
                                                 , SideMenuItem(..)
                                                 )
+import           System.PosixCompat.Types       ( EpochTime )
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
-
 
 --------------------------------------------------------------------------------
 data EditProfilePage = EditProfilePage
@@ -70,8 +73,8 @@ instance H.ToMarkup EditProfilePage where
           "Registered since"
           "registered-since"
           ( Just
-          . H.toValue @Text
-          . show
+          . H.toValue
+          . formatEpochIso8601
           . User._userProfileRegistrationDate
           $ profile
           )
@@ -179,7 +182,11 @@ profileView profile entities hasEditButton =
             )
           keyValuePair
             "Registered since"
-            (H.text . show . User._userProfileRegistrationDate $ profile)
+            ( H.toHtml
+            . formatEpochIso8601
+            . User._userProfileRegistrationDate
+            $ profile
+            )
           maybe mempty
                 (keyValuePair "Twitter" . linkTwitter)
                 (User._userProfileTwitterUsername profile)
@@ -267,10 +274,18 @@ publicProfileView profile =
                 (User._userProfileBio profile)
           keyValuePair
             "Registered since"
-            (H.text . show . User._userProfileRegistrationDate $ profile)
+            ( H.toHtml
+            . formatEpochIso8601
+            . User._userProfileRegistrationDate
+            $ profile
+            )
           maybe mempty
                 (keyValuePair "Twitter" . linkTwitter)
                 (User._userProfileTwitterUsername profile)
 
     title' "Advisors" Nothing
     displayAdvisors $ User._userProfileAdvisors profile
+
+
+formatEpochIso8601 :: EpochTime -> Text
+formatEpochIso8601 = T.pack . iso8601Show . posixSecondsToUTCTime . realToFrac

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -68,6 +68,7 @@ module Curiosity.Runtime
   -- * Emails
   , filterEmails
   , filterEmails'
+  , selectEmailById
   -- * Servant compat
   , appMHandlerNatTrans
   -- * Re-exports for backwards compat: must be removed in the future.
@@ -1803,6 +1804,10 @@ setEmailDone db Email.Email {..} = do
       pure $ Right ()
     Nothing -> pure . Left $ Email.Err "Email not found" -- TODO
 
+selectEmailById :: Email.EmailId -> RunM (Maybe Email.Email)
+selectEmailById eid = do
+  db <- asks _rDb
+  liftIO . STM.atomically $ Core.selectEmailById db eid
 
 --------------------------------------------------------------------------------
 readForm

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -108,6 +108,8 @@ import           WaiAppStatic.Storage.Filesystem.Extended
                                                 )
 import           WaiAppStatic.Types             ( ss404Handler
                                                 , ssLookupFile
+                                                , ssMaxAge
+                                                , MaxAge(NoMaxAge)
                                                 )
 
 
@@ -2697,6 +2699,7 @@ serveDocumentation root = serveDirectoryWith settings
   settings = (defaultWebAppSettings root)
     { ss404Handler = Just custom404
     , ssLookupFile = webAppLookup hashFileIfExists root
+    , ssMaxAge = NoMaxAge
     }
 
 custom404 :: Application

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -59,6 +59,7 @@ import qualified Curiosity.Html.Homepage       as Pages
 import qualified Curiosity.Html.Invoice        as Pages
 import qualified Curiosity.Html.LandingPage    as Pages
 import qualified Curiosity.Html.Legal          as Pages
+import qualified Curiosity.Html.Misc           as Misc
 import qualified Curiosity.Html.Order          as Pages
 import qualified Curiosity.Html.Quotation      as Pages
 import qualified Curiosity.Html.Run            as Pages
@@ -493,6 +494,8 @@ type Partials =
        :> "state.json"
        :> Get '[JSON] (JP.PrettyJSON '[ 'JP.DropNulls] HaskDb)
 
+  :<|> "partials" :> "nav" :> H.UserAuthentication :> Get '[HTML] Html
+
   -- live data
   :<|> "partials" :> "legal-entities" :> Get '[HTML] Html
   :<|> "partials" :> "legal-entities.json" :> Get '[JSON] [Legal.Entity]
@@ -634,6 +637,8 @@ partials scenariosDir =
     :<|> partialScenario scenariosDir
     :<|> partialScenarioState scenariosDir
     :<|> partialScenarioStateAsJson scenariosDir
+
+    :<|> partialNav
 
     -- live data
     :<|> partialLegalEntities
@@ -880,6 +885,17 @@ partialLegalEntitiesAsJson = do
   db       <- asks Rt._rDb
   entities <- liftIO . atomically $ Rt.readLegalEntities db
   pure entities
+
+--------------------------------------------------------------------------------
+-- | render partial html with the main navigation bar. this is used within
+-- documentation. (the navigation is different depending on the user being
+-- logged in or not.)
+partialNav :: ServerC m => SAuth.AuthResult User.UserId -> m Html
+partialNav authResult = withMaybeUser
+  authResult
+  (\_ -> pure $ Misc.header Nothing)
+  (\profile -> pure . Misc.header $ Just profile
+  )
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
- The navigation bar in the documentation part of the web site now shows whether the user is logged in or not (just like in the rest of the site).
- The documentation part of the site was served with an aggressive cache control policy, which made the pages not refreshed after changes. This is now disabled.
- From the list of emails at `/emails`, it is now possible to see each individual email.
- Emails have now a body (a template) and a title, defined by their template name. Those are visible in the individual email view.