### PR TITLE
Code cleaning

### DIFF
--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -192,6 +192,7 @@ test-suite curiosity-tests
     , Curiosity.CommandSpec
     , Curiosity.CoreSpec
     , Curiosity.DataSpec
+    , Curiosity.DslSpec
     , Curiosity.RunSpec
     , Curiosity.RuntimeSpec
   type: exitcode-stdio-1.0

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -85,7 +85,8 @@ data Command =
     -- ^ Show a given user. If True, use Haskell format instead of JSON. If
     -- True, show only the user ID and username.
   | FilterUsers User.Predicate
-  | UpdateUser (S.DBUpdate User.UserProfile)
+  | UpdateUser User.Update
+  | DeleteUser User.UserId
   | SetUserEmailAddrAsVerified User.UserName
     -- ^ High-level operations on users.
   | SignQuotation Quotation.QuotationId
@@ -662,11 +663,11 @@ parserUser = A.subparser
        "invite"
        (A.info (parserInvite <**> A.helper) $ A.progDesc "Invite a new user")
   <> A.command
-       "delete"
-       (A.info (parserDeleteUser <**> A.helper) $ A.progDesc "Delete a user")
-  <> A.command
        "update"
        (A.info (parserUpdateUser <**> A.helper) $ A.progDesc "Update a user")
+  <> A.command
+       "delete"
+       (A.info (parserDeleteUser <**> A.helper) $ A.progDesc "Delete a user")
   <> A.command
        "get"
        (A.info (parserGetUser <**> A.helper) $ A.progDesc "Select a user")
@@ -710,9 +711,6 @@ parserInvite = do
   email <- A.argument A.str (A.metavar "EMAIL" <> A.help "An email address")
   pure $ Invite $ User.Invite email
 
-parserDeleteUser :: A.Parser Command
-parserDeleteUser = UpdateUser . User.UserDelete <$> argumentUserId
-
 parserUpdateUser :: A.Parser Command
 parserUpdateUser = do
   uid      <- argumentUserId
@@ -725,9 +723,10 @@ parserUpdateUser = do
     <> A.help "Twitter username."
     <> A.metavar "USERNAME"
     )
-  pure $ UpdateUser . User.UserUpdate uid $ User.Update (Just name)
-                                                        (Just bio)
-                                                        mtwitter
+  pure $ UpdateUser $ User.Update uid (Just name) (Just bio) mtwitter
+
+parserDeleteUser :: A.Parser Command
+parserDeleteUser = DeleteUser <$> argumentUserId
 
 parserGetUser :: A.Parser Command
 parserGetUser =

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -540,14 +540,6 @@ parserBusinessUnitLinkUser = do
     )
   pure $ LinkBusinessUnitToUser slug uid role
 
-argumentUnitId = Legal.EntityId <$> A.argument A.str metavarUnitId
-
-metavarUnitId = A.metavar "BENT-ID" <> A.completer complete <> A.help
-  "A business unit ID"
-  where complete = A.mkCompleter . const $ pure ["LENT-", "LENT-1", "LENT-2"]
-        -- TODO I'd like to lookup IDs in the state, but here we don't know
-        -- where the state is (it depends on other command-line options).
-
 argumentUnitSlug = A.argument A.str metavarUnitSlug
 
 metavarUnitSlug = A.metavar "SLUG" <> A.completer complete <> A.help
@@ -636,14 +628,6 @@ parserUpdateLegalEntityIsHost :: Bool -> A.Parser Command
 parserUpdateLegalEntityIsHost b = do
   slug <- argumentEntitySlug
   pure $ UpdateLegalEntityIsHost slug b
-
-argumentEntityId = Legal.EntityId <$> A.argument A.str metavarEntityId
-
-metavarEntityId = A.metavar "LENT-ID" <> A.completer complete <> A.help
-  "A legal entity ID"
-  where complete = A.mkCompleter . const $ pure ["LENT-", "LENT-1", "LENT-2"]
-        -- TODO I'd like to lookup IDs in the state, but here we don't know
-        -- where the state is (it depends on other command-line options).
 
 argumentEntitySlug = A.argument A.str metavarEntitySlug
 

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -15,7 +15,6 @@ module Curiosity.Command
   , commandToString
   ) where
 
