### PR TITLE
Continue the quotation flow

### DIFF
--- a/scenarios/quotation-flow--reject.golden
+++ b/scenarios/quotation-flow--reject.golden
@@ -15,13 +15,13 @@ Signup confirmation email enqueued: EMAIL-3
 User updated: USER-3
 10: as mila
 Modifying default user.
-11: forms quotation new --client charlie
+11: forms quotation new --client charlie --seller-entity one --seller-unit alpha
 Quotation form created: TBPJLIUG
-13: forms quotation submit TBPJLIUG
+12: forms quotation submit TBPJLIUG
 Quotation form validated.
 Quotation created: QUOT-1
 Quotation sent to client: QUOT-1
-15: as charlie
+14: as charlie
 Modifying default user.
-16: quotation reject QUOT-1 --comment "Rejecting, for some reason."
+15: quotation reject QUOT-1 --comment "Rejecting, for some reason."
 Quotation rejected.

--- a/scenarios/quotation-flow--reject.golden
+++ b/scenarios/quotation-flow--reject.golden
@@ -3,17 +3,17 @@ State is now empty.
 2: user signup alice a alice@example.com --accept-tos
 User created: USER-1
 Signup confirmation email enqueued: EMAIL-1
-4: user signup susie s susie@example.com --accept-tos
+4: user signup mila s mila@example.com --accept-tos
 User created: USER-2
 Signup confirmation email enqueued: EMAIL-2
-5: user update USER-2 Susie "I'm Susie, the Seller in the quotation-flow scenario."
+5: user update USER-2 Mila "I'm Mila, the Seller in the quotation-flow scenario."
 User updated: USER-2
 7: user signup charlie c charlie@example.com --accept-tos
 User created: USER-3
 Signup confirmation email enqueued: EMAIL-3
 8: user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 User updated: USER-3
-10: as susie
+10: as mila
 Modifying default user.
 11: forms quotation new --client charlie
 Quotation form created: TBPJLIUG

--- a/scenarios/quotation-flow--reject.golden
+++ b/scenarios/quotation-flow--reject.golden
@@ -13,15 +13,27 @@ User created: USER-3
 Signup confirmation email enqueued: EMAIL-3
 8: user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 User updated: USER-3
-10: as mila
+10: entity create one "One S.A." 100200300 BE0100200300
+Legal entity created: LENT-1
+11: entity set-supervised one
+Legal entity updated: one
+12: entity set-host one
+Legal entity updated: one
+14: unit create alpha Alpha
+Business entity created: BENT-1
+15: unit update alpha "The first business unit of the prototype, Alpha is run by @mila."
+Business unit updated: alpha
+16: unit link-user alpha USER-2 --holder
+Business unit updated: alpha
+18: as mila
 Modifying default user.
-11: forms quotation new --client charlie --seller-entity one --seller-unit alpha
+19: forms quotation new --client charlie --seller-entity one --seller-unit alpha
 Quotation form created: TBPJLIUG
-12: forms quotation submit TBPJLIUG
+20: forms quotation submit TBPJLIUG
 Quotation form validated.
 Quotation created: QUOT-1
 Quotation sent to client: QUOT-1
-14: as charlie
+22: as charlie
 Modifying default user.
-15: quotation reject QUOT-1 --comment "Rejecting, for some reason."
+23: quotation reject QUOT-1 --comment "Rejecting, for some reason."
 Quotation rejected.

--- a/scenarios/quotation-flow--reject.golden
+++ b/scenarios/quotation-flow--reject.golden
@@ -27,7 +27,7 @@ Business unit updated: alpha
 Business unit updated: alpha
 18: as mila
 Modifying default user.
-19: forms quotation new --client charlie --seller-entity one --seller-unit alpha
+19: forms quotation new --client charlie --seller-entity one --seller-unit alpha --buyer-entity one --buyer-unit alpha
 Quotation form created: TBPJLIUG
 20: forms quotation submit TBPJLIUG
 Quotation form validated.

--- a/scenarios/quotation-flow--reject.txt
+++ b/scenarios/quotation-flow--reject.txt
@@ -16,7 +16,7 @@ unit update alpha "The first business unit of the prototype, Alpha is run by @mi
 unit link-user alpha USER-2 --holder
 
 as mila
