### PR TITLE
Improve the `run` command

### DIFF
--- a/scenarios/init-entities.golden
+++ b/scenarios/init-entities.golden
@@ -1,6 +1,6 @@
-1: entity create one One S.A. 100200300 BE0100200300
+1: entity create one "One S.A." 100200300 BE0100200300
 Legal entity created: LENT-1
-2: entity update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
+2: entity update one "One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One."
 Legal entity updated: one
 3: entity link-user one USER-1 --validator
 Legal entity updated: one
@@ -8,9 +8,9 @@ Legal entity updated: one
 Legal entity updated: one
 5: entity set-host one
 Legal entity updated: one
-7: entity create two Two S.A. 100200400 BE0100200400
+7: entity create two "Two S.A." 100200400 BE0100200400
 Legal entity created: LENT-2
-8: entity update two Two S.A. is the second legal entity of the prototype.
+8: entity update two "Two S.A. is the second legal entity of the prototype."
 Legal entity updated: two
 9: entity link-user two USER-1 --validator
 Legal entity updated: two
@@ -18,15 +18,15 @@ Legal entity updated: two
 Legal entity updated: two
 11: entity set-host two
 Legal entity updated: two
-13: entity create three Three S.R.L. 100200500 BE0100200500
+13: entity create three "Three S.R.L." 100200500 BE0100200500
 Legal entity created: LENT-3
-14: entity update three Three S.R.L. is the first un-supervised legal entity of the prototype.
+14: entity update three "Three S.R.L. is the first un-supervised legal entity of the prototype."
 Legal entity updated: three
 15: entity link-user three USER-3 --validator
 Legal entity updated: three
-17: entity create four Four S.R.L. 100200600 BE0100200600
+17: entity create four "Four S.R.L." 100200600 BE0100200600
 Legal entity created: LENT-4
-18: entity update four Four S.R.L. is the second un-supervised legal entity of the prototype.
+18: entity update four "Four S.R.L. is the second un-supervised legal entity of the prototype."
 Legal entity updated: four
 19: entity link-user four USER-5 --validator
 Legal entity updated: four

--- a/scenarios/init-units.golden
+++ b/scenarios/init-units.golden
@@ -1,6 +1,6 @@
 1: unit create alpha Alpha
 Business entity created: BENT-1
-2: unit update alpha The first business unit of the prototype, Alpha is run by @mila.
+2: unit update alpha "The first business unit of the prototype, Alpha is run by @mila."
 Business unit updated: alpha
 3: unit link-user alpha USER-4 --holder
 Business unit updated: alpha

--- a/scenarios/init-users.golden
+++ b/scenarios/init-users.golden
@@ -1,7 +1,7 @@
 2: user signup alice a alice@example.com --accept-tos
 User created: USER-1
 Signup confirmation email enqueued: EMAIL-1
-3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
+3: user update USER-1 Alice "Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !"
 User updated: USER-1
 5: user signup bob b bob@example.com --accept-tos
 User created: USER-2
@@ -12,7 +12,7 @@ Signup confirmation email enqueued: EMAIL-3
 8: user signup mila m mila@example.com --accept-tos
 User created: USER-4
 Signup confirmation email enqueued: EMAIL-4
-9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
+9: user update USER-4 Mila "I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha."
 User updated: USER-4
 11: user signup chloe c chloe@example.com --accept-tos
 User created: USER-5

--- a/scenarios/quotation-flow--reject.golden
+++ b/scenarios/quotation-flow--reject.golden
@@ -6,12 +6,12 @@ Signup confirmation email enqueued: EMAIL-1
 4: user signup susie s susie@example.com --accept-tos
 User created: USER-2
 Signup confirmation email enqueued: EMAIL-2
-5: user update USER-2 Susie I'm Susie, the Seller in the quotation-flow scenario.
+5: user update USER-2 Susie "I'm Susie, the Seller in the quotation-flow scenario."
 User updated: USER-2
 7: user signup charlie c charlie@example.com --accept-tos
 User created: USER-3
 Signup confirmation email enqueued: EMAIL-3
-8: user update USER-3 Charlie I'm Charlie, a Client in the quotation-flow scenario.
+8: user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 User updated: USER-3
 10: as susie
 Modifying default user.
@@ -23,5 +23,5 @@ Quotation created: QUOT-1
 Quotation sent to client: QUOT-1
 15: as charlie
 Modifying default user.
-16: quotation reject QUOT-1 --comment Rejecting, for some reason.
+16: quotation reject QUOT-1 --comment "Rejecting, for some reason."
 Quotation rejected.

--- a/scenarios/quotation-flow.golden
+++ b/scenarios/quotation-flow.golden
@@ -6,12 +6,12 @@ Signup confirmation email enqueued: EMAIL-1
 4: user signup susie s susie@example.com --accept-tos
 User created: USER-2
 Signup confirmation email enqueued: EMAIL-2
-5: user update USER-2 Susie I'm Susie, the Seller in the quotation-flow scenario.
+5: user update USER-2 Susie "I'm Susie, the Seller in the quotation-flow scenario."
 User updated: USER-2
 7: user signup charlie c charlie@example.com --accept-tos
 User created: USER-3
 Signup confirmation email enqueued: EMAIL-3
-8: user update USER-3 Charlie I'm Charlie, a Client in the quotation-flow scenario.
+8: user update USER-3 Charlie "I'm Charlie, a Client in the quotation-flow scenario."
 User updated: USER-3
 10: as susie
 Modifying default user.

--- a/scenarios/state-0.golden
+++ b/scenarios/state-0.golden
@@ -4,7 +4,7 @@ State is now empty.
 > 2: user signup alice a alice@example.com --accept-tos
 > User created: USER-1
 > Signup confirmation email enqueued: EMAIL-1