-import qualified Commence.Runtime.Storage      as S
 import qualified Curiosity.Data                as Data
 import qualified Curiosity.Data.Business       as Business
 import qualified Curiosity.Data.Email          as Email

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -9,7 +9,7 @@ module Curiosity.Core
   , instantiateStmDb
   , reset
   , readFullStmDbInHask'
-  , signupUser
+  , signup
   , inviteUser
   , createUserFull
   , modifyUsers
@@ -292,16 +292,16 @@ generateEmailId Db {..} =
 
 
 --------------------------------------------------------------------------------
-signupUser
+signup
   :: StmDb -> User.Signup -> STM (Either User.Err (User.UserId, Email.EmailId))
-signupUser db signup@User.Signup {..} = do
+signup db input@User.Signup {..} = do
   STM.catchSTM (Right <$> transaction) (pure . Left)
  where
   transaction = do
     now        <- readTime db
     newId      <- generateUserId db
     newProfile <-
-      pure (User.validateSignup now newId signup)
+      pure (User.validateSignup now newId input)
         >>= either (STM.throwSTM . User.ValidationErrs) pure
     emailId <-
       createEmail db Email.SignupConfirmationEmail Email.systemEmailAddr email

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -20,6 +20,7 @@ module Curiosity.Core
   , selectUserByInviteToken
   , modifyQuotations
   , selectQuotationById
+  , checkCredentials
   -- * ID generation
   , generateUserId
   , generateBusinessId
@@ -437,6 +438,22 @@ selectUserByInviteToken db token = do
   records <- STM.readTVar tvar
   pure $ find ((== Just token) . User.getInviteToken . User._userProfileCreds)
               records
+
+
+--------------------------------------------------------------------------------
+checkCredentials
+  :: StmDb -> User.Credentials -> STM (Maybe User.UserProfile)
+checkCredentials db User.Credentials {..} = do
+  mprofile <- selectUserByUsername db _userCredsName
+  case mprofile of
+    Just profile | User.checkPassword profile _userCredsPassword ->
+      pure $ Just profile
+    _ -> pure Nothing
+checkCredentials db User.InviteToken {..} = do
+  mprofile <- selectUserByInviteToken db _inviteToken
+  case mprofile of
+    Just profile -> pure $ Just profile
+    _ -> pure Nothing
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -137,7 +137,8 @@ instance FromForm Login where
 
 -- | Represents the input data to update a user profile.
 data Update = Update
