### PR TITLE
CI: Push build artifacts to a Nix binary cache.

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,10 @@
+# GitHub Actions CI
+
+On top of building and testing the curiosity codebase, this CI pipeline is also in charge of populating the Nix binary cache.
+
+We currently store this binary cache in a Backblaze B2 bucket.
+
+This pipeline is relying on some [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets):
+
+- `NIX_PUB_KEY` and `NIX_SIGNING_KEY`: respectively the public and private key used to sign the binary cache NARs. You can generate such a key using `nix-store --generate-binary-cache-key curiosity-store cache-priv-key.pem cache-pub-key.pem`.
+- `B2_APPKEY_ID` and `B2_APPKEY`: respectively the B2 bucket key id and the associated private key.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,27 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v17
+      uses: cachix/install-nix-action@v18
+      env:
+        SIGNING_PUB: ${{ secrets.NIX_PUB_KEY }}
       with:
         nix_path: nixpkgs=channel:nixos-22.05
+        extra_nix_config: |
+          post-build-hook = /etc/nix/post-build-hook
+          substituters = https://s3.eu-central-003.backblazeb2.com/curiosity-store/ https://cache.nixos.org/
+          trusted-public-keys = curiosity-store:W3LXUB+6DjtZkKV0gEfNXGtTjA+hMqjPUoK6mzzco+w= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+
+    - name: Setup Nix Cache
+      env:
+        SIGNING_KEY: ${{ secrets.NIX_SIGNING_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.B2_APPKEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.B2_APPKEY }}
+      run: |
+        sudo bash -c "echo ${SIGNING_KEY} > /etc/nix/key.private"
+        sudo mkdir -p /run/keys
+        sudo bash -c "echo ${AWS_ACCESS_KEY_ID} > /run/keys/AWS_ACCESS_KEY_ID"
+        sudo bash -c "echo ${AWS_SECRET_ACCESS_KEY} > /run/keys/AWS_SECRET_ACCESS_KEY"
+        sudo cp .github/workflows/post-build-hook /etc/nix/post-build-hook
 
     - name: Build Curiosity
       run: nix-build -A binaries --show-trace

--- a/.github/workflows/post-build-hook
+++ b/.github/workflows/post-build-hook
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eu
+set -f
+export IFS=' '
+# Adding back the nix profile to the $PATH, it's originally missing.
+# I assume cachix/install-nix-action only change the user's $PATH.
+PATH=/nix/var/nix/profiles/default/bin:$PATH
+export AWS_ACCESS_KEY_ID=$(cat /run/keys/AWS_ACCESS_KEY_ID)
+export AWS_SECRET_ACCESS_KEY=$(cat /run/keys/AWS_SECRET_ACCESS_KEY)
+
+echo "Signing paths" $OUT_PATHS
+nix store sign --key-file /etc/nix/key.private $OUT_PATHS
+echo "Uploading paths" $OUT_PATHS
+exec nix copy \
+     --to 's3://curiosity-store?endpoint=s3.eu-central-003.backblazeb2.com' \
+     --secret-key-files /etc/nix/key.private \
+     $OUT_PATHS

--- a/README.md
+++ b/README.md
@@ -206,6 +206,26 @@ Right (UsersVisualised [UserProfile {_userCreds = UserCreds {_userCredsId = User
 
 ```
 
+# Nix Cache
+
+You can re-use the curiosity binaries built by the CI through a custom Nix binary cache.
+
+On a NixOS system add the following snippet to your system configuration:
+
+```nix
+nix.settings = {
+  substituters = [ "https://s3.eu-central-003.backblazeb2.com/curiosity-store/" "https://cache.nixos.org/" ];
+  trusted-public-keys = [ "curiosity-store:W3LXUB+6DjtZkKV0gEfNXGtTjA+hMqjPUoK6mzzco+w=" "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" ];
+}
+```
+
+On a non-NixOS system, you can edit the `/etc/nix/nix.conf` file and set the `substituters` and `trusted-public-keys` configuration attributes to:
+
+```
+substituters = https://s3.eu-central-003.backblazeb2.com/curiosity-store/ https://cache.nixos.org/
+trusted-public-keys = curiosity-store:W3LXUB+6DjtZkKV0gEfNXGtTjA+hMqjPUoK6mzzco+w= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+```
+
 # Docker image
 
 A Docker image can be built to experiment with the `cty` program, and have


### PR DESCRIPTION
Continuation of https://github.com/hypered/curiosity/pull/113

We add a Nix post-build hook to the GitHub action build pipeline that pushes the produced store paths to a backblaze object storage.

We configure the object storage as a binary cache for the builder to speed up the build phase by caching the dependencies builds.