### PR TITLE
Document how to use ghcid and add helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,33 @@ A [GitHub action](https://github.com/hypered/curiosity/actions) is used to run
 the tests on every commit, and report the results on each Pull Request. It is
 also used to populate a [Nix binary cache](#nix-binary-cache).
 
+# `ghcid`
+
+Reloading the code automatically upon changes can be done with `ghcid`. A
+convenience script to run `ghcid` is `script/ghcid.sh`.
+
+`ghcid` can also be instructed to run something when code loads successfully.
+This is used to typically run tests, but can also be used to restart the
+Curiosity HTTP server.
+
+This looks like this (be sure to enter the `nix-shell` first):
+
+```
+$ ghcid --warnings --command scripts/ghci.sh --test ':main serve'
+```
+
+Note: use the
+[`autoReload`](https://smartcoop.sh/haddock/Curiosity-Html-Misc.html#v:autoReload)
+function defined in `Curiosity.Html.Misc` to cause an open web page to be
+automatically refreshed when working on some HTML snippet.
+
+The same mechanism can be used with the HSPec-based tests or the Golden tests:
+
+```
+$ ghcid --warnings --command scripts/ghci-spec.sh --test ':main'
+$ ghcid --warnings --command scripts/ghci-scenarios.sh --test ':main'
+```
+
 # Running
 
 There are multiple ways to run Curiosity's code. Building the `cty` binary and

--- a/scripts/ghci-scenarios.conf
+++ b/scripts/ghci-scenarios.conf
@@ -1,0 +1,3 @@
+:load ../smart-design-hs/lib/src/Prelude.hs
+:set -XImplicitPrelude
+:load tests/run-scenarios.hs

--- a/scripts/ghci-scenarios.sh
+++ b/scripts/ghci-scenarios.sh
@@ -1,0 +1,33 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash ../shell.nix
+
+# This is a bit convoluted because the Prelude is from smart-design-hs:
+#   - -XNoImplicitPrelude is set here on the command-line
+#   - The ghci.conf file will load smart-design-hs's Prelude
+#   - Then set again -XImplicitPrelude
+#   - Then load what we want: tests/run-scenarios.hs
+
+ghc --interactive \
+  -i../smart-design-hs/lib/src/ \
+  -ibin/ \
+  -isrc/ \
+  -hide-package base \
+  -XNoImplicitPrelude \
+  -XHaskell2010 \
+  -XStrictData \
+  -XMultiParamTypeClasses \
+  -XDerivingStrategies \
+  -XDerivingVia \
+  -XDeriveGeneric \
+  -XRecordWildCards \
+  -XTypeSynonymInstances \
+  -XFlexibleInstances \
+  -XFlexibleContexts \
+  -XUndecidableInstances \
+  -XLambdaCase \
+  -XTypeApplications \
+  -XScopedTypeVariables \
+  -XGADTs \
+  -XOverloadedStrings \
+  -XPackageImports \
+  -ghci-script scripts/ghci-scenarios.conf

--- a/scripts/ghci-spec.conf
+++ b/scripts/ghci-spec.conf
@@ -1,0 +1,3 @@
+:load ../smart-design-hs/lib/src/Prelude.hs
+:set -XImplicitPrelude
+:load tests/run-spec.hs

--- a/scripts/ghci-spec.sh
+++ b/scripts/ghci-spec.sh
@@ -1,0 +1,34 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash ../shell.nix
+
+# This is a bit convoluted because the Prelude is from smart-design-hs:
+#   - -XNoImplicitPrelude is set here on the command-line
+#   - The ghci.conf file will load smart-design-hs's Prelude
+#   - Then set again -XImplicitPrelude
+#   - Then load what we want: tests/run-spec.hs
+
+ghc --interactive \
+  -i../smart-design-hs/lib/src/ \
+  -ibin/ \
+  -isrc/ \
+  -itests/ \
+  -hide-package base \
+  -XNoImplicitPrelude \
+  -XHaskell2010 \
+  -XStrictData \
+  -XMultiParamTypeClasses \
+  -XDerivingStrategies \
+  -XDerivingVia \
+  -XDeriveGeneric \
+  -XRecordWildCards \
+  -XTypeSynonymInstances \
+  -XFlexibleInstances \
+  -XFlexibleContexts \
+  -XUndecidableInstances \
+  -XLambdaCase \
+  -XTypeApplications \
+  -XScopedTypeVariables \
+  -XGADTs \
+  -XOverloadedStrings \
+  -XPackageImports \
+  -ghci-script scripts/ghci-spec.conf

--- a/tests/run-spec.hs
+++ b/tests/run-spec.hs
@@ -1,0 +1,23 @@
+-- This file is not necessary for `cabal test` (which uses Spec.hs instead) but
+-- makes if possible to load the tests in GHCi and ghcid.
+
+import qualified CuriositySpec
+import qualified Curiosity.CommandSpec
+import qualified Curiosity.CoreSpec
+import qualified Curiosity.DataSpec
+import qualified Curiosity.DslSpec
+import qualified Curiosity.RunSpec
+import qualified Curiosity.RuntimeSpec
+import           Test.Hspec
+
+
+--------------------------------------------------------------------------------
+main :: IO ()
+main = hspec $ do
+  CuriositySpec.spec
+  Curiosity.CommandSpec.spec
+  Curiosity.CoreSpec.spec
+  Curiosity.DataSpec.spec
+  Curiosity.DslSpec.spec
+  Curiosity.RunSpec.spec
+  Curiosity.RuntimeSpec.spec


### PR DESCRIPTION
- This adds some notes in the README about using ghcid to reload the code and either run tests or the server.
- This adds two scripts, `ghci-scenarios.sh` and `ghci-spec.sh` to load the toplevel files for the HSPec-based tests or Golden-files -based tests.