-  { _updateDisplayName     :: Maybe UserDisplayName
+  { _updateUserId          :: UserId
+  , _updateDisplayName     :: Maybe UserDisplayName
   , _updateBio             :: Maybe Text
   , _updateTwitterUsername :: Maybe Text
   }
@@ -146,9 +147,10 @@ data Update = Update
 instance FromForm Update where
   fromForm f =
     Update
-      <$> parseMaybe "display-name"     f
-      <*> parseMaybe "bio"              f
-      <*> parseMaybe "twitter-username" f
+      <$> parseUnique "user-id"          f
+      <*> parseMaybe  "display-name"     f
+      <*> parseMaybe  "bio"              f
+      <*> parseMaybe  "twitter-username" f
 
 
 --------------------------------------------------------------------------------
@@ -321,19 +323,12 @@ instance Storage.DBIdentity UserProfile where
 
 instance Storage.DBStorageOps UserProfile where
   data DBUpdate UserProfile =
-    UserCreate UserProfile
-    | UserDelete UserId
-    | UserUpdate UserId Update
+      UserDelete UserId
     deriving (Show, Eq)
   
   data DBSelect UserProfile =
-    -- | Attempt a user-login using the more ambiguous but more friendly
-    -- `UserName` and `Password.
-    UserLoginWithUserName Credentials
     -- | Select a user with a known `UserId`.
-    | SelectUserById UserId
-    -- | Select a user with `UserName`.
-    | SelectUserByUserName UserName
+      SelectUserById UserId
     deriving (Show, Eq)
 
 -- | Predicates to filter users.

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -322,7 +322,6 @@ instance Storage.DBIdentity UserProfile where
 instance Storage.DBStorageOps UserProfile where
   data DBUpdate UserProfile =
     UserCreate UserProfile
-    | UserCreateGeneratingUserId Signup
     | UserDelete UserId
     | UserUpdate UserId Update
     deriving (Show, Eq)

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -57,9 +57,6 @@ module Curiosity.Data.User
   , firstUserRights
   , validateSignup
   , validateSignup'
-  -- * Export all DB ops.
-  , Storage.DBUpdate(..)
-  , Storage.DBSelect(..)
   -- * Errors
   , Err(..)
   , userNotFound
@@ -67,7 +64,6 @@ module Curiosity.Data.User
   ) where
 
 import qualified Commence.Runtime.Errors       as Errs
-import qualified Commence.Runtime.Storage      as Storage
 import qualified Commence.Types.Secret         as Secret
 import qualified Commence.Types.Wrapped        as W
 import           Control.Lens
@@ -316,20 +312,6 @@ instance Nav.IsNavbarContent UserProfile where
     greeting = H.div . H.text $ T.unwords
       ["Hi", _userCredsName _userProfileCreds ^. coerced]
     editProfileLink = H.a ! A.href "/settings/profile" $ "Edit profile"
-
-instance Storage.DBIdentity UserProfile where
-  type DBId UserProfile = UserId
-  dbId = _userProfileId
-
-instance Storage.DBStorageOps UserProfile where
-  data DBUpdate UserProfile =
-      UserDelete UserId
-    deriving (Show, Eq)
-  
-  data DBSelect UserProfile =
-    -- | Select a user with a known `UserId`.
-      SelectUserById UserId
-    deriving (Show, Eq)
 
 -- | Predicates to filter users.
 data Predicate = PredicateEmailAddrToVerify | PredicateHas AccessRight

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -15,7 +15,7 @@ module Curiosity.Dsl
   , user
   , signup
   , can
-  , example
+  , example0
   ) where
 
 import qualified Control.Concurrent.STM        as STM
@@ -70,9 +70,9 @@ can profile name = ask >>= (Run . lift . flip (Core.canPerform name) profile)
 
 --------------------------------------------------------------------------------
 -- In a GHCi session, e.g. obtained with scripts/ghci-dsl.sh:
---     ghci> run db0 example
-example :: Run (Bool, Bool)
-example = do
+--     ghci> run db0 example0
+example0 :: Run (Bool, Bool)
+example0 = do
   signup "alice" "a" "alice@example.com"
   signup "bob"   "b" "bob@example.com"
 

--- a/src/Curiosity/Dsl.hs
+++ b/src/Curiosity/Dsl.hs
@@ -61,7 +61,7 @@ signup
   -> User.UserEmailAddr
   -> Run (Either User.Err (User.UserId, Email.EmailId))
 signup username password email =
-  ask >>= (Run . lift . flip Core.signupUser input)
+  ask >>= (Run . lift . flip Core.signup input)
   where input = User.Signup username password email True
 
 can :: User.UserProfile -> Syntax.Name -> Run Bool

--- a/src/Curiosity/Html/Action.hs
+++ b/src/Curiosity/Html/Action.hs
@@ -123,14 +123,6 @@ instance H.ToMarkup EchoPage where
       panelWrapper
         $ H.div ! A.class_ "c-display" $
           H.pre . H.code $ H.text _echoPageContent
-   where
-    withText msg =
-      Render.renderCanvas
-        $ Dsl.SingletonCanvas
-        $ H.div
-        ! A.class_ "c-display"
-        $ H.code
-        $ H.toMarkup msg
 
 -- | Similar to `EchoPage` but also shows validation errors
 data EchoPage' = EchoPage'
@@ -152,11 +144,3 @@ instance H.ToMarkup EchoPage' where
               H.pre . H.code $ "Valid."
             else
               H.pre . H.code . H.text $ unlines _echoPage'Errors
-   where
-    withText msg =
-      Render.renderCanvas
-        $ Dsl.SingletonCanvas
-        $ H.div
-        ! A.class_ "c-display"
-        $ H.code
-        $ H.toMarkup msg

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -217,9 +217,9 @@ displayAdvisors (Just (User.Advisors {..})) = do
   H.text . User.unUserId $ _userAdvisorsCurrent
   "Past advisors:"
   H.ul $ mapM_
-    (\(from, to, id) -> H.li
+    (\(since, till, id) -> H.li
       (  H.text (User.unUserId id)
-      >> H.text (" (From " <> show from <> ", to " <> show to <> ")")
+      >> H.text (" (From " <> show since <> ", to " <> show till <> ")")
       )
     )
     _userAdvisorsPast

--- a/src/Curiosity/Html/User.hs
+++ b/src/Curiosity/Html/User.hs
@@ -37,6 +37,11 @@ instance H.ToMarkup EditProfilePage where
   toMarkup (EditProfilePage profile submitUrl) =
     renderForm profile $ groupLayout $ do
       title "User profile"
+      H.input
+        ! A.type_ "hidden"
+        ! A.id "user-id"
+        ! A.name "user-id"
+        ! A.value (H.toValue $ User._userProfileId profile)
       disabledText
           "Username"
           "username"

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -121,14 +121,14 @@ run (Command.CommandWithTarget (Command.Run conf scriptPath runOutput) target (C
 
 run (Command.CommandWithTarget (Command.Parse confParser) _ _) =
   case confParser of
-    Command.ConfCommand command -> do
+    Command.ConfCommand input -> do
       let result =
             A.execParserPure A.defaultPrefs Command.parserInfo
               $   T.unpack
-              <$> T.words command
+              <$> T.words input
       case result of
-        A.Success x -> do
-          print x
+        A.Success command -> do
+          print command
           exitSuccess
         A.Failure err -> do
           print err

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -82,7 +82,6 @@ module Curiosity.Runtime
 
 import qualified Commence.Multilogging         as ML
 import qualified Commence.Runtime.Errors       as Errs
-import qualified Commence.Runtime.Storage      as S
 import qualified Control.Concurrent.STM        as STM
 import           Control.Lens                  as Lens
 import "exceptions" Control.Monad.Catch         ( MonadCatch
@@ -1694,7 +1693,7 @@ createTwoRemittanceAdvs db = do
 selectUserByIdResolved db id = do
   let usersTVar = Data._dbUserProfiles db
   users' <- STM.readTVar usersTVar
-  case find ((== id) . S.dbId) users' of
+  case find ((== id) . User._userProfileId) users' of
     Just user -> do
       entities <- selectEntitiesWhereUserId db $ User._userProfileId user
       pure $ Just (user, entities)

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -25,7 +25,7 @@ module Curiosity.Runtime
   , selectUserByUsernameResolved
   , filterUsers
   , filterUsers'
-  , signupUser
+  , signup
   -- * High-level entity operations
   , selectEntityBySlug
   , selectEntityBySlugResolved
@@ -494,7 +494,7 @@ handleCommand runtime@Runtime {..} user command = do
           pure (ExitSuccess, ["Legal entity updated: " <> slug])
         Left err -> pure (ExitFailure 1, [show err])
     Command.Signup input -> do
-      muid <- stepRunM runtime $ signupUser input
+      muid <- stepRunM runtime $ signup input
       case muid of
         Right (User.UserId uid, Email.EmailId eid) -> pure
           ( ExitSuccess
@@ -1724,12 +1724,12 @@ filterUsers' predicate = do
   db <- asks _rDb
   atomicallyM $ filterUsers db predicate
 
-signupUser
+signup
   :: User.Signup -> RunM (Either User.Err (User.UserId, Email.EmailId))
-signupUser input = ML.localEnv (<> "Command" <> "Signup") $ do
+signup input = ML.localEnv (<> "Command" <> "Signup") $ do
   ML.info "Signing up new user..."
   db   <- asks _rDb
-  muid <- atomicallyM $ Core.signupUser db input
+  muid <- atomicallyM $ Core.signup db input
   case muid of
     Right (User.UserId uid, Email.EmailId eid) -> do
       ML.info $ "User created: " <> uid

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -103,7 +103,8 @@ import qualified Curiosity.Data.SimpleContract as SimpleContract
 import qualified Curiosity.Data.User           as User
 import           Curiosity.Runtime.Error       as RErr
 import           Curiosity.Runtime.IO          as RIO
-import           Curiosity.Runtime.IO.AppM     as AppM
+import           Curiosity.Runtime.IO.AppM      ( AppM, runAppM, runAppMSafe )
+import qualified Curiosity.Runtime.IO.AppM     as AppM
 import           Curiosity.Runtime.Type        as RType
 import           Curiosity.STM.Helpers          ( atomicallyM )
 import qualified Data.Aeson.Text               as Aeson

--- a/src/Curiosity/Runtime/IO/AppM.hs
+++ b/src/Curiosity/Runtime/IO/AppM.hs
@@ -80,9 +80,6 @@ instance S.DBStorage AppM STM User.UserProfile where
 
     User.UserCreate input -> second pure <$> Core.createUserFull db input
 
-    User.UserCreateGeneratingUserId input ->
-      second (pure . fst) <$> Core.signupUser db input
-
     User.UserDelete id ->
       S.dbSelect @AppM @STM db (User.SelectUserById id) <&> headMay >>= maybe
         (pure . User.userNotFound $ show id)

--- a/src/Curiosity/Runtime/IO/AppM.hs
+++ b/src/Curiosity/Runtime/IO/AppM.hs
@@ -8,15 +8,11 @@ module Curiosity.Runtime.IO.AppM
 
 import qualified Commence.Multilogging         as ML
 import qualified Commence.Runtime.Errors       as Errs
-import qualified Control.Concurrent.STM        as STM
 import           Control.Lens                  as Lens
 import "exceptions" Control.Monad.Catch         ( MonadCatch
                                                 , MonadMask
                                                 , MonadThrow
                                                 )
-import qualified Curiosity.Core                as Core
-import qualified Curiosity.Data                as Data
-import qualified Curiosity.Data.User           as User
 import           Curiosity.Runtime.Type        as RType
 import           Prelude                 hiding ( state )
 

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -946,13 +946,10 @@ handleSignup input@User.Signup {..} =
   ML.localEnv (<> "HTTP" <> "Signup")
     $   do
           ML.info $ "Signing up new user: " <> show username <> "..."
-          withRuntime $ Rt.signupUser input
+          withRuntime $ Rt.signup input
     >>= \case
-          Right uid -> do
-            ML.info
-              $  "User created: "
-              <> show uid
-              <> ". Sending success result."
+          Right _ -> do
+            ML.info "Sending success result."
             pure Signup.SignupSuccess
           Left err -> do
             ML.info

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -971,7 +971,7 @@ handleLogin conf jwtSettings input =
                                              (User._loginPassword input)
           db <- asks Rt._rDb
           liftIO
-            . atomically $ Rt.checkCredentials db credentials
+            . atomically $ Core.checkCredentials db credentials
     >>= \case
           Just u -> do
             ML.info "Found user, applying authentication cookies..."

--- a/tests/Curiosity/DslSpec.hs
+++ b/tests/Curiosity/DslSpec.hs
@@ -1,0 +1,15 @@
+module Curiosity.DslSpec
+  ( spec
+  ) where
+
+import           Curiosity.Dsl
+import           Test.Hspec
+
+
+--------------------------------------------------------------------------------
+spec :: Spec
+spec = do
+  describe "Dsl" $ do
+    it ("The example runs.") $ do
+      result <- run db0 example0
+      result `shouldBe` (True, False)

--- a/tests/Curiosity/RuntimeSpec.hs
+++ b/tests/Curiosity/RuntimeSpec.hs
@@ -37,7 +37,7 @@ spec = do
       runtime <- bootDbAndLogFile emptyHask "/tmp/curiosity-test-xxx-3.log"
       let db = _rDb runtime
           input = Signup "alice" "secret" "alice@example.com" True
-      Right (uid, eid) <- atomically $ signupUser db input
+      Right (uid, eid) <- atomically $ signup db input
       Just profile <- atomically $ selectUserById db uid
 
       uid `shouldBe` "USER-1"
@@ -49,6 +49,6 @@ spec = do
       runtime <- bootDbAndLogFile emptyHask "/tmp/curiosity-test-xxx-4.log"
       let db = _rDb runtime
           input = Signup "smartcoop" "secret" "smartcoop@example.com" True
-      muser <- atomically $ signupUser db input
+      muser <- atomically $ signup db input
 
       muser `shouldBe` Left (ValidationErrs [UsernameBlocked])

--- a/tests/CuriositySpec.hs
+++ b/tests/CuriositySpec.hs
@@ -95,6 +95,7 @@ spec = do
 
     malice <- runIO $ parseFile "data/alice.json"
     case malice of
+      Left err -> runIO $ "x" `shouldBe` err -- TODO How to make it fail ?
       Right alice -> do
         let aliceState = Data.emptyHask
               { Data._dbNextUserId   = C.CounterValue 2


### PR DESCRIPTION
These changes mostly rename some functions to be more consistent, remove unused code, and make compilation warning-free.

Another change is that we no longer use `Commence.Runtime.Storage`. It was seldom used (i.e. only by some `UserProfile` operations, and in only some routes in `Server.hs`). This allows to move `checkCredentials` and `checkPassword` in the right modules (pure code in `Data` and STM-based code in `Core`).