-forms quotation new --client charlie --seller-entity one --seller-unit alpha
+forms quotation new --client charlie --seller-entity one --seller-unit alpha --buyer-entity one --buyer-unit alpha
 forms quotation submit TBPJLIUG
 
 as charlie

--- a/scenarios/quotation-flow--reject.txt
+++ b/scenarios/quotation-flow--reject.txt
@@ -1,13 +1,13 @@
 reset
 user signup alice a alice@example.com --accept-tos
 
-user signup susie s susie@example.com --accept-tos
-user update USER-2 Susie "I'm Susie, the Seller in the quotation-flow scenario."
+user signup mila s mila@example.com --accept-tos
+user update USER-2 Mila "I'm Mila, the Seller in the quotation-flow scenario."
 
 user signup charlie c charlie@example.com --accept-tos
 user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 
-as susie
+as mila
 forms quotation new --client charlie
 # forms quotation edit
 forms quotation submit TBPJLIUG

--- a/scenarios/quotation-flow--reject.txt
+++ b/scenarios/quotation-flow--reject.txt
@@ -7,6 +7,14 @@ user update USER-2 Mila "I'm Mila, the Seller in the quotation-flow scenario."
 user signup charlie c charlie@example.com --accept-tos
 user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 
+entity create one "One S.A." 100200300 BE0100200300
+entity set-supervised one
+entity set-host one
+
+unit create alpha Alpha
+unit update alpha "The first business unit of the prototype, Alpha is run by @mila."
+unit link-user alpha USER-2 --holder
+
 as mila
 forms quotation new --client charlie --seller-entity one --seller-unit alpha
 forms quotation submit TBPJLIUG

--- a/scenarios/quotation-flow--reject.txt
+++ b/scenarios/quotation-flow--reject.txt
@@ -8,8 +8,7 @@ user signup charlie c charlie@example.com --accept-tos
 user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 
 as mila
-forms quotation new --client charlie
-# forms quotation edit
+forms quotation new --client charlie --seller-entity one --seller-unit alpha
 forms quotation submit TBPJLIUG
 
 as charlie

--- a/scenarios/quotation-flow--validate-fail.golden
+++ b/scenarios/quotation-flow--validate-fail.golden
@@ -1,0 +1,16 @@
+1: reset
+State is now empty.
+2: user signup alice a alice@example.com --accept-tos
+User created: USER-1
+Signup confirmation email enqueued: EMAIL-1
+4: user signup mila s mila@example.com --accept-tos
+User created: USER-2
+Signup confirmation email enqueued: EMAIL-2
+5: user update USER-2 Mila "I'm Mila, the Seller in the quotation-flow scenario."
+User updated: USER-2
+7: as mila
+Modifying default user.
+8: forms quotation new --client xochitl --seller-entity one --seller-unit alpha
+Quotation form created: TBPJLIUG
+9: forms quotation validate TBPJLIUG
+The client username does not exist.

--- a/scenarios/quotation-flow--validate-fail.golden
+++ b/scenarios/quotation-flow--validate-fail.golden
@@ -10,9 +10,11 @@ Signup confirmation email enqueued: EMAIL-2
 User updated: USER-2
 7: as mila
 Modifying default user.
-8: forms quotation new --client xochitl --seller-entity one --seller-unit alpha
+8: forms quotation new --client xochitl --seller-entity one --seller-unit alpha --buyer-entity one --buyer-unit alpha
 Quotation form created: TBPJLIUG
 9: forms quotation validate TBPJLIUG
 The client username does not exist.
 The selling entity does not exist.
 The selling unit does not exist.
+The buying entity does not exist.
+The buying unit does not exist.

--- a/scenarios/quotation-flow--validate-fail.golden
+++ b/scenarios/quotation-flow--validate-fail.golden
@@ -14,3 +14,5 @@ Modifying default user.
 Quotation form created: TBPJLIUG
 9: forms quotation validate TBPJLIUG
 The client username does not exist.
+The selling entity does not exist.
+The selling unit does not exist.

--- a/scenarios/quotation-flow--validate-fail.txt
+++ b/scenarios/quotation-flow--validate-fail.txt
@@ -5,5 +5,5 @@ user signup mila s mila@example.com --accept-tos
 user update USER-2 Mila "I'm Mila, the Seller in the quotation-flow scenario."
 
 as mila