-> 3: user update USER-1 Alice Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !
+> 3: user update USER-1 Alice "Hi ! I'm the first advisor registered on this prototype. I know and have access to everything... Let me know if you need anything !"
 > User updated: USER-1
 > 5: user signup bob b bob@example.com --accept-tos
 > User created: USER-2
@@ -15,15 +15,15 @@ State is now empty.
 > 8: user signup mila m mila@example.com --accept-tos
 > User created: USER-4
 > Signup confirmation email enqueued: EMAIL-4
-> 9: user update USER-4 Mila I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha.
+> 9: user update USER-4 Mila "I'm Mila, the first member to join this prototype. My advisor is @alice and I've created @alpha."
 > User updated: USER-4
 > 11: user signup chloe c chloe@example.com --accept-tos
 > User created: USER-5
 > Signup confirmation email enqueued: EMAIL-5
 3: run init-entities.txt
-> 1: entity create one One S.A. 100200300 BE0100200300
+> 1: entity create one "One S.A." 100200300 BE0100200300
 > Legal entity created: LENT-1
-> 2: entity update one One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One.
+> 2: entity update one "One S.A. is the main legal entity of the prototype. Unless required for fiscal or legal reasons, new contracts are hosted in One."
 > Legal entity updated: one
 > 3: entity link-user one USER-1 --validator
 > Legal entity updated: one
@@ -31,9 +31,9 @@ State is now empty.
 > Legal entity updated: one
 > 5: entity set-host one
 > Legal entity updated: one
-> 7: entity create two Two S.A. 100200400 BE0100200400
+> 7: entity create two "Two S.A." 100200400 BE0100200400
 > Legal entity created: LENT-2
-> 8: entity update two Two S.A. is the second legal entity of the prototype.
+> 8: entity update two "Two S.A. is the second legal entity of the prototype."
 > Legal entity updated: two
 > 9: entity link-user two USER-1 --validator
 > Legal entity updated: two
@@ -41,22 +41,22 @@ State is now empty.
 > Legal entity updated: two
 > 11: entity set-host two
 > Legal entity updated: two
-> 13: entity create three Three S.R.L. 100200500 BE0100200500
+> 13: entity create three "Three S.R.L." 100200500 BE0100200500
 > Legal entity created: LENT-3
-> 14: entity update three Three S.R.L. is the first un-supervised legal entity of the prototype.
+> 14: entity update three "Three S.R.L. is the first un-supervised legal entity of the prototype."
 > Legal entity updated: three
 > 15: entity link-user three USER-3 --validator
 > Legal entity updated: three
-> 17: entity create four Four S.R.L. 100200600 BE0100200600
+> 17: entity create four "Four S.R.L." 100200600 BE0100200600
 > Legal entity created: LENT-4
-> 18: entity update four Four S.R.L. is the second un-supervised legal entity of the prototype.
+> 18: entity update four "Four S.R.L. is the second un-supervised legal entity of the prototype."
 > Legal entity updated: four
 > 19: entity link-user four USER-5 --validator
 > Legal entity updated: four
 4: run init-units.txt
 > 1: unit create alpha Alpha
 > Business entity created: BENT-1
-> 2: unit update alpha The first business unit of the prototype, Alpha is run by @mila.
+> 2: unit update alpha "The first business unit of the prototype, Alpha is run by @mila."
 > Business unit updated: alpha
 > 3: unit link-user alpha USER-4 --holder
 > Business unit updated: alpha

--- a/src/Curiosity/Interpret.hs
+++ b/src/Curiosity/Interpret.hs
@@ -146,7 +146,8 @@ interpretLines runtime user dir content nesting acc0 accumulate = go user acc0 0
   go user' acc nbr ((ln, line) : rest) = do
     let (prefix, comment) = T.breakOn "#" line
         separated         = map T.pack . wordsq $ T.unpack prefix
-        grouped           = T.unwords separated
+        quote s           = if " " `T.isInfixOf` s then "\"" <> s <> "\"" else s
+        grouped           = T.unwords $ map quote separated
         nbr'  = succ nbr
         trace' = Trace nbr
                        ln

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -552,7 +552,7 @@ serverT natTrans ctx conf jwtS root dataDir scenariosDir =
     :<|> messageSignupSuccess
 
     :<|> showRun
-    :<|> handleRun
+    :<|> handleRun scenariosDir
     :<|> serveScenario scenariosDir
 
     :<|> showState
@@ -2451,10 +2451,11 @@ showRun authResult = withMaybeUser
 
 handleRun
   :: ServerC m
-  => SAuth.AuthResult User.UserId
+  => FilePath
+  -> SAuth.AuthResult User.UserId
   -> Data.Command
   -> m Pages.EchoPage
-handleRun authResult (Data.Command cmd) = withMaybeUser
+handleRun path authResult (Data.Command cmd) = withMaybeUser
   authResult
   (\_ -> run' Nothing <&> Pages.EchoPage Nothing)
   (\profile -> run' (Just profile) <&> Pages.EchoPage (Just profile))
@@ -2463,7 +2464,7 @@ handleRun authResult (Data.Command cmd) = withMaybeUser
     runtime <- ask
     output  <- liftIO $ Inter.interpretLines runtime
                                              username
-                                             "/tmp/nowhere"
+                                             path
                                              [cmd]
                                              0
                                              []


### PR DESCRIPTION
- The `/run` page can access scenarios when using the `run` command.
- The output was not showing quotes around multi-word arguments. This is now fixed.
- In the HTML representation of a scenario output, links to individual states were broken when the scenario was calling another scenario (using the `run` command). This is now fixed.