### PR TITLE
Introduce basic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'ci-*'
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v17
+      with:
+        nix_path: nixpkgs=channel:nixos-22.05
+
+    - name: Build Curiosity
+      run: nix-build -A binaries --show-trace

--- a/default.nix
+++ b/default.nix
@@ -33,7 +33,7 @@ in rec
     # Build with nix-build -A <attr>
     # binaries + haddock are also available as binaries.all.
     inherit nixpkgs binaries content data scenarios haddock run;
-    static = (import "${sources.design-hs}").static;
+    static = (import "${sources.smart-design-hs}").static;
     man-pages = (import ./man {}).man-pages;
     toplevel = os.config.system.build.toplevel;
     image = os.config.system.build.digitalOceanImage;

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -4,14 +4,14 @@
 let
 
   sources = import ./sources.nix;
-  inherit (sources) commence design-hs; 
+  inherit (sources) commence smart-design-hs;
 
   getOverlays = pkg : import "${pkg}/nix/overlays.nix";
 
   # We can overlay haskell packages here.
   haskellOverlays =
           getOverlays commence # we get 2 packages: commence-core and commence-interactive-state
-       ++ getOverlays design-hs
+       ++ getOverlays smart-design-hs
        ;
 
 in haskellOverlays ++ [ (import ./overlay.nix) ]

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -7,15 +7,15 @@
     },
     "commence": {
         "branch": "main",
-        "repo": "git@github.com:hypered/commence.git",
+        "description": "Building blocks to prototype classical three-tier web applications with Servant and STM",
+        "homepage": null,
+        "owner": "hypered",
+        "repo": "commence",
         "rev": "9ab2e5bc2e4b278477a3df77270e2d62ac8acc4c",
-        "type": "git"
-    },
-    "design-hs": {
-        "branch": "main",
-        "repo": "git@github.com:hypered/smart-design-hs.git",
-        "rev": "4233098ba310370587f1b5548e2d78c2d8e0353d",
-        "type": "git"
+        "sha256": "0l4s5y7gmxr7y56q4sqk7mn0aknqa55vl4f5iyvmbcwrs5kgbgmz",
+        "type": "tarball",
+        "url": "https://github.com/hypered/commence/archive/9ab2e5bc2e4b278477a3df77270e2d62ac8acc4c.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "gitignore": {
         "branch": "master",
@@ -63,6 +63,18 @@
         "sha256": "1q8hin4wj8iic4f9nlrpfh3pnyba1v89hfv9vlkgii37v44yl5cr",
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/b3a8f7ed267e0a7ed100eb7d716c9137ff120fe3.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "smart-design-hs": {
+        "branch": "main",
+        "description": "An implementation of smartcoop/design in Haskell ",
+        "homepage": "https://design.smartcoop.sh",
+        "owner": "hypered",
+        "repo": "smart-design-hs",
+        "rev": "4233098ba310370587f1b5548e2d78c2d8e0353d",
+        "sha256": "1p5nd1mpnd7y2hfm8zjnc9l503whahlzb3whhnqh1iqwz252ryqs",
+        "type": "tarball",
+        "url": "https://github.com/hypered/smart-design-hs/archive/4233098ba310370587f1b5548e2d78c2d8e0353d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Introduce a GitHub actions based CI job. This job builds and test curiosity through its nix build.

Test run logs (on my fork): https://github.com/NinjaTrappeur/curiosity/actions/runs/3490071859/jobs/5841018110

I had to alter some niv sources to simplify the CI setup. See the https://github.com/hypered/curiosity/commit/f7f7089e0451bb94ee554efb7beacf61a31b5633 commit message for more details.

I'd probably make sense to introduce some kind of Nix cache. As it is, we'll rebuild some Haskell dependencies for every commit. We could probably discuss this synchronously as a followup to this PR.