-forms quotation new --client xochitl --seller-entity one --seller-unit alpha
+forms quotation new --client xochitl --seller-entity one --seller-unit alpha --buyer-entity one --buyer-unit alpha
 forms quotation validate TBPJLIUG

--- a/scenarios/quotation-flow--validate-fail.txt
+++ b/scenarios/quotation-flow--validate-fail.txt
@@ -1,0 +1,9 @@
+reset
+user signup alice a alice@example.com --accept-tos
+
+user signup mila s mila@example.com --accept-tos
+user update USER-2 Mila "I'm Mila, the Seller in the quotation-flow scenario."
+
+as mila
+forms quotation new --client xochitl --seller-entity one --seller-unit alpha
+forms quotation validate TBPJLIUG

--- a/scenarios/quotation-flow.golden
+++ b/scenarios/quotation-flow.golden
@@ -27,7 +27,7 @@ Business unit updated: alpha
 Business unit updated: alpha
 18: as mila
 Modifying default user.
-19: forms quotation new --client charlie --seller-entity one --seller-unit alpha
+19: forms quotation new --client charlie --seller-entity one --seller-unit alpha --buyer-entity one --buyer-unit alpha
 Quotation form created: TBPJLIUG
 20: forms quotation validate TBPJLIUG
 Quotation form is valid.

--- a/scenarios/quotation-flow.golden
+++ b/scenarios/quotation-flow.golden
@@ -17,28 +17,30 @@ User updated: USER-3
 Modifying default user.
 11: forms quotation new --client charlie
 Quotation form created: TBPJLIUG
-13: forms quotation submit TBPJLIUG
+12: forms quotation validate TBPJLIUG
+Quotation form is valid.
+14: forms quotation submit TBPJLIUG
 Quotation form validated.
 Quotation created: QUOT-1
 Quotation sent to client: QUOT-1
-15: as charlie
+16: as charlie
 Modifying default user.
-16: quotation sign QUOT-1
+17: quotation sign QUOT-1
 Order created: ORD-1
-18: as susie
+19: as susie
 Modifying default user.
-19: invoice emit --from ORD-1
+20: invoice emit --from ORD-1
 Invoice created: INV-1
 Internal (proxy) invoice created: INV-2
 Generating payment for INV-2...
 Remittance advice (using proxy bank account) created: REM-1
 Remittance advice (using business unit bank account) created: REM-2
 Invoice sent to client: INV-1
-21: as system
+22: as system
 Modifying default user.
-22: reminder send INV-1
+23: reminder send INV-1
 Reminder for invoice sent: INV-1
-23: payment match INV-1
+24: payment match INV-1
 Generating payment for INV-1...
 Remittance advice (using client bank account) created: REM-3
 Remittance advice (using business unit bank account) created: REM-4

--- a/scenarios/quotation-flow.golden
+++ b/scenarios/quotation-flow.golden
@@ -15,7 +15,7 @@ Signup confirmation email enqueued: EMAIL-3
 User updated: USER-3
 10: as mila
 Modifying default user.
-11: forms quotation new --client charlie
+11: forms quotation new --client charlie --seller-entity one --seller-unit alpha
 Quotation form created: TBPJLIUG
 12: forms quotation validate TBPJLIUG
 Quotation form is valid.

--- a/scenarios/quotation-flow.golden
+++ b/scenarios/quotation-flow.golden
@@ -13,34 +13,46 @@ User created: USER-3
 Signup confirmation email enqueued: EMAIL-3
 8: user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 User updated: USER-3
-10: as mila
+10: entity create one "One S.A." 100200300 BE0100200300
+Legal entity created: LENT-1
+11: entity set-supervised one
+Legal entity updated: one
+12: entity set-host one
+Legal entity updated: one
+14: unit create alpha Alpha
+Business entity created: BENT-1
+15: unit update alpha "The first business unit of the prototype, Alpha is run by @mila."
+Business unit updated: alpha
+16: unit link-user alpha USER-2 --holder
+Business unit updated: alpha
+18: as mila
 Modifying default user.
-11: forms quotation new --client charlie --seller-entity one --seller-unit alpha
+19: forms quotation new --client charlie --seller-entity one --seller-unit alpha
 Quotation form created: TBPJLIUG
-12: forms quotation validate TBPJLIUG
+20: forms quotation validate TBPJLIUG
 Quotation form is valid.
-14: forms quotation submit TBPJLIUG
+22: forms quotation submit TBPJLIUG
 Quotation form validated.
 Quotation created: QUOT-1
 Quotation sent to client: QUOT-1
