### PR TITLE
Server: add setuid/setgid capabilities

### DIFF
--- a/machine/configuration.nix
+++ b/machine/configuration.nix
@@ -22,7 +22,7 @@ let
       if [[ $2 =~ $regex ]]
       then
         username="''${BASH_REMATCH[1]}"
-        cty --user $username --socket /curiosity.sock $SSH_ORIGINAL_COMMAND
+        cty --user $username --socket /run/curiosity.sock $SSH_ORIGINAL_COMMAND
       else
         echo "Expecting 'cty --user <username>' command prefix."
         exit 1

--- a/modules/curiosity.nix
+++ b/modules/curiosity.nix
@@ -29,6 +29,9 @@
         --data-dir ${(import ../.).data} \
         --scenarios-dir ${(import ../.).scenarios} \
         --stdout
+        --unix-socket-path /run/curiosity.sock
+        --user-name curiosity
+        --user-group curiosity
       '';
 
       # Hardening Options

--- a/src/Curiosity/Process.hs
+++ b/src/Curiosity/Process.hs
@@ -18,7 +18,7 @@ import qualified Curiosity.Server              as Srv
 --------------------------------------------------------------------------------
 startServer :: Command.ServerConf -> Rt.Runtime -> IO Errs.RuntimeErr
 startServer conf runtime@Rt.Runtime {..} = do
-  let Command.ServerConf port _ _ _ _ _ = conf
+  let port = Command._serverPort conf
   startupLogInfo _rLoggers $ "Starting up server on port " <> show port <> "..."
   try @SomeException (Srv.run conf runtime) >>= pure . either
     Errs.RuntimeException

--- a/src/Curiosity/Run.hs
+++ b/src/Curiosity/Run.hs
@@ -25,6 +25,7 @@ import qualified System.Console.Haskeline      as HL
 import           System.Directory               ( doesFileExist )
 import           System.Environment             ( lookupEnv )
 import           System.Posix.User              ( getLoginName )
+import qualified System.Posix.User             as PU
 
 
 --------------------------------------------------------------------------------
@@ -239,12 +240,21 @@ run (Command.CommandWithTarget command target (Command.User user)) = do
 
 --------------------------------------------------------------------------------
 handleServe :: P.Conf -> P.ServerConf -> IO ExitCode
-handleServe conf serverConf = do
+handleServe conf serverConf@P.ServerConf{..} = do
+  muserEntry <- mapM (PU.getUserEntryForName . T.unpack) _serverUserName
+  mgroupEntry <- mapM (PU.getGroupEntryForName . T.unpack) _serverGroupName
+  let muid = PU.userID <$> muserEntry
+  let mgid = PU.groupID <$> mgroupEntry
+  -- Note: setOwnerAndGroup won't change a uid/gid if it's set to -1.
+  let uid = fromMaybe (-1) muid
+  let gid = fromMaybe (-1) mgid
+
   threads <- Rt.emptyHttpThreads
   runtime@Rt.Runtime {..} <- Rt.bootConf conf threads >>= either throwIO pure
   Rt.runRunM runtime Rt.spawnEmailThread
+  let unixSocketConf = Rt.UnixSocket _serverUnixSocketPath uid gid
   when (P._serverUnixDomain serverConf) $
-    void $ Rt.runRunM runtime Rt.spawnUnixThread
+    void $ Rt.runRunM runtime $ Rt.spawnUnixThread unixSocketConf
   P.startServer serverConf runtime >>= P.endServer _rLoggers
   mPowerdownErrs <- Rt.powerdown runtime
   maybe exitSuccess throwIO mPowerdownErrs
@@ -255,7 +265,7 @@ handleSock :: P.Conf -> IO ExitCode
 handleSock conf = do
   putStrLn @Text "Creating runtime..."
   runtime <- Rt.bootConf conf Rt.NoThreads >>= either throwIO pure
-  Rt.runWithRuntime runtime
+  Rt.runWithRuntime runtime $ Rt.UnixSocket "./curiosity.sock" (-1) (-1)
   exitSuccess
 
 


### PR DESCRIPTION
We add tree new CLI flags to cty serve:

- --unix-socket-path: path pointing to the unix socket. Defaults to
  `./curiosity.sock`
- --user-name: name of the user we want to run curiosity for.
- --group-name: name of the user we want to run curiosity for.

On a production setting, we often like to bind the unix sockets to
/run. You need to be root to do that. The idea is to start the
software as root, let it bind its socket in /run, then setuid/setgid
the process to its definitive user/group.

We decided not to change the state.json uid/gid. It means that we'll
have to "manually" set the appropriate permission. Likely via the
service pre-start procedure. It might be a bad idea we want to
revisit, it might be the right way to do it, only experience will
tell on that one.

We also update the curiosity systemd service to reflect this change.
