### PR TITLE
Use Ormolu, together with treefmt.

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,10 +1,4 @@
 {
-    "brittany": {
-        "branch": "master",
-        "repo": "https://github.com/lspitzner/brittany",
-        "rev": "0aa04af4eba499b81fdfb401d98414e7731583cc",
-        "type": "git"
-    },
     "commence": {
         "branch": "main",
         "description": "Building blocks to prototype classical three-tier web applications with Servant and STM",

--- a/shell.nix
+++ b/shell.nix
@@ -23,9 +23,7 @@ let
   haskell-tooling = with hp; [ cabal-install ghcid hlint hasktags ];
 
   # Add more as we need them.
-  formatters =
-    let brittany = hp.callCabal2nix "brittany" sources.brittany { };
-    in [ brittany ];
+  formatters = [ nixpkgs.ormolu nixpkgs.treefmt ] ;
 
   system-tooling = with nixpkgs; [
     inotify-tools # needed for HotExe.sh (filesystem notifs.)

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,12 @@
+[formatter.haskell]
+command = "ormolu"
+options = [
+    "--ghc-opt",
+    "-XImportQualifiedPost",
+    "--ghc-opt",
+    "-XTypeApplications",
+    "--mode",
+    "inplace",
+    "--check-idempotence"
+]
+includes = ["*.hs"]


### PR DESCRIPTION
This adds Ormolu as the Haskell source code formatter, replacing Brittany. Brittany is unmaintained since 2022-11-11. This also adds a `treefmt` configuration file to drive Ormolu. That configuration could be extended in the future to e.g. also format Nix expressions. 