-16: as charlie
+24: as charlie
 Modifying default user.
-17: quotation sign QUOT-1
+25: quotation sign QUOT-1
 Order created: ORD-1
-19: as mila
+27: as mila
 Modifying default user.
-20: invoice emit --from ORD-1
+28: invoice emit --from ORD-1
 Invoice created: INV-1
 Internal (proxy) invoice created: INV-2
 Generating payment for INV-2...
 Remittance advice (using proxy bank account) created: REM-1
 Remittance advice (using business unit bank account) created: REM-2
 Invoice sent to client: INV-1
-22: as system
+30: as system
 Modifying default user.
-23: reminder send INV-1
+31: reminder send INV-1
 Reminder for invoice sent: INV-1
-24: payment match INV-1
+32: payment match INV-1
 Generating payment for INV-1...
 Remittance advice (using client bank account) created: REM-3
 Remittance advice (using business unit bank account) created: REM-4

--- a/scenarios/quotation-flow.golden
+++ b/scenarios/quotation-flow.golden
@@ -3,17 +3,17 @@ State is now empty.
 2: user signup alice a alice@example.com --accept-tos
 User created: USER-1
 Signup confirmation email enqueued: EMAIL-1
-4: user signup susie s susie@example.com --accept-tos
+4: user signup mila s mila@example.com --accept-tos
 User created: USER-2
 Signup confirmation email enqueued: EMAIL-2
-5: user update USER-2 Susie "I'm Susie, the Seller in the quotation-flow scenario."
+5: user update USER-2 Mila "I'm Mila, the Seller in the quotation-flow scenario."
 User updated: USER-2
 7: user signup charlie c charlie@example.com --accept-tos
 User created: USER-3
 Signup confirmation email enqueued: EMAIL-3
 8: user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 User updated: USER-3
-10: as susie
+10: as mila
 Modifying default user.
 11: forms quotation new --client charlie
 Quotation form created: TBPJLIUG
@@ -27,7 +27,7 @@ Quotation sent to client: QUOT-1
 Modifying default user.
 17: quotation sign QUOT-1
 Order created: ORD-1
-19: as susie
+19: as mila
 Modifying default user.
 20: invoice emit --from ORD-1
 Invoice created: INV-1

--- a/scenarios/quotation-flow.txt
+++ b/scenarios/quotation-flow.txt
@@ -1,13 +1,13 @@
 reset
 user signup alice a alice@example.com --accept-tos
 
-user signup susie s susie@example.com --accept-tos
-user update USER-2 Susie "I'm Susie, the Seller in the quotation-flow scenario."
+user signup mila s mila@example.com --accept-tos
+user update USER-2 Mila "I'm Mila, the Seller in the quotation-flow scenario."
 
 user signup charlie c charlie@example.com --accept-tos
 user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 
-as susie
+as mila
 forms quotation new --client charlie
 forms quotation validate TBPJLIUG
 # forms quotation edit
@@ -16,7 +16,7 @@ forms quotation submit TBPJLIUG
 as charlie
 quotation sign QUOT-1
 
-as susie
+as mila
 invoice emit --from ORD-1
 
 as system

--- a/scenarios/quotation-flow.txt
+++ b/scenarios/quotation-flow.txt
@@ -7,6 +7,14 @@ user update USER-2 Mila "I'm Mila, the Seller in the quotation-flow scenario."
 user signup charlie c charlie@example.com --accept-tos
 user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 
+entity create one "One S.A." 100200300 BE0100200300
+entity set-supervised one
+entity set-host one
+
+unit create alpha Alpha
+unit update alpha "The first business unit of the prototype, Alpha is run by @mila."
+unit link-user alpha USER-2 --holder
+
 as mila
 forms quotation new --client charlie --seller-entity one --seller-unit alpha
 forms quotation validate TBPJLIUG

--- a/scenarios/quotation-flow.txt
+++ b/scenarios/quotation-flow.txt
@@ -8,7 +8,7 @@ user signup charlie c charlie@example.com --accept-tos
 user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 
 as mila
-forms quotation new --client charlie
+forms quotation new --client charlie --seller-entity one --seller-unit alpha
 forms quotation validate TBPJLIUG
 # forms quotation edit
 forms quotation submit TBPJLIUG

