### PR TITLE
ci/build-curiosity.sh: fix error handling bug

### DIFF
--- a/ci/build-curiosity.sh
+++ b/ci/build-curiosity.sh
@@ -26,11 +26,10 @@ error=0
 
 for job in $(nix-eval-jobs "${args[@]}" | jq -r 'select(.isCached == false) | @base64'); do
   job=$(echo "$job" | base64 -d)
-  attr=$(echo "$job" | jq -r .attr)
-  echo "### $attr"
-  error=$(echo "$job" | jq -r .error)
-  if [[ $error != null ]]; then
-    log "### ❌ $attr"
+  name=$(echo "$job" | jq -r .name)
+  evalerror=$(echo "$job" | jq -r .error)
+  if [[ $evalerror != null ]]; then
+    log "### ❌ $name"
     log
     log "<details><summary>Eval error:</summary><pre>"
     log "$error"
@@ -38,21 +37,19 @@ for job in $(nix-eval-jobs "${args[@]}" | jq -r 'select(.isCached == false) | @b
     error=1
   else
     drvPath=$(echo "$job" | jq -r .drvPath)
-    drvName=$(echo "$job" | jq -r .name)
     if ! nix-store --realize "$drvPath" 2>&1 | tee build-log.txt; then
-      log "### ❌ $attr"
+      log "### ❌ $name"
       log
       log "<details><summary>Build error:</summary>last 50 lines:<pre>"
       log "$(tail -n 50 build-log.txt)"
       log "</pre></details>"
       error=1
     else
-      log "### ✅ $attr"
-      echo "${drvName}=${drvPath}" >> "$GITHUB_OUTPUT"
+      log "### ✅ $name"
     fi
     log
-    rm build-log.txt
   fi
 done
 
-exit "$error"
+echo "Exit with error code $error"
+exit $error


### PR DESCRIPTION
We had a bug in the error handling path. The eval error status was overriding the build error status in a pure bash style.

This was leading sucessful runs to return "null" (the eval error status), failing the whole build.

We take advantage of this bugfix to properly display the derivation pname in place of the attr name (which is always null in our setup: we build a single derivation).

I tested this here on a non-cached build https://github.com/hypered/curiosity/actions/runs/4057548571 (it's building mosh for no particular reason: curiosity tend to be quite long to build :sweat_smile: )

