### PR TITLE
Use nix-build-uncached

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
         sudo cp .github/workflows/post-build-hook /etc/nix/post-build-hook
 
     - name: Build Curiosity
-      run: nix-build -A toplevel --show-trace
+      run: nix-shell -p nix-build-uncached --run 'nix-build-uncached -build-flags "--experimental-features nix-command" -A toplevel'


### PR DESCRIPTION
This is a Draft because this doesn't seem to work.

This avoids a build if the result is already in the cache, including copying the result from the cache to local Nix store. This is especially useful in a continuous integration system where we don't care about the Nix store (since it will be thrown away at the end of the build). A particular case that should benefit from such an optimization is when merging a branch to `main`: the result should always be something that was built previously by a PR.