--- a/scenarios/quotation-flow.txt
+++ b/scenarios/quotation-flow.txt
@@ -16,7 +16,7 @@ unit update alpha "The first business unit of the prototype, Alpha is run by @mi
 unit link-user alpha USER-2 --holder
 
 as mila
-forms quotation new --client charlie --seller-entity one --seller-unit alpha
+forms quotation new --client charlie --seller-entity one --seller-unit alpha --buyer-entity one --buyer-unit alpha
 forms quotation validate TBPJLIUG
 # forms quotation edit
 forms quotation submit TBPJLIUG

--- a/scenarios/quotation-flow.txt
+++ b/scenarios/quotation-flow.txt
@@ -9,6 +9,7 @@ user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario
 
 as susie
 forms quotation new --client charlie
+forms quotation validate TBPJLIUG
 # forms quotation edit
 forms quotation submit TBPJLIUG
 

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -856,8 +856,15 @@ parserFormNewQuotation = do
   sellerEntity <- A.option
     (A.eitherReader (Right . T.pack))
     (A.long "seller-entity" <> A.help "Selling legal entity." <> A.metavar "ENTITY")
+  buyerUnit <- A.option
+    (A.eitherReader (Right . T.pack))
+    (A.long "buyer-unit" <> A.help "Buying business unit." <> A.metavar "UNIT")
+  buyerEntity <- A.option
+    (A.eitherReader (Right . T.pack))
+    (A.long "buyer-entity" <> A.help "Buying legal entity." <> A.metavar "ENTITY")
   pure $ FormNewQuotation $ Quotation.CreateQuotationAll
     (Just client) (Just sellerUnit) (Just sellerEntity)
+    (Just buyerUnit) (Just buyerEntity)
 
 parserFormValidateQuotation :: A.Parser Command
 parserFormValidateQuotation = do

--- a/src/Curiosity/Command.hs
+++ b/src/Curiosity/Command.hs
@@ -850,7 +850,14 @@ parserFormNewQuotation = do
   client <- A.option
     (A.eitherReader (Right . User.UserName . T.pack))
     (A.long "client" <> A.help "Client username." <> A.metavar "USERNAME")
-  pure $ FormNewQuotation $ Quotation.CreateQuotationAll (Just client)
+  sellerUnit <- A.option
+    (A.eitherReader (Right . T.pack))
+    (A.long "seller-unit" <> A.help "Selling business unit." <> A.metavar "UNIT")
+  sellerEntity <- A.option
+    (A.eitherReader (Right . T.pack))
+    (A.long "seller-entity" <> A.help "Selling legal entity." <> A.metavar "ENTITY")
+  pure $ FormNewQuotation $ Quotation.CreateQuotationAll
+    (Just client) (Just sellerUnit) (Just sellerEntity)
 
 parserFormValidateQuotation :: A.Parser Command
 parserFormValidateQuotation = do

--- a/src/Curiosity/Core.hs
+++ b/src/Curiosity/Core.hs
@@ -31,6 +31,8 @@ module Curiosity.Core
   , generateEmploymentId
   , generateInvoiceId
   , generateEmailId
+  -- * Operations on legal entities
+  , selectEntityBySlug
   -- * Operations on business units
   , createBusiness
   , updateBusiness
@@ -467,6 +469,14 @@ selectQuotationById db id = do
   let tvar = _dbQuotations db
   records <- STM.readTVar tvar
   pure $ find ((== id) . Quotation._quotationId) records
+
+
+--------------------------------------------------------------------------------
+selectEntityBySlug :: StmDb -> Text -> STM (Maybe Legal.Entity)
+selectEntityBySlug db name = do
+  let tvar = _dbLegalEntities db
+  records <- STM.readTVar tvar
+  pure $ find ((== name) . Legal._entitySlug) records
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/Quotation.hs
+++ b/src/Curiosity/Data/Quotation.hs
@@ -62,15 +62,20 @@ import           Web.HttpApiData                ( FromHttpApiData(..) )
 -- invalid inputs. As it is filled, it is kept in a Map in "Curiosity.Data",
 -- where it is identified by a key. The form data are validated when they are
 -- "submitted", using the `SubmitQuotation` data type below, and the key.
