### PR TITLE
Add a "Reject quotation" action to the web interface

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://design.smartcoop.sh",
         "owner": "hypered",
         "repo": "smart-design-hs",
-        "rev": "4233098ba310370587f1b5548e2d78c2d8e0353d",
-        "sha256": "1p5nd1mpnd7y2hfm8zjnc9l503whahlzb3whhnqh1iqwz252ryqs",
+        "rev": "9174089bf96836dc0583e5ba71771706b7ac673a",
+        "sha256": "05m523anh4yck2ccafr5k06bpnq6b40zd20n19wddgla773ybiwc",
         "type": "tarball",
-        "url": "https://github.com/hypered/smart-design-hs/archive/4233098ba310370587f1b5548e2d78c2d8e0353d.tar.gz",
+        "url": "https://github.com/hypered/smart-design-hs/archive/9174089bf96836dc0583e5ba71771706b7ac673a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/src/Curiosity/Data/Quotation.hs
+++ b/src/Curiosity/Data/Quotation.hs
@@ -28,6 +28,7 @@ module Curiosity.Data.Quotation
   , QuotationState(..)
   , displayQuotationState
   , SetQuotationAsSigned(..)
+  , SetQuotationAsRejected(..)
   , Predicate(..)
   , applyPredicate
   , Err(..)
@@ -173,6 +174,12 @@ newtype SetQuotationAsSigned = SetQuotationAsSigned QuotationId
 
 instance FromForm SetQuotationAsSigned where
   fromForm f = SetQuotationAsSigned <$> parseUnique "quotation-id" f
+
+data SetQuotationAsRejected = SetQuotationAsRejected QuotationId (Maybe Text)
+
+instance FromForm SetQuotationAsRejected where
+  fromForm f = SetQuotationAsRejected <$> parseUnique "quotation-id" f
+                                      <*> parseMaybe "comment"       f
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Action.hs
+++ b/src/Curiosity/Html/Action.hs
@@ -6,6 +6,7 @@ under e.g. `cty user do` and the action menu on table views.
 module Curiosity.Html.Action
   ( SetUserEmailAddrAsVerifiedPage(..)
   , SetQuotationAsSignedPage(..)
+  , SetQuotationAsRejectedPage(..)
   , ActionResult(..)
   , EchoPage(..)
   , EchoPage'(..)
@@ -96,6 +97,34 @@ setQuotationAsSignedForm id = H.form $ do
   H.input ! A.type_ "hidden" ! A.id "quotation-id" ! A.name "quotation-id" ! A.value
     (H.toValue id)
   button "/a/set-quotation-as-signed" "Set as signed"
+
+
+--------------------------------------------------------------------------------
+-- | A form to perform the SetQuotationAsRejected action.
+data SetQuotationAsRejectedPage = SetQuotationAsRejectedPage
+  { setQuotationAsRejectedQuotation :: Quotation.Quotation
+    -- ^ The quotation to be set as rejected.
+  }
+
+instance H.ToMarkup SetQuotationAsRejectedPage where
+  toMarkup SetQuotationAsRejectedPage {..} =
+    let id = Quotation._quotationId setQuotationAsRejectedQuotation
+    in  fullScrollWrapper . panelWrapper $ do
+          H.toMarkup $ setQuotationAsRejectedPanel id
+          setQuotationAsRejectedForm id
+
+setQuotationAsRejectedPanel id =
+  PanelHeaderAndBody "Set quotation as rejected"
+    $ H.dl
+    ! A.class_ "c-key-value c-key-value--horizontal c-key-value--short"
+    $ do
+        keyValuePair "ID" id
+
+setQuotationAsRejectedForm id = H.form $ do
+  H.input ! A.type_ "hidden" ! A.id "quotation-id" ! A.name "quotation-id" ! A.value
+    (H.toValue id)
+  H.input ! A.id "comment" ! A.name "comment"
+  button "/a/set-quotation-as-rejected" "Set as rejected"
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Html/Quotation.hs
+++ b/src/Curiosity/Html/Quotation.hs
@@ -53,6 +53,10 @@ panelQuotations quotations =
              , "Set as signed"
              , "/action/set-quotation-as-signed/" <> Quotation.unQuotationId _quotationId
              )
+           , ( Misc.divIconClose
+             , "Set as rejected"
+             , "/action/set-quotation-as-rejected/" <> Quotation.unQuotationId _quotationId
+             )
            ]
       else []
     , Nothing

--- a/src/Curiosity/Runtime.hs
+++ b/src/Curiosity/Runtime.hs
@@ -42,6 +42,7 @@ module Curiosity.Runtime
   , writeCreateQuotationForm
   , submitCreateQuotationForm
   , setQuotationAsSignedFull
+  , setQuotationAsRejectedFull
   -- ** Orders
   , filterOrders
   , filterOrders'


### PR DESCRIPTION
A `reject` command was aleady present in the command-line interface. It is now visible behind the "3 dots" action button on the list of quotations.