### PR TITLE
NixOS integration VM test

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,29 @@ $ run-full-environment
 ```
 
 It is also possible to only run Nginx in that shell with `run-nginx`. This is
-usefull for instance to proxy a `cty serve` running from GHCi.
+useful for instance to proxy a `cty serve` running from GHCi.
+
+The `run-vm-test` attribute let's you run a NixOS VM integration test
+that mirrors the production setup. You can run it either interactively
+or non-interactively:
+
+```sh
+$ nix-build -A run-vm-test
+# ^ Will run the VM test in a non interactive fashion.
+$ nix-build -A run-vm-test.driverInteractive && ./result/bin/nixos-test-driver
+> start_all( )
+# ^ Will open two qemu windows, one for the server, one for the client.
+
+```
+
+You can use the root account to interactively log in the VMs. The
+client can access to the server using the smartcoop.sh domain name.
+You can read the relevant [NixOS manual
+section](https://nixos.org/manual/nixos/stable/index.html#sec-running-nixos-tests-interactively)
+for more informations.
+
+Note: these VMs are not connected to internet, smartcoop.sh refers to
+the server VM, not the production machine in that context.
 
 And finally, we can run a local virtual machine running `cty serve` and a Nginx
 reverse proxy using [see below](#qemu):

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -154,6 +154,7 @@ library
     , memory
     , network
     , optparse-applicative
+    , systemd
     , unix-compat
     , wai-app-static
 

--- a/default.nix
+++ b/default.nix
@@ -33,6 +33,7 @@ in rec
     # Build with nix-build -A <attr>
     # binaries + haddock are also available as binaries.all.
     inherit nixpkgs binaries content data scenarios haddock run;
+    inherit (run) run-vm-test;
     static = (import "${sources.design-hs}").static;
     man-pages = (import ./man {}).man-pages;
     toplevel = os.config.system.build.toplevel;

--- a/modules/curiosity.nix
+++ b/modules/curiosity.nix
@@ -30,6 +30,28 @@
         --scenarios-dir ${(import ../.).scenarios} \
         --stdout
       '';
+
+      # Hardening Options
+      CapabilityBoundingSet = [ "" ];
+      DevicePolicy = "closed";
+      LockPersonality = true;
+      MemoryDenyWriteExecute = true;
+      NoNewPrivileges = true;
+      PrivateDevices = true;
+      ProtectClock = true;
+      ProtectHome = true;
+      ProtectHostname = true;
+      ProtectControlGroups = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      ProtectProc = "invisible";
+      ProcSubset = "pid";
+      RemoveIPC = true;
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
     };
   };
 }

--- a/scripts/integration-tests/default.nix
+++ b/scripts/integration-tests/default.nix
@@ -7,7 +7,7 @@
   scenarios ? (import ../../.).scenarios,
   system ? builtins.currentSystem,
   lib ? nixpkgs.lib
-}:
+}@attrs:
 
 let
   runCuriosity = nixpkgs.writers.writeBashBin "run-curiosity" ''
@@ -39,6 +39,7 @@ let
     set -euo pipefail
     ${nixpkgs.hivemind}/bin/hivemind ${procFile}
   '';
+  run-vm-test = import ./vm-test.nix attrs;
 in {
-  inherit run-full-environment run-nginx;
+  inherit run-full-environment run-nginx run-vm-test;
 }

--- a/scripts/integration-tests/test-curiosity.sh
+++ b/scripts/integration-tests/test-curiosity.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eu
+
+if [[ -z "${CURIOSITY_ENDPOINT:-}" ]]; then
+    scriptdir=$(realpath -s "$0" | xargs dirname)
+    echo "Missing curiosity endpoint."
+    echo "Did you read $scriptdir/readme.md ?"
+    exit 1
+fi
+
+echo "[+] Querying curiosity root endpoint"
+curl -s --show-error -f -v "$CURIOSITY_ENDPOINT" > /dev/null
+echo "[+] Checking that static assets are brotli-compressed"
+curl -s --show-error -H "Accept-Encoding: br" "$CURIOSITY_ENDPOINT"/static/css/main.css | brotli -d | grep "@charset"
+echo "[+] Checking that SSI is functional"
+curl -s --show-error "$CURIOSITY_ENDPOINT"/documentation/scenarios | grep 'href="/partials/scenarios/'

--- a/scripts/integration-tests/vm-test.nix
+++ b/scripts/integration-tests/vm-test.nix
@@ -1,0 +1,57 @@
+{
+  nixpkgs ? (import ../../.).nixpkgs,
+  binaries ? (import ../../.).binaries,
+  haddock ? (import ../../.).haddock,
+  content ? (import ../../.).content,
+  data ? (import ../../.).data,
+  scenarios ? (import ../../.).scenarios,
+  system ? builtins.currentSystem,
+  lib ? nixpkgs.lib
+}:
+
+let
+  x = x;
+  tls-cert = nixpkgs.runCommand "selfSignedCerts" { buildInputs = [ nixpkgs.openssl ]; } ''
+    openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -nodes -subj '/CN=${serverFqdn}' -days 36500
+    mkdir -p $out
+    cp key.pem cert.pem $out
+  '';
+  serverFqdn = "smartcoop.sh";
+  hosts = nodes: ''
+    ${nodes.server.config.networking.primaryIPAddress} ${serverFqdn}
+  '';
+in nixpkgs.nixosTest {
+  name = "curiosity-vm/test";
+  nodes = {
+    server = { nodes, pkgs, config, ...}: {
+      imports = [
+        ../../machine/configuration.nix
+      ];
+      security.pki.certificateFiles = [ "${tls-cert}/cert.pem" ];
+      networking.extraHosts = hosts nodes;
+      networking.firewall.enable = false;
+      services.nginx.virtualHosts."${serverFqdn}" = {
+        addSSL = true;
+        sslCertificate = "${tls-cert}/cert.pem";
+        sslCertificateKey = "${tls-cert}/key.pem";
+      };
+    };
+    client = { nodes, pkgs, config, ...}: {
+      security.pki.certificateFiles = [ "${tls-cert}/cert.pem" ];
+      networking.extraHosts = hosts nodes;
+      environment.systemPackages = [
+        pkgs.curl
+        pkgs.brotli
+      ];
+    };
+  };
+  testScript = ''
+    start_all()
+    server.wait_for_unit("nginx.service")
+    server.wait_for_unit("curiosity.service")
+    server.wait_for_unit("multi-user.target")
+    client.wait_for_unit("multi-user.target")
+    client.succeed('CURIOSITY_ENDPOINT="https://${serverFqdn}" ${nixpkgs.bash}/bin/bash -c ${./test-curiosity.sh}')
+    exit(0)
+  '';
+}


### PR DESCRIPTION
We introduce a NixOS VM integration test. For now, this test only makes sure the production environment is able to serve a page, checks the static assets are correctly brotli-compressed and makes sure the nginx SSI setup works as expected.

A startup race condition pushed me to perform a small invasive change to the server in https://github.com/hypered/curiosity/commit/78d909da4fa1e4f0196c8f444c36d6239b7590a2. If you're not willing to send this systemd notify UDP packet from the server, we have another more hacky option consisting in curl-polling the webpage from the client VM until the server is up and running before conducting the test. The systemd-notify systemd is cleaner, though, and is also helpful in a production environment.

Note: I took advantage of this PR to add some hardening options to the curiosity systemd service. Granted the production environment is not really critical ATM, still, it won't hurt.

See individual commit messages and readme documentation for more information.