-newtype CreateQuotationAll = CreateQuotationAll
+data CreateQuotationAll = CreateQuotationAll
   { _createQuotationClientUsername :: Maybe User.UserName
+  , _createQuotationSellerUnit     :: Maybe Text
+  , _createQuotationSellerEntity   :: Maybe Text
   }
   deriving (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
 instance FromForm CreateQuotationAll where
-  fromForm f = CreateQuotationAll <$> parseMaybe "client-username" f
-    -- TODO Make it Nothing if empty string.
+  fromForm f = CreateQuotationAll
+    <$> parseMaybe "client-username" f
+    <*> parseMaybe "seller-unit"     f
+    <*> parseMaybe "seller-entity"   f
+    -- TODO Make them Nothing if empty strings.
 
 
 --------------------------------------------------------------------------------
@@ -84,6 +89,8 @@ instance FromForm CreateQuotationAll where
 emptyCreateQuotationAll :: CreateQuotationAll
 emptyCreateQuotationAll = CreateQuotationAll
   { _createQuotationClientUsername = Nothing
+  , _createQuotationSellerUnit     = Nothing
+  , _createQuotationSellerEntity   = Nothing
   }
 
 

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -27,7 +27,6 @@ module Curiosity.Runtime
   , filterUsers'
   , signup
   -- * High-level entity operations
-  , selectEntityBySlug
   , selectEntityBySlugResolved
   , selectEntitiesWhereUserId
   , readLegalEntities
@@ -618,11 +617,13 @@ handleCommand runtime@Runtime {..} user command = do
         Just profile -> do
           mcontract <- readCreateQuotationFormResolved _rDb profile input
           case mcontract of
-            Right (contract, resolvedClient) -> do
+            Right (contract, resolvedClient, resolvedSellerEntity, resolvedSellerUnit) -> do
               case
                   Quotation.validateCreateQuotation profile
                                                     contract
                                                     resolvedClient
+                                                    resolvedSellerEntity
+                                                    resolvedSellerUnit
                 of
                   Right _    -> pure (ExitSuccess, ["Quotation form is valid."])
                   Left  errs -> pure (ExitFailure 1, map Quotation.unErr errs)
@@ -829,7 +830,7 @@ createLegalFull db new = do
 
 updateLegal :: Core.StmDb -> Legal.Update -> STM (Either User.Err ())
 updateLegal db Legal.Update {..} = do
-  mentity <- selectEntityBySlug db _updateSlug
+  mentity <- Core.selectEntityBySlug db _updateSlug
   case mentity of
     Just Legal.Entity{} -> do
       let replaceOlder entities =
@@ -854,7 +855,7 @@ linkLegalEntityToUser
   -> Legal.ActingRole
   -> STM (Either User.Err ())
 linkLegalEntityToUser db slug uid role = do
-  mentity <- selectEntityBySlug db slug
+  mentity <- Core.selectEntityBySlug db slug
   case mentity of
     Just Legal.Entity {..} -> do
       let replaceOlder entities =
@@ -880,7 +881,7 @@ linkLegalEntityToUser' slug uid role = do
 updateLegalEntityIsSupervised
   :: Core.StmDb -> Text -> Bool -> STM (Either User.Err ())
 updateLegalEntityIsSupervised db slug b = do
-  mentity <- selectEntityBySlug db slug
+  mentity <- Core.selectEntityBySlug db slug
   case mentity of
     Just Legal.Entity{} -> do
       let replaceOlder entities =
@@ -901,7 +902,7 @@ updateLegalEntityIsSupervised' slug b = do
 updateLegalEntityIsHost
   :: Core.StmDb -> Text -> Bool -> STM (Either User.Err ())
 updateLegalEntityIsHost db slug b = do
-  mentity <- selectEntityBySlug db slug
+  mentity <- Core.selectEntityBySlug db slug
   case mentity of
     Just Legal.Entity{} -> do
       let replaceOlder entities =
@@ -1165,7 +1166,7 @@ readCreateQuotationFormResolved'
   :: User.UserProfile
   -> Text
   -> RunM
-       (Either () (Quotation.CreateQuotationAll, Maybe User.UserProfile))
+       (Either () (Quotation.CreateQuotationAll, Maybe User.UserProfile, Maybe Legal.Entity, Maybe Business.Unit))
 readCreateQuotationFormResolved' profile key = do
   db <- asks _rDb
   atomicallyM $ readCreateQuotationFormResolved db profile key
@@ -1179,7 +1180,7 @@ readCreateQuotationFormResolved
   -> STM
        ( Either
            ()
-           (Quotation.CreateQuotationAll, Maybe User.UserProfile)
+           (Quotation.CreateQuotationAll, Maybe User.UserProfile, Maybe Legal.Entity, Maybe Business.Unit)
        )
 readCreateQuotationFormResolved db profile key = do
   mform <- readCreateQuotationForm db (profile, key)
@@ -1187,7 +1188,11 @@ readCreateQuotationFormResolved db profile key = do
     Right form -> do
       mclient <- maybe (pure Nothing) (Core.selectUserByUsername db)
         $ Quotation._createQuotationClientUsername form
-      pure $ Right (form, mclient)
+      mentity <- maybe (pure Nothing) (Core.selectEntityBySlug db)
+        $ Quotation._createQuotationSellerEntity form
+      munit <- maybe (pure Nothing) (Core.selectUnitBySlug db)
+        $ Quotation._createQuotationSellerUnit form
+      pure $ Right (form, mclient, mentity, munit)
     Left err -> pure $ Left err
 
 readCreateQuotationForm'
@@ -1238,8 +1243,8 @@ submitCreateQuotationForm
 submitCreateQuotationForm db (profile, Quotation.SubmitQuotation key) = do
   minput <- readCreateQuotationFormResolved db profile key
   case minput of
-    Right (input, mresolvedClient) -> do
-      mid <- submitCreateQuotationForm' db (profile, input) mresolvedClient
+    Right (input, mresolvedClient, mresolvedSellerEntity, mresolvedSellerUnit) -> do
+      mid <- submitCreateQuotationForm' db (profile, input) mresolvedClient mresolvedSellerEntity mresolvedSellerUnit
       case mid of
         Right (id, resolvedClient) -> do
           -- Quotation created, do the rest of the atomic process.
@@ -1257,12 +1262,14 @@ submitCreateQuotationForm'
   :: Core.StmDb
   -> (User.UserProfile, Quotation.CreateQuotationAll)
   -> Maybe User.UserProfile
+  -> Maybe Legal.Entity
+  -> Maybe Business.Unit
   -> STM
        (Either Quotation.Err (Quotation.QuotationId, User.UserProfile))
-submitCreateQuotationForm' db (profile, input) mResolvedClient = do
-  let mc = Quotation.validateCreateQuotation profile input mResolvedClient
+submitCreateQuotationForm' db (profile, input) mresolvedClient mresolvedSellerEntity mresolvedSellerUnit = do
+  let mc = Quotation.validateCreateQuotation profile input mresolvedClient mresolvedSellerEntity mresolvedSellerUnit
   case mc of
-    Right (c, resolvedClient) -> do
+    Right (c, resolvedClient, _, _) -> do
       mid <- createQuotation db c
       case mid of
         Right id  -> pure $ Right (id, resolvedClient)
@@ -1685,12 +1692,6 @@ setUserEmailAddrAsVerified db username = do
         pure $ Right ()
       Just _ -> pure . Left $ User.EmailAddrAlreadyVerified
     Nothing -> pure . Left $ User.UserNotFound $ User.unUserName username
-
-selectEntityBySlug :: Core.StmDb -> Text -> STM (Maybe Legal.Entity)
-selectEntityBySlug db name = do
-  let tvar = Data._dbLegalEntities db
-  records <- STM.readTVar tvar
-  pure $ find ((== name) . Legal._entitySlug) records
 
 selectEntityBySlugResolved
   :: Core.StmDb -> Text -> STM (Maybe (Legal.Entity, [Legal.ActingUser]))

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1167,10 +1167,10 @@ showConfirmQuotationPage
 showConfirmQuotationPage key profile = do
   output <- withRuntime $ Rt.readCreateQuotationFormResolved' profile key
   case output of
-    Right (quotationAll, clientProfile, sellerEntity, sellerUnit) -> do
+    Right (quotationAll, clientProfile, sellerEntity, sellerUnit, buyerEntity, buyerUnit) -> do
       let
         errors =
-          Quotation.validateCreateQuotation' profile quotationAll clientProfile sellerEntity sellerUnit
+          Quotation.validateCreateQuotation' profile quotationAll clientProfile sellerEntity sellerUnit buyerEntity buyerUnit
       pure $ Pages.ConfirmQuotationPage
         profile
         key
@@ -1473,10 +1473,10 @@ documentConfirmQuotationPage dataDir key = do
   profile <- readJson $ dataDir </> "alice.json"
   output  <- withRuntime $ Rt.readCreateQuotationFormResolved' profile key
   case output of
-    Right (quotationAll, clientProfile, sellerEntity, sellerUnit) -> do
+    Right (quotationAll, clientProfile, sellerEntity, sellerUnit, buyerEntity, buyerUnit) -> do
       let
         errors =
-          Quotation.validateCreateQuotation' profile quotationAll clientProfile sellerEntity sellerUnit
+          Quotation.validateCreateQuotation' profile quotationAll clientProfile sellerEntity sellerUnit buyerEntity buyerUnit
       pure $ Pages.ConfirmQuotationPage
         profile
         key
@@ -1492,9 +1492,9 @@ echoSubmitQuotation dataDir (Quotation.SubmitQuotation key) = do
   profile <- readJson $ dataDir </> "alice.json"
   output  <- withRuntime $ Rt.readCreateQuotationFormResolved' profile key
   case output of
-    Right (quotation, resovedClient, resolvedSellerEntity, resolvedSellerUnit) -> pure . Pages.EchoPage (Just profile) $ show
+    Right (quotation, resovedClient, resolvedSellerEntity, resolvedSellerUnit, resolvedBuyerEntity, resolvedBuyerUnit) -> pure . Pages.EchoPage (Just profile) $ show
       ( quotation
-      , Quotation.validateCreateQuotation profile quotation resovedClient resolvedSellerEntity resolvedSellerUnit
+      , Quotation.validateCreateQuotation profile quotation resovedClient resolvedSellerEntity resolvedSellerUnit resolvedBuyerEntity resolvedBuyerUnit
       )
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -1167,10 +1167,10 @@ showConfirmQuotationPage
 showConfirmQuotationPage key profile = do
   output <- withRuntime $ Rt.readCreateQuotationFormResolved' profile key
   case output of
-    Right (quotationAll, clientProfile) -> do
+    Right (quotationAll, clientProfile, sellerEntity, sellerUnit) -> do
       let
         errors =
-          Quotation.validateCreateQuotation' profile quotationAll clientProfile
+          Quotation.validateCreateQuotation' profile quotationAll clientProfile sellerEntity sellerUnit
       pure $ Pages.ConfirmQuotationPage
         profile
         key
@@ -1473,10 +1473,10 @@ documentConfirmQuotationPage dataDir key = do
   profile <- readJson $ dataDir </> "alice.json"
   output  <- withRuntime $ Rt.readCreateQuotationFormResolved' profile key
   case output of
-    Right (quotationAll, clientProfile) -> do
+    Right (quotationAll, clientProfile, sellerEntity, sellerUnit) -> do
       let
         errors =
-          Quotation.validateCreateQuotation' profile quotationAll clientProfile
+          Quotation.validateCreateQuotation' profile quotationAll clientProfile sellerEntity sellerUnit
       pure $ Pages.ConfirmQuotationPage
         profile
         key
@@ -1492,9 +1492,9 @@ echoSubmitQuotation dataDir (Quotation.SubmitQuotation key) = do
   profile <- readJson $ dataDir </> "alice.json"
   output  <- withRuntime $ Rt.readCreateQuotationFormResolved' profile key
   case output of
-    Right (quotation, resovedClient) -> pure . Pages.EchoPage (Just profile) $ show
+    Right (quotation, resovedClient, resolvedSellerEntity, resolvedSellerUnit) -> pure . Pages.EchoPage (Just profile) $ show
       ( quotation
-      , Quotation.validateCreateQuotation profile quotation resovedClient
+      , Quotation.validateCreateQuotation profile quotation resovedClient resolvedSellerEntity resolvedSellerUnit
       )
     Left _ -> Errs.throwError' . Rt.FileDoesntExistErr $ T.unpack key -- TODO Specific error.
 


### PR DESCRIPTION
- Call the "dry run" validation in the quotation flow. This simply calls the validation code, without impacting the system state.
- In the setup code, we rename Susie (the seller) to Mila for consistency, as Mila is defined to be within Alpha and One in state-0.
- `forms quotation new` can now requires a seller entity and a seller unit, and a buyer entity and a buyer unit. The quotation flow is updated to setup Alpha and One so they can be used later in the scenario.

