### PR TITLE
Introduce the cty-2.hypered.systems domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  DEPLOY_HOST: cty.hypered.systems
+  DEPLOY_HOST: cty-2.hypered.systems
 
 jobs:
   build:
@@ -77,7 +77,7 @@ jobs:
         echo "SSH_KEY_PATH=$ssh_key" > $GITHUB_OUTPUT
       id: deploy_env
 
-    - name: Deploy closure to cty.hypered.systems
+    - name: Deploy closure to cty-2.hypered.systems
       if: github.event_name == 'push' && github.ref_name == 'main'
       env:
         NIX_SSHOPTS: "-o StrictHostKeyChecking=no -i ${{ steps.deploy_env.outputs.SSH_KEY_PATH }} -l root"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021-2022 SmartCoop SC.
+Copyright 2021-2022 SmartCoop SC, 2023 Hypered SRL
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ In particular, in addition of working features, we want
 > logic by virtue of having a working implementation.
 
 A demonstration instance of Curiosity is running at
-[cty.hypered.systems](https://cty.hypered.systems). It contains
-[documentation](https://cty.hypered.systems/documentation) that complements this
+[cty-2.hypered.systems](https://cty-2.hypered.systems). It contains
+[documentation](https://cty-2.hypered.systems/documentation) that complements this
 README. If you're non-technical, those links are a better starting point. The
 rest of this README is intended for more technical profiles.
 
@@ -97,7 +97,7 @@ $ ghcid --warnings --command scripts/ghci.sh --test ':main serve'
 ```
 
 Note: use the
-[`autoReload`](https://cty.hypered.systems/haddock/Curiosity-Html-Misc.html#v:autoReload)
+[`autoReload`](https://cty-2.hypered.systems/haddock/Curiosity-Html-Misc.html#v:autoReload)
 function defined in `Curiosity.Html.Misc` to cause an open web page to be
 automatically refreshed when working on some HTML snippet.
 
@@ -211,12 +211,12 @@ $ result/bin/nixos-test-driver
 
 This opens two QEMU windows, one for the server, one for the client, and you
 can use the root account to interactively log in the VMs. The client can access
-the server using the `cty.hypered.systems` domain name. You can read the relevant
+the server using the `cty-2.hypered.systems` domain name. You can read the relevant
 [NixOS manual
 section](https://nixos.org/manual/nixos/stable/index.html#sec-running-nixos-tests-interactively)
 for more informations.
 
-**Note**: these VMs are not connected to the internet, `cty.hypered.systems` here
+**Note**: these VMs are not connected to the internet, `cty-2.hypered.systems` here
 refers to the server VM, not the production machine.
 
 And finally, we can run a local virtual machine running both `cty serve` and an
@@ -230,7 +230,7 @@ $ result/bin/run-nixos-vm
 The web application can be accessed at `127.0.0.1:8180`. A helper script is
 provided to do the same: `scripts/runvm.sh`.
 
-The virtual machine image running at `cty.hypered.systems` is based on the above, and
+The virtual machine image running at `cty-2.hypered.systems` is based on the above, and
 can be built with:
 
 ```
@@ -303,7 +303,7 @@ Exiting
 ```
 
 Such scripts, together with their expected output, are used as a high-level
-[testing mechanism](https://cty.hypered.systems/documentation/tests).
+[testing mechanism](https://cty-2.hypered.systems/documentation/tests).
 
 # Nix binary cache
 
@@ -417,7 +417,7 @@ $ nix-build -A public --out-link _site
 $ scripts/serve-doc.sh
 ```
 
-# The `cty.hypered.systems` host
+# The `cty-2.hypered.systems` host
 
 These are raw notes about how `smartcoo.sh` was deployed. I (Thu) have used 4
 scripts that come from my [nix-notes](https://github.com/noteed/nix-notes)
@@ -463,7 +463,7 @@ control.
 
 -   `deploy.sh` is used to deploy changes to the Droplet, without needing to
     rebuild an image or create a new Droplet. Note that I specified
-    `cty.hypered.systems` within the script instead of its IP address. See below.
+    `cty-2.hypered.systems` within the script instead of its IP address. See below.
 
 # The `smartcoop.sh` domain
 
@@ -473,7 +473,8 @@ the DO web interface (within the "curiosity" project). Then I've created an A
 record for `@`, associated to the above IP address.
 
 The domain expires in 2023 June and will not be renewed. Instead, the work will
-be moved to `cty.hypered.systems`.
+be moved to `cty-1.hypered.systems`. (`cty-2.hypered.systems` is used for the
+current version.)
 
 # Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-**Note**: The project as initially carried for Smart Coop is easily available
-in the `smartcoop.sh` branch. The corresponding domain will be let expiring in
-June 2023.
-
 # Curiosity - A prototype application
 
 This repository contains a prototype application. What we hear about
@@ -105,7 +101,7 @@ Note: use the
 function defined in `Curiosity.Html.Misc` to cause an open web page to be
 automatically refreshed when working on some HTML snippet.
 
-The same mechanism can be used with the HSPec-based tests or the Golden tests:
+The same mechanism can be used with the HSpec-based tests or the Golden tests:
 
 ```
 $ ghcid --warnings --command scripts/ghci-spec.sh --test ':main'
@@ -478,3 +474,9 @@ record for `@`, associated to the above IP address.
 
 The domain expires in 2023 June and will not be renewed. Instead, the work will
 be moved to `cty.hypered.systems`.
+
+# Acknowledgement
+
+This project was initially carried for Smart Coop, from August 2022 till
+January 2023. The version done for Smart Coop is easily available in the
+`smartcoop.sh` branch. The corresponding domain expired in June 2023.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ A demonstration instance of Curiosity is running at
 README. If you're non-technical, those links are a better starting point. The
 rest of this README is intended for more technical profiles.
 
+A previous version of Curiosity, written for Smart Coop, is running at
+[cty-1.hypered.systems](https://cty-1.hypered.systems).
+
 # Content
 
 Curiosity offers multiple tools compiled as a single executable, called
@@ -419,9 +422,9 @@ $ scripts/serve-doc.sh
 
 # The `cty-2.hypered.systems` host
 
-These are raw notes about how `smartcoo.sh` was deployed. I (Thu) have used 4
-scripts that come from my [nix-notes](https://github.com/noteed/nix-notes)
-repository.
+These are raw notes about how the original `smartcoop.sh` was deployed. I (Thu)
+have used 4 scripts that come from my
+[nix-notes](https://github.com/noteed/nix-notes) repository.
 
 Those scripts require some environment variables for authentication, and some
 configuration to point to the right services (DigitalOcean instead of AWS). I'm
@@ -465,19 +468,11 @@ control.
     rebuild an image or create a new Droplet. Note that I specified
     `cty-2.hypered.systems` within the script instead of its IP address. See below.
 
-# The `smartcoop.sh` domain
-
-I've bought the domain at Namecheap on 2022-06-08 and configured Namecheap to
-use DO's name servers. I've created the `smartcoop.sh` domain manually within
-the DO web interface (within the "curiosity" project). Then I've created an A
-record for `@`, associated to the above IP address.
-
-The domain expires in 2023 June and will not be renewed. Instead, the work will
-be moved to `cty-1.hypered.systems`. (`cty-2.hypered.systems` is used for the
-current version.)
-
 # Acknowledgement
 
 This project was initially carried for Smart Coop, from August 2022 till
 January 2023. The version done for Smart Coop is easily available in the
 `smartcoop.sh` branch. The corresponding domain expired in June 2023.
+
+The work done done for Smart Coop is visible at `cty-1.hypered.systems`.
+(`cty-2.hypered.systems` is used for the current version.)

--- a/content/about.md
+++ b/content/about.md
@@ -8,7 +8,7 @@ title: Curiosity
 Curiosity is an ever-evolving prototype system to think, discuss, and
 communicate the future of Smart Coop's developments. It is exposed to
 end-users as a web application and a running instance of Curiosity is made
-available at [`cty.hypered.systems`](//cty.hypered.systems) for demonstration purpose. For
+available at [`cty-2.hypered.systems`](//cty-2.hypered.systems) for demonstration purpose. For
 tech savvy users, the complete system is packaged as a [virtual machine
 image](/documentation/machine), made to be easily run and explored.
 
@@ -17,7 +17,7 @@ image](/documentation/machine), made to be easily run and explored.
 To achieve our goals in making Curiosity a central place to inform future
 developments, the complete documentation is part of the virtual machine image.
 The documentation is comprised of HTML pages, visible at
-[`cty.hypered.systems`](//cty.hypered.systems/documentation), and [man
+[`cty-2.hypered.systems`](//cty-2.hypered.systems/documentation), and [man
 pages](/documentation/man-pages), available from the terminal within the
 virtual machine.
 

--- a/content/documentation/asciinema.html
+++ b/content/documentation/asciinema.html
@@ -15,7 +15,7 @@
     <!--# include virtual="/partials/nav" -->
     <div class="o-container o-container--medium">
         <div class="o-container-vertical">
-            <div class="c-display">
+            <div class="c-content">
 <section id="asciinema" class="level1">
 <h1>Asciinema</h1>
 <div id="cast"></div>

--- a/content/documentation/attributes.md
+++ b/content/documentation/attributes.md
@@ -157,7 +157,7 @@ configuration-name     firmware            kernel                  specialisatio
 ```
 
 The complete system, as found in the virtual machine image or on the machine
-running [`cty.hypered.systems`](https://cty.hypered.systems), can be built with the
+running [`cty-2.hypered.systems`](https://cty-2.hypered.systems), can be built with the
 `toplevel` attribute.
 
 Since NixOS is based on a Linux kernel, we can find in the results an

--- a/content/documentation/changelog.md
+++ b/content/documentation/changelog.md
@@ -150,7 +150,7 @@ the static documentation part of the site.
 - This calls
   [`scripts/deploy.sh`](https://github.com/hypered/curiosity/blob/main/scripts/deploy.sh)
   after a succesful build when the impacted branch is `main`, so that
-  [`cty.hypered.systems`](https://cty.hypered.systems) is deployed automatically.
+  [`cty-2.hypered.systems`](https://cty-2.hypered.systems) is deployed automatically.
 - See [PR-125](https://github.com/hypered/curiosity/pull/125).
 
 **Improve the run command.**
@@ -189,7 +189,7 @@ some roles as edges.
   there is already [`/state`](/state) and [`/state.json`](/state.json)).
 - Similarly for executed scenarios, it is possible to see the SVG
   representation of the state after each step, e.g. in the [quotation
-flow](https://cty.hypered.systems/documentation/scenarios/quotation-flow).
+flow](https://cty-2.hypered.systems/documentation/scenarios/quotation-flow).
 - See [PR-128](https://github.com/hypered/curiosity/pull/128).
 
 **Improve documentation.** This adds some improvements to the documentation and
@@ -284,7 +284,7 @@ quotation, and the rejection accepts an optional comment. See [PR-104](https://g
 ## 2022-11-08
 
 **Document the main sale flow.** This adds a dedicated [documentation
-page](https://cty.hypered.systems/documentation/smart) written by Roger to document
+page](https://cty-2.hypered.systems/documentation/smart) written by Roger to document
 some business matter, and in particular a Sale flow. To contrast that flow with
 the existing `quotation-flow.golden`, this scenario is now rendered within a
 [documentation page](/documentation/scenarios/quotation-flow). See
@@ -559,7 +559,7 @@ employment contracts, and invoices.
   yet complete.)
 - Introduce the idea of a set, called `state-0`, of well-known example objects
   that can be manipulated by test scenarios. See the
-  [documentation](https://cty.hypered.systems/documentation/scenarios).
+  [documentation](https://cty-2.hypered.systems/documentation/scenarios).
 - See [PR-63](https://github.com/hypered/curiosity/pull/63),
   [PR-68](https://github.com/hypered/curiosity/pull/68), and
   [PR-72](https://github.com/hypered/curiosity/pull/72).
@@ -570,7 +570,7 @@ viewed as a UBL `PartyLegalEntity`.
 - The structure of that representation is taken from
   [issue 39](https://github.com/hypered/curiosity/issues/39).
 - See the example in the
-  [documentation](https://cty.hypered.systems/documentation/ubl).
+  [documentation](https://cty-2.hypered.systems/documentation/ubl).
 - See [PR-65](https://github.com/hypered/curiosity/pull/65).
 
 Add [Brotli compression](https://en.wikipedia.org/wiki/Brotli) to Nginx. This
@@ -599,7 +599,7 @@ Improve the `cty` command-line.
   mentioned above.
 - See [PR-70](https://github.com/hypered/curiosity/pull/70).
 
-Add a script to find broken links on [`cty.hypered.systems`](https://cty.hypered.systems).
+Add a script to find broken links on [`cty-2.hypered.systems`](https://cty-2.hypered.systems).
 
 - See [PR-71](https://github.com/hypered/curiosity/pull/71).
 
@@ -613,7 +613,7 @@ virtual machine image.
 - The default options for `cty serve` and the options for the `cty serve`
   service are changed to no longer overlap (e.g. the default listen port is
   9000, but the service is configured to use 9100).
-- There is now a `play.cty.hypered.systems` domain, and Nginx is configured to
+- There is now a `play.cty-2.hypered.systems` domain, and Nginx is configured to
   forward its requests to port 9000. I.e. when the user decides to run
  `cty serve`, it's possible to access it on that new domain.
 - `jq` is also available to further process some `cty` output.
@@ -733,7 +733,7 @@ Practices, SEO). Now they are 97, 100, 100, 100.
 - Add a blocklist for usernames. This is interesting because it shows how to
   use hard-coded data both in some business-logic and show those same data in
   the documentation. See [PR-36](https://github.com/hypered/curiosity/pull/36).
-- The `cty.hypered.systems` domain is now available in HTTPS. See
+- The `cty-2.hypered.systems` domain is now available in HTTPS. See
   [PR-37](https://github.com/hypered/curiosity/pull/37).
 
 ## 2022-07-31

--- a/content/documentation/clis.md
+++ b/content/documentation/clis.md
@@ -26,11 +26,11 @@ page](/documentation/asciinema).
 # Quick start
 
 This quick start section assumes you have SSH access to the Linux user `alice`
-at `cty.hypered.systems`, but also applies to the other possible
+at `cty-2.hypered.systems`, but also applies to the other possible
 [environments](/documentation/environments):
 
 ```
-$ ssh alice@cty.hypered.systems
+$ ssh alice@cty-2.hypered.systems
 Last login: Thu Sep 22 18:24:30 2022 from xxx.xxx.xxx.xxx
 Welcome to the Curiosity environment.
 Run `man curiosity` for the manual.
@@ -41,7 +41,7 @@ For simplicity, we write the prompt `[alice@curiosity-1:~]$` as `$` in the
 following text.
 
 In addition to the documentation available online at
-[`cty.hypered.systems`](https://cty.hypered.systems/documentation), information is also
+[`cty-2.hypered.systems`](https://cty-2.hypered.systems/documentation), information is also
 available locally in man pages and as part of the `cty` command-line
 executable:
 
@@ -156,8 +156,8 @@ documentation](/documentation/scenarios#scenarios) from where they can be run
 and explored.
 
 To expose the state file using a web interface, `cty serve` can be used. By
-default it uses port 9000. In the specific case of the `cty.hypered.systems` machine,
-it can be reached by using the [`play.cty.hypered.systems`](https://play.cty.hypered.systems)
+default it uses port 9000. In the specific case of the `cty-2.hypered.systems` machine,
+it can be reached by using the [`play.cty-2.hypered.systems`](https://play.cty-2.hypered.systems)
 sub-domain:
 
 ```

--- a/content/documentation/environments.md
+++ b/content/documentation/environments.md
@@ -69,7 +69,7 @@ When running a virtual machine based on that image, the reverse proxy, the SSH
 server and the Curiosity web application are automatically started.
 
 An example deployment of this virtual machine image runs at
-[cty.hypered.systems](https://cty.hypered.systems).
+[cty-2.hypered.systems](https://cty-2.hypered.systems).
 
 ## Docker image
 

--- a/content/documentation/machine.md
+++ b/content/documentation/machine.md
@@ -11,7 +11,7 @@ including this page).
 
 The same image can be built for different environments. For instance we use KVM
 for local development and the virtual machine available at
-[`cty.hypered.systems`](//cty.hypered.systems) for demonstration purpose is
+[`cty-2.hypered.systems`](//cty-2.hypered.systems) for demonstration purpose is
 [deployed](/documentation/deployment) at DigitalOcean.
 
 ## Built with Nix

--- a/content/documentation/man-pages.md
+++ b/content/documentation/man-pages.md
@@ -13,11 +13,11 @@ tools are, is to start typing `cty` at a virtual machine prompt then hit the
 `TAB` key twice to see the proposed auto-completion. There is also a more
 general man page available as `man curiosity`.
 
-Assuming an SSH access to `cty.hypered.systems`, here is a possible session
+Assuming an SSH access to `cty-2.hypered.systems`, here is a possible session
 demonstrating the above:
 
 ```
-$ ssh root@cty.hypered.systems
+$ ssh root@cty-2.hypered.systems
 [root@curiosity-1:~]# cty<TAB><TAB>
 cty
 [root@curiosity-1:~]# man cty

--- a/content/documentation/nix.md
+++ b/content/documentation/nix.md
@@ -10,7 +10,7 @@ manager](https://nixos.org/guides/how-nix-works.html). Nix provides a reliable
 way to specify project dependencies and build our artifacts, whether it is [our
 `cty` binary](/documentation/clis), or even Curiosity's main deliverable: the
 complete virtual machine image running at
-[`cty.hypered.systems`](https://cty.hypered.systems).
+[`cty-2.hypered.systems`](https://cty-2.hypered.systems).
 
 Once you have Nix installed and a clone of the [Curiosity
 repository](https://github.com/hypered/curiosity), building the `cty` binary
@@ -34,7 +34,7 @@ $ nix-build -A toplevel
 
 Whenever we change something in the Curiosity repository, we can build a new
 toplevel and activate it on a given machine (e.g. the machine running at
-[`cty.hypered.systems`](https://cty.hypered.systems)).
+[`cty-2.hypered.systems`](https://cty-2.hypered.systems)).
 
 # Binary cache
 

--- a/content/documentation/search.html
+++ b/content/documentation/search.html
@@ -15,7 +15,7 @@
     <!--# include virtual="/partials/nav" -->
     <div class="o-container o-container--medium">
         <div class="o-container-vertical">
-            <div class="c-display">
+            <div class="c-content">
                 <div class="c-input-with-icon">
                     <input class="c-input" type="text" placeholder="Search ..." data-stork="content">
                 </div>

--- a/content/documentation/state.md
+++ b/content/documentation/state.md
@@ -56,7 +56,7 @@ state file is `cty init`.
 # Virtual machine state
 
 The virtual machine shipped with the prototype (and featured at
-[`cty.hypered.systems`](https://cty.hypered.systems)) is configured to start with an initial
+[`cty-2.hypered.systems`](https://cty-2.hypered.systems)) is configured to start with an initial
 state, called [`state-0`](/documentation/state-0). This is the same state used
 in automated [test scenarios](/documentation/scenarios).
 

--- a/content/documentation/why.md
+++ b/content/documentation/why.md
@@ -254,7 +254,7 @@ I didn't talk about the more technical aspects of Curiosity, but it's written
 very similarly to a real system. For instance, it is setup within a virtual
 machine image, with a reverse-proxy, ready to be deployed in a cloud provider
 or on-premises infrastructure, as demonstrated by
-[`cty.hypered.systems`](https://cty.hypered.systems), and a basic continuous
+[`cty-2.hypered.systems`](https://cty-2.hypered.systems), and a basic continuous
 integration and automated deployment pipeline exists.
 
 Unfortunately Curiosity failed to attract a discussion centered around it.

--- a/content/humans.txt
+++ b/content/humans.txt
@@ -9,5 +9,6 @@
                                                           /| 
                                                           \|
 
-                  Curiosity is  written for Smart  by @noteed
-                  and  @asheshambasta.
+                  Curiosity is  written by @noteed.
+                  Curiosity was started for Smart Coop by
+                  @noteed and @asheshambasta.

--- a/curiosity.cabal
+++ b/curiosity.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               curiosity
-version:            0.1.0.0
+version:            0.2.0.0
 category:           web
 
 common common-extensions

--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,7 @@ let
       "${toString sources.nixpkgs}/nixos/modules/virtualisation/digital-ocean-image.nix"
       ./machine/disk-size.nix
       ./machine/https.nix
+      (sources.curiosity-1 + "/machine/https.nix")
       ./modules/play.nix
     ];
   };

--- a/machine/configuration.nix
+++ b/machine/configuration.nix
@@ -10,7 +10,7 @@ let
     # $2 must be 'cty --user <username>'.
     # In practice, they are provided by the SSH ForceCommand.
     # $SSH_ORIGINAL_COMMAND is what the user types, e.g.
-    # if she types 'ssh curiosity@cty.hypered.systems state', then
+    # if she types 'ssh curiosity@cty-2.hypered.systems state', then
     # it is 'state'.
 
     if [[ -n $SSH_ORIGINAL_COMMAND ]]

--- a/machine/configuration.nix
+++ b/machine/configuration.nix
@@ -1,6 +1,8 @@
 { config, lib, pkgs,
   ... }:
 let
+  sources = import ../nix/sources.nix;
+
   cty-shell = pkgs.writeShellScriptBin "cty-shell" ''
     #! /bin/bash
 
@@ -50,8 +52,12 @@ in
   services.getty.autologinUser = lib.mkDefault "root";
 
   imports = [
+    # curiosity-2 unit and cty-2 domain.
     ../modules/curiosity.nix
     ../modules/nginx.nix
+    # curiosity-1 unit and cty-1 domain.
+    (sources.curiosity-1 + "/modules/curiosity.nix")
+    (sources.curiosity-1 + "/modules/nginx.nix")
   ];
 
   environment.systemPackages = [

--- a/machine/https.nix
+++ b/machine/https.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   services.nginx = {
-    virtualHosts."cty.hypered.systems" = {
+    virtualHosts."cty-2.hypered.systems" = {
       forceSSL = true;
       enableACME = true;
     };
@@ -9,6 +9,6 @@
 
   security.acme.acceptTerms = true;
   security.acme.certs = {
-    "cty.hypered.systems".email = "noteed@gmail.com";
+    "cty-2.hypered.systems".email = "noteed@gmail.com";
   };
 }

--- a/modules/curiosity.nix
+++ b/modules/curiosity.nix
@@ -10,20 +10,20 @@
         let preScript = pkgs.writers.writeBashBin "curiosityStartPre" ''
           # Run from a state file, reset to a known state.
           # TODO system is meaningless for now.
-          rm -f /tmp/state.json
+          rm -f /tmp/state-2.json
           ${(import ../.).binaries}/bin/cty \
-          --state /tmp/state.json \
+          --state /tmp/state-2.json \
           --user system \
           init
           ${(import ../.).binaries}/bin/cty \
-          --state /tmp/state.json \
+          --state /tmp/state-2.json \
           --user system \
           run ${(import ../.).scenarios}/state-0.txt
           '';
         in "${preScript}/bin/curiosityStartPre";
       ExecStart = ''
         ${(import ../.).binaries}/bin/cty \
-        --state /tmp/state.json \
+        --state /tmp/state-2.json \
         --user system \
         serve \
         --server-port 9102 \

--- a/modules/curiosity.nix
+++ b/modules/curiosity.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 {
-  systemd.services.curiosity = {
+  systemd.services.curiosity-2 = {
     wantedBy = [ "multi-user.target" ];
     # TODO Right way to depends on graphviz in curiosity.
     path = [ pkgs.graphviz ];
@@ -26,7 +26,7 @@
         --state /tmp/state.json \
         --user system \
         serve \
-        --server-port 9100 \
+        --server-port 9102 \
         --static-dir ${(import ../.).content} \
         --data-dir ${(import ../.).data} \
         --scenarios-dir ${(import ../.).scenarios} \

--- a/modules/nginx.nix
+++ b/modules/nginx.nix
@@ -17,18 +17,19 @@ in
 {
   services.nginx = {
     enable = true;
-    package = pkgs.nginxMainline;
-    additionalModules = [ pkgs.nginxModules.brotli ];
+    # Commented out because already defined in curiosity-1.
+    # package = pkgs.nginxMainline;
+    # additionalModules = [ pkgs.nginxModules.brotli ];
     recommendedGzipSettings = true;
-    virtualHosts."cty.hypered.systems" = {
+    virtualHosts."cty-2.hypered.systems" = {
       locations = {
-        "/".proxyPass = "http://127.0.0.1:9100";
+        "/".proxyPass = "http://127.0.0.1:9102";
         "/about" = {
-          proxyPass = "http://127.0.0.1:9100";
+          proxyPass = "http://127.0.0.1:9102";
           extraConfig = "ssi on;";
         };
         "/documentation" = {
-          proxyPass = "http://127.0.0.1:9100";
+          proxyPass = "http://127.0.0.1:9102";
           extraConfig = "ssi on;";
         };
         "/static/" = {
@@ -38,9 +39,10 @@ in
         "/haddock/".alias = (import ../.).haddock + "/share/doc/curiosity-0.1.0.0/html/";
       };
 
-      extraConfig = ''
-        brotli_static on;
-      '';
+      # Commented out because already defined in curiosity-1.
+      # extraConfig = ''
+      #   brotli_static on;
+      # '';
     };
   };
 }

--- a/modules/play.nix
+++ b/modules/play.nix
@@ -2,7 +2,7 @@
 {
   services.nginx = {
     enable = true;
-    virtualHosts."play.cty.hypered.systems" = {
+    virtualHosts."play.cty-2.hypered.systems" = {
       forceSSL = true;
       enableACME = true;
       locations = {
@@ -18,6 +18,6 @@
   };
 
   security.acme.certs = {
-    "play.cty.hypered.systems".email = "noteed@gmail.com";
+    "play.cty-2.hypered.systems".email = "noteed@gmail.com";
   };
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -5,7 +5,6 @@ let
   sources = import ./sources.nix;
   contents = import ./contents.nix { nixpkgs = super; };
   inherit (super.lib.attrsets) mapAttrs;
-  inherit (import sources.gitignore { inherit lib; }) gitignoreFilter;
 
   ourOverrides = selfh: superh:
     let

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,6 +1,8 @@
 # Central overlay that supplies all overlays that:
 # 1. Make this package available.
-# 2. Provide this particular package with a fixed point of overlayed packages, if they become needed.
+# 2. Provide this particular package with a fixed point of overlayed packages,
+#    if they become needed.
+
 let
 
   sources = import ./sources.nix;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,6 +11,18 @@
         "url": "https://github.com/hypered/commence/archive/9896c3278020ddb9f4c60fb3dc748ad4dfe7fce6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "curiosity-1": {
+        "branch": "cty-1.hypered.systems",
+        "description": "Branch corresponding to the version written for Smart Coop",
+        "homepage": null,
+        "owner": "hypered",
+        "repo": "curiosity",
+        "rev": "68d8d2a29001364f76a714cdd60e6010f4292f5f",
+        "sha256": "0qabyjc737j4w5kipxfbsgvl9905x5pbglcl0zs77kj10absn983",
+        "type": "tarball",
+        "url": "https://github.com/hypered/curiosity/archive/68d8d2a29001364f76a714cdd60e6010f4292f5f.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "gitignore": {
         "branch": "master",
         "description": "Nix function for filtering local git sources",

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://monohs.hypered.design",
         "owner": "hypered",
         "repo": "smart-design-hs",
-        "rev": "b4c814ebf235edecc5c039acfdd5f2b7bdab4621",
-        "sha256": "1q2ffszcpinraq4j54a7177ji9r7sa922djglzrycmbpbv3m3aa4",
+        "rev": "ea580f708773edc291de813104ec293f55a83221",
+        "sha256": "0qqzip6kqbx7bp1ig6j01pa7x1i99hw45x37hbmp6y5ax6z0m6gp",
         "type": "tarball",
-        "url": "https://github.com/hypered/smart-design-hs/archive/b4c814ebf235edecc5c039acfdd5f2b7bdab4621.tar.gz",
+        "url": "https://github.com/hypered/smart-design-hs/archive/ea580f708773edc291de813104ec293f55a83221.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,7 +15,7 @@ nix_args=(
 )
 
 # This is the curiosity-1 host at Digital Ocean.
-TARGET="root@cty.hypered.systems"
+TARGET="root@cty-2.hypered.systems"
 
 PROFILE_PATH="${PROFILE_PATH:-}"
 NIX_SSHOPTS="${NIX_SSHOPTS:-}"

--- a/scripts/integration-tests/vm-test.nix
+++ b/scripts/integration-tests/vm-test.nix
@@ -16,7 +16,7 @@ let
     mkdir -p $out
     cp key.pem cert.pem $out
   '';
-  serverFqdn = "cty.hypered.systems";
+  serverFqdn = "cty-2.hypered.systems";
   hosts = nodes: ''
     ${nodes.server.config.networking.primaryIPAddress} ${serverFqdn}
   '';

--- a/scripts/spider.sh
+++ b/scripts/spider.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# Find broken links on cty.hypered.systems. This doesn't check for outbound links.
+# Find broken links on cty-2.hypered.systems. This doesn't check for outbound links.
 # Once done, check the bottom of the generated spider.log file (or lines
 # preceding the "broken link" markers). Without the --wait, this takes about
 # 11 seconds. With --wait 1, this takes about 6 minutes.
@@ -14,4 +14,4 @@ wget \
   --level 0 \
   --wait 1 \
   --output-file spider.log \
-  https://cty.hypered.systems
+  https://cty-2.hypered.systems

--- a/scripts/stork.css
+++ b/scripts/stork.css
@@ -18,7 +18,7 @@
 }
 
 /* Disable the normal (from the design system) link borders. */
-.c-display a {
+.c-content a {
   border-bottom: 0.1rem solid var(--stork-border-color);
 }
 

--- a/scripts/template-public.html
+++ b/scripts/template-public.html
@@ -85,7 +85,7 @@
     </header>
     <div class="o-container o-container--medium">
         <div class="o-container-vertical">
-            <div class="c-display">
+            <div class="c-content">
 $body$
             </div>
         </div>

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -14,7 +14,7 @@
     <!--# include virtual="/partials/nav" -->
     <div class="o-container o-container--medium">
         <div class="o-container-vertical">
-            <div class="c-display">
+            <div class="c-content">
 $body$
             </div>
         </div>

--- a/src/Curiosity/Data/Email.hs
+++ b/src/Curiosity/Data/Email.hs
@@ -36,7 +36,7 @@ import           Web.HttpApiData                ( FromHttpApiData(..) )
 
 --------------------------------------------------------------------------------
 systemEmailAddr :: User.UserEmailAddr
-systemEmailAddr = "hello@cty.hypered.systems"
+systemEmailAddr = "hello@cty-2.hypered.systems"
 
 
 --------------------------------------------------------------------------------

--- a/src/Curiosity/Data/User.hs
+++ b/src/Curiosity/Data/User.hs
@@ -448,7 +448,7 @@ firstUserRights = [CanCreateContracts, CanVerifyEmailAddr]
 -- | In addition of dynamic rules (e.g. the username should not already be
 -- taken), we disallow some names because they might be used later by the
 -- system or the company, or cause confusion (because usernames are used as
--- e.g. cty.hypered.systems/<username>).
+-- e.g. cty-2.hypered.systems/<username>).
 usernameBlocklist :: [UserName]
 usernameBlocklist =
   [ "a"

--- a/src/Curiosity/Form/Login.hs
+++ b/src/Curiosity/Form/Login.hs
@@ -96,7 +96,7 @@ loginPage Page {..} = Dsl.SingletonCanvas $ do
                       ! A.class_ "c-button__content"
                       $ "Log in"
                     H.div ! A.class_ "o-form-group u-ta-center" $ ""
-        H.div ! A.class_ "c-content u-text-center u-spacer-top-l" $ do
+        H.div ! A.class_ "c-text u-text-center u-spacer-top-l" $ do
           H.a ! A.class_ "u-text-muted" ! A.href "/signup" $ "Sign up"
           " | "
           H.a

--- a/src/Curiosity/Form/Signup.hs
+++ b/src/Curiosity/Form/Signup.hs
@@ -124,7 +124,7 @@ signupPage Page {..} = Dsl.SingletonCanvas $ do
                       ! A.class_ "c-button__content"
                       $ "Sign up"
                     H.div ! A.class_ "o-form-group u-ta-center" $ ""
-        H.div ! A.class_ "c-content u-text-center u-spacer-top-l" $ do
+        H.div ! A.class_ "c-text u-text-center u-spacer-top-l" $ do
           H.a ! A.class_ "u-text-muted" ! A.href "/login" $ "Log in"
 
 
@@ -156,6 +156,6 @@ withMessage title msg =
     $ H.div
     ! A.class_ "o-container-vertical"
     $ do
-        H.div ! A.class_ "c-content" $ H.h1 $ H.toHtml title
+        H.div ! A.class_ "c-text" $ H.h1 $ H.toHtml title
 
         H.div ! A.class_ "c-panel" $ H.div ! A.class_ "c-panel__body" $ msg

--- a/src/Curiosity/Html/Action.hs
+++ b/src/Curiosity/Html/Action.hs
@@ -150,7 +150,7 @@ instance H.ToMarkup EchoPage where
   toMarkup EchoPage {..} =
     renderView' _echoPageUserProfile $
       panelWrapper
-        $ H.div ! A.class_ "c-display" $
+        $ H.div ! A.class_ "c-content" $
           H.pre . H.code $ H.text _echoPageContent
 
 -- | Similar to `EchoPage` but also shows validation errors
@@ -166,7 +166,7 @@ instance H.ToMarkup EchoPage' where
   toMarkup EchoPage' {..} =
     renderView' _echoPage'UserProfile $
       panelWrapper
-        $ H.div ! A.class_ "c-display" $ do
+        $ H.div ! A.class_ "c-content" $ do
           H.pre . H.code $ H.text _echoPage'Content
           if null _echoPage'Errors
             then

--- a/src/Curiosity/Html/SimpleContract.hs
+++ b/src/Curiosity/Html/SimpleContract.hs
@@ -335,7 +335,7 @@ instance H.ToMarkup SelectRolePage where
   toMarkup (SelectRolePage profile key confirmRoleBaseUrl) = renderFormLarge profile $ do
     title' "Select role" Nothing
 
-    H.div ! A.class_ "c-display" $ do
+    H.div ! A.class_ "c-content" $ do
       mapM_ (displayRole0 confirmRoleBaseUrl key) SimpleContract.roles
 
 displayRole0 confirmRoleBaseUrl key (SimpleContract.Role0 title_ roles1) = do

--- a/src/Curiosity/Server.hs
+++ b/src/Curiosity/Server.hs
@@ -2601,15 +2601,15 @@ partialScenario scenariosDir name = do
   let ts' = Inter.flatten ts
   pure $ do
     H.style
-      ".c-display table code {\n\
+      ".c-content table code {\n\
       \background: white;\n\
       \ white-space: normal;\n\
       \}\n\
-      \.c-display table td {\n\
+      \.c-content table td {\n\
       \  padding-top: 0;\n\
       \  padding-bottom: 0;\n\
       \}\n\
-      \.c-display table a {\n\
+      \.c-content table a {\n\
       \  border-bottom: 0;\n\
       \}\n"
     H.table $ do


### PR DESCRIPTION
The version of Curiosity as it was done for Smart Coop is kept in the https://github.com/hypered/curiosity/tree/smartcoop.sh branch.
To host it at https://cty-1.hypered.systems/ instead of the original `smartcoop.sh` domain, a https://github.com/hypered/curiosity/tree/cty-1.hypered.systems branch has been created (with minimal changes to update the domain name).

In this PR, we resume work on Curiosity. To avoid possible confusion with the Smart Coop version, we remove some branding aspect, mainly by using an updated design system repository (updates in that repository were mainly exploratory, and the result is not great, but at least this is different enough to avoid said confusion).

Curiosity defines a virtual machine image, and we update its definition to include cty-1. (So this branch, and the main branch after merge, exposes the "current" version at `cty-2.`, and an older version at `cty-1.hypered.systems` .)

Further changes have yet to be made to update phrasing related to Smart as it is no longer